### PR TITLE
in_stock behavior now reflects SFCC inStock

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaProduct.js
@@ -257,9 +257,9 @@ var aggregatedValueHandlers = {
         return productPrice;
     },
     in_stock: function (product) {
-        return product.availabilityModel.inStock
-            ? product.availabilityModel.availability >= algoliaData.getPreference('InStockThreshold')
-            : false;
+        // the in_stock property now exports the SFCC attribute product.availabilityModel.inStock,
+        // not whether the threshold defined in Algolia_InStockThreshold value is reached.
+        return product.availabilityModel.inStock;
     },
     image_groups: function (product) {
         // Get all image Groups of product for all locales


### PR DESCRIPTION
Changed `in_stock` behavior to mirror SFCC's `product.availabilityModel.inStock` instead of relying on the threshold.
The old `in_stock` property calculation was flawed in that `product.availabilityModel.availability` would never be greater than `Algolia_InStockThreshold` and thus it would return `false` in each case.