### PR TITLE
fix: uploadCartridge script was not updaloading bm_algolia

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "lint:css": "sgmf-scripts --lint css",
         "lint:js": "sgmf-scripts --lint js",
         "upload": "sgmf-scripts --upload",
-        "uploadCartridge": "sgmf-scripts --uploadCartridge int_algolia && sgmf-scripts --uploadCartridge int_algolia_controllers && sgmf-scripts --uploadCartridge int_algolia_sfra",
+        "uploadCartridge": "sgmf-scripts --uploadCartridge int_algolia && sgmf-scripts --uploadCartridge int_algolia_controllers && sgmf-scripts --uploadCartridge int_algolia_sfra && sgmf-scripts --uploadCartridge bm_algolia",
         "watch": "sgmf-scripts --watch",
         "watch:static": "sgmf-scripts --watch static"
     },


### PR DESCRIPTION
I lost quite some time looking why my test changes were not appearing in the Business Manager interface.

The reason was actually simple: they were not uploaded by default :tired_face: