### PR TITLE
APEX-177: Events not tracked when a search result is accessed from Autocomplete

### DIFF
--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/autocomplete-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/autocomplete-config.js
@@ -35,6 +35,14 @@ function enableAutocomplete(config) {
                                 ],
                             });
                         },
+                        onSelect: function(event) {
+                            aa('clickedObjectIDsAfterSearch', {
+                                index: event.item.__autocomplete_indexName,
+                                eventName: 'Clicked on autocomplete product',
+                                queryID: event.item.__autocomplete_queryID,
+                                objectID: event.item.objectID,
+                            });
+                        },
                         templates: {
                             header() {
                                 return html`
@@ -54,6 +62,13 @@ function enableAutocomplete(config) {
                                     });
                                     item.firstImage = smallImageGroup.images[0];
                                 }
+
+                                // add queryID, objectID and indexName to the URL (analytics)
+                                var newURL = new URL(item.url);
+                                newURL.searchParams.append('objectID', item.objectID);
+                                newURL.searchParams.append('queryID', item.__autocomplete_queryID);
+                                newURL.searchParams.append('indexName', item.__autocomplete_indexName);
+
                                 return html`
                                     <div class="text-truncate text-nowrap">
                                         <img class="swatch-circle hidden-xs-down" src=${item.firstImage.dis_base_link}></img>


### PR DESCRIPTION
Added `objectID`, `queryID` and `indexName` to the URL of the PDP that opens when an Autocomplete result is clicked. This fixes the “Product Add to cart” event not being sent when the user navigates to the PDP from an Autocomplete result. Prior to this the event was sent only when the user was coming from an InstantSearch result.

In addition to this, I also added a new event that is sent when the user clicks an Autocomplete result (“Clicked on autocomplete product”), this was also missing previously.