### PR TITLE
fix(routing): avoid casting to number

### DIFF
--- a/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/index.js
+++ b/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/index.js
@@ -6,10 +6,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     var userCurrency = algoliaData.currencyCode;
     var userCurrencySymbol = algoliaData.currencySymbol;
-    var categoryDisplayNamePath = $suggestionsWrapper.data('category-display-name-path');  // path of the current category
-    var categoryDisplayNamePathSeparator = $suggestionsWrapper.data('category-display-name-path-separator'); // separator used to serialize the category path (by default: '>')
-    var urlQuery = $suggestionsWrapper.data('q'); // onload search query - for search page - URL param: q
-    var searchPageRoot = $suggestionsWrapper.data('search-page-root'); // onload search query - for search page - URL param: q
+    var categoryDisplayNamePath = $suggestionsWrapper.attr('data-category-display-name-path');  // path of the current category
+    var categoryDisplayNamePathSeparator = $suggestionsWrapper.attr('data-category-display-name-path-separator'); // separator used to serialize the category path (by default: '>')
+    var urlQuery = $suggestionsWrapper.attr('data-q'); // onload search query - for search page - URL param: q
+    var searchPageRoot = $suggestionsWrapper.attr('data-search-page-root'); // onload search query - for search page - URL param: q
 
 
     var productsIndex = algoliaData.productsIndex;


### PR DESCRIPTION
jQuery's `data` function will try to cause bugs by turning items into numbers if they're numbers: https://api.jquery.com/data/#data-html5

> Every attempt is made to convert the attribute's string value to a JavaScript value (this includes booleans, numbers, objects, arrays, and null). A string is only converted to a number if doing so doesn't change its representation (for example, the string "100" is converted to the number 100, but "1E02" and "100.000" are left as strings because their numeric value of 100 serializes to "100"). When a string starts with '{' or '[', then jQuery.parseJSON is used to parse it; it must follow valid JSON syntax including quoted property names. A string not parseable as a JavaScript value is not converted.
> To retrieve a data-* attribute value as an unconverted string, use the **attr()** method.

This is found through https://algolia.atlassian.net/browse/CR-1775

cc @sbellone @tkrugg 