### PR TITLE
feat: add update methods to ingestion api service

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algoliaIngestionAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIngestionAPI.js
@@ -7,13 +7,14 @@ var algoliaIngestionService = require('*/cartridge/scripts/services/algoliaInges
 var Logger = require('dw/system/Logger');
 
 /**
- * Register a source
+ * Register the source
  * https://www.algolia.com/doc/rest-api/ingestion/#create-a-source
  * @param {string} name - name
+ * @param {string} siteID - SFCC site ID
  *
  * @returns {string} sourceID - the ID of the created source
  */
-function registerSource(name) {
+function registerSource(name, siteID) {
     var ingestionService = algoliaIngestionService.getService();
     var baseURL = ingestionService.getConfiguration().getCredential().getURL();
 
@@ -23,6 +24,9 @@ function registerSource(name) {
     var requestBody = {
         type: 'sfcc',
         name: name,
+        input: {
+            siteID: siteID,
+        }
     };
 
     try {
@@ -33,12 +37,12 @@ function registerSource(name) {
             Logger.error('Error while registering source. Response: ' + result.object.body);
         }
     } catch(e) {
-        Logger.error('Error while registering source: ' + e.message + ': ' + e.stack);
+        Logger.error('Uncaught error while registering source: ' + e.message + ': ' + e.stack);
     }
 }
 
 /**
- * Register an authentication
+ * Register the authentication
  * https://www.algolia.com/doc/rest-api/ingestion/#create-a-authentication
  * @param {Object} authInfo - authentication info object
  * @param {string} authInfo.name - authentication name
@@ -68,15 +72,15 @@ function registerAuthentication(authInfo) {
         if (result.ok) {
             return result.object.body.authenticationID;
         } else {
-            Logger.error('Error while registering authentication for appId + ' + appId + '. Response: ' + result.object.body);
+            Logger.error('Error while registering authentication for appId + ' + authInfo.appId + '. Response: ' + result.object.body);
         }
     } catch(e) {
-        Logger.error('Error while registering authentication for appId + ' + appId + ': ' + e.message + ': ' + e.stack);
+        Logger.error('Uncaught error while registering authentication for appId + ' + authInfo.appId + ': ' + e.message + ': ' + e.stack);
     }
 }
 
 /**
- * Register a destination
+ * Register the destination
  * https://www.algolia.com/doc/rest-api/ingestion/#create-a-destination
  * @param {Object} destinationInfo - destination info object
  * @param {string} destinationInfo.name - destination name
@@ -106,10 +110,10 @@ function registerDestination(destinationInfo) {
         if (result.ok) {
             return result.object.body.destinationID;
         } else {
-            Logger.error('Error while registering destination (indexName=' + indexName + 'authenticationID=' + authenticationID + '). Response: ' + result.object.body);
+            Logger.error('Error while registering destination (indexName=' + destinationInfo.indexName + 'authenticationID=' + authenticationID + '). Response: ' + result.object.body);
         }
     } catch(e) {
-        Logger.error('Error while registering destination (indexName=' + indexName + 'authenticationID=' + authenticationID + '):' + e.message + ': ' + e.stack);
+        Logger.error('Error while registering destination (indexName=' + destinationInfo.indexName + 'authenticationID=' + authenticationID + '):' + e.message + ': ' + e.stack);
     }
 }
 
@@ -135,7 +139,7 @@ function registerTask(taskInfo) {
         destinationID: taskInfo.destinationID,
         action: taskInfo.action,
         trigger: {
-            type: 'onDemand'
+            type: 'subscription'
         },
     };
 
@@ -144,10 +148,10 @@ function registerTask(taskInfo) {
         if (result.ok) {
             return result.object.body.taskID;
         } else {
-            Logger.error('Error while registering task ' + action + '(sourceID=' + sourceID + '; destinationID=' + destinationID + '). Response: ' + result.object.body);
+            Logger.error('Error while registering task ' + taskInfo.action + '(sourceID=' + taskInfo.sourceID + '; destinationID=' + taskInfo.destinationID + '). Response: ' + result.object.body);
         }
     } catch(e) {
-        Logger.error('Error while registering task ' + action + '(sourceID=' + sourceID + '; destinationID=' + destinationID + '): ' + e.message + ': ' + e.stack);
+        Logger.error('Uncaught error while registering task ' + taskInfo.action + '(sourceID=' + taskInfo.sourceID + '; destinationID=' + taskInfo.destinationID + '): ' + e.message + ': ' + e.stack);
     }
 }
 

--- a/cartridges/int_algolia/cartridge/scripts/algoliaIngestionAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIngestionAPI.js
@@ -80,6 +80,45 @@ function registerAuthentication(authInfo) {
 }
 
 /**
+ * Update the authentication
+ * https://www.algolia.com/doc/rest-api/ingestion/#update-a-authentication
+ * @param {string} authenticationID - the id of the registered authentication
+ * @param {Object} authInfo - authentication info object
+ * @param {string} authInfo.name - authentication name
+ * @param {string} authInfo.appId - authentication appId
+ * @param {string} authInfo.apiKey - authentication apiKey
+ *
+ * @returns {string} authenticationID - the ID of the created authentication
+ */
+function updateAuthentication(authenticationID, authInfo) {
+    var ingestionService = algoliaIngestionService.getService();
+    var baseURL = ingestionService.getConfiguration().getCredential().getURL();
+
+    ingestionService.setRequestMethod('PATCH');
+    ingestionService.setURL(baseURL + '/1/authentications/' + authenticationID);
+
+    var requestBody = {
+        name: authInfo.name,
+        input: {
+            appID: authInfo.appId,
+            apiKey: authInfo.apiKey,
+        },
+    };
+
+    try {
+        var result = ingestionService.setThrowOnError().call(requestBody);
+        if (result.ok) {
+            Logger.info(result);
+            return result.object.body.authenticationID;
+        } else {
+            Logger.error('Error while updating authentication for appId + ' + authInfo.appId + ': ' + result.errorMessage);
+        }
+    } catch (e) {
+        Logger.error('Uncaught error while updating authentication for appId + ' + authInfo.appId + ': ' + e.message + ': ' + e.stack);
+    }
+}
+
+/**
  * Register the destination
  * https://www.algolia.com/doc/rest-api/ingestion/#create-a-destination
  * @param {Object} destinationInfo - destination info object
@@ -114,6 +153,46 @@ function registerDestination(destinationInfo) {
         }
     } catch(e) {
         Logger.error('Error while registering destination (indexName=' + destinationInfo.indexName + 'authenticationID=' + authenticationID + '):' + e.message + ': ' + e.stack);
+    }
+}
+
+/**
+ * Update the destination
+ * https://www.algolia.com/doc/rest-api/ingestion/#update-a-destination
+ * @param {string} destinationID - the id of the registered destination
+ * @param {Object} destinationInfo - destination info object
+ * @param {string} destinationInfo.name - destination name
+ * @param {string} destinationInfo.indexName - destination index name
+ * @param {string} destinationInfo.authenticationID - authenticationID to use
+ *
+ * @returns {string} destinationID - the ID of the created destination
+ */
+function updateDestination(destinationID, destinationInfo) {
+    var ingestionService = algoliaIngestionService.getService();
+    var baseURL = ingestionService.getConfiguration().getCredential().getURL();
+
+    ingestionService.setRequestMethod('PATCH');
+    ingestionService.setURL(baseURL + '/1/destinations/' + destinationID);
+
+    Logger.info('destination: ' + baseURL + '/1/destinations/' + destinationID)
+
+    var requestBody = {
+        name: destinationInfo.name,
+        input: {
+            indexName: destinationInfo.indexName,
+        },
+        authenticationID: destinationInfo.authenticationID,
+    };
+
+    try {
+        var result = ingestionService.setThrowOnError().call(requestBody);
+        if (result.ok) {
+            return result.object.body.destinationID;
+        } else {
+            Logger.error('Error while registering destination (indexName=' + destinationInfo.indexName + 'authenticationID=' + authenticationID + '). Response: ' + result.object.body);
+        }
+    } catch(e) {
+        Logger.error('Uncaught error while registering destination (indexName=' + destinationInfo.indexName + 'authenticationID=' + authenticationID + '):' + e.message + ': ' + e.stack);
     }
 }
 
@@ -157,5 +236,7 @@ function registerTask(taskInfo) {
 
 module.exports.registerSource = registerSource;
 module.exports.registerAuthentication = registerAuthentication;
+module.exports.updateAuthentication = updateAuthentication;
 module.exports.registerDestination = registerDestination;
+module.exports.updateDestination = updateDestination;
 module.exports.registerTask = registerTask;

--- a/cartridges/int_algolia/cartridge/scripts/algoliaIngestionAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIngestionAPI.js
@@ -82,7 +82,7 @@ function registerAuthentication(authInfo) {
  * @param {string} authInfo.appId - authentication appId
  * @param {string} authInfo.apiKey - authentication apiKey
  *
- * @returns {string} authenticationID - the ID of the created authentication
+ * @returns {string} authenticationID - the ID of the updated authentication
  */
 function updateAuthentication(authenticationID, authInfo) {
     var ingestionService = algoliaIngestionService.getService();
@@ -152,7 +152,7 @@ function registerDestination(destinationInfo) {
  * @param {string} destinationInfo.indexName - destination index name
  * @param {string} destinationInfo.authenticationID - authenticationID to use
  *
- * @returns {string} destinationID - the ID of the created destination
+ * @returns {string} destinationID - the ID of the updated destination
  */
 function updateDestination(destinationID, destinationInfo) {
     var ingestionService = algoliaIngestionService.getService();

--- a/cartridges/int_algolia/cartridge/scripts/algoliaIngestionAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIngestionAPI.js
@@ -29,15 +29,12 @@ function registerSource(name, siteID) {
         }
     };
 
-    try {
-        var result = ingestionService.setThrowOnError().call(requestBody);
-        if (result.ok) {
-            return result.object.body.sourceID;
-        } else {
-            Logger.error('Error while registering source. Response: ' + result.object.body);
-        }
-    } catch(e) {
-        Logger.error('Uncaught error while registering source: ' + e.message + ': ' + e.stack);
+    var result = ingestionService.call(requestBody);
+    if (result.ok) {
+        return result.object.body.sourceID;
+    } else {
+        Logger.error('Error while registering source. Response: ' + result.getErrorMessage());
+        throw new Error(result.getErrorMessage());
     }
 }
 
@@ -67,15 +64,12 @@ function registerAuthentication(authInfo) {
         },
     };
 
-    try {
-        var result = ingestionService.setThrowOnError().call(requestBody);
-        if (result.ok) {
-            return result.object.body.authenticationID;
-        } else {
-            Logger.error('Error while registering authentication for appId + ' + authInfo.appId + '. Response: ' + result.object.body);
-        }
-    } catch(e) {
-        Logger.error('Uncaught error while registering authentication for appId + ' + authInfo.appId + ': ' + e.message + ': ' + e.stack);
+    var result = ingestionService.call(requestBody);
+    if (result.ok) {
+        return result.object.body.authenticationID;
+    } else {
+        Logger.error('Error while registering authentication for appId + ' + authInfo.appId + '. Response: ' + result.getErrorMessage());
+        throw new Error(result.getErrorMessage());
     }
 }
 
@@ -105,16 +99,12 @@ function updateAuthentication(authenticationID, authInfo) {
         },
     };
 
-    try {
-        var result = ingestionService.setThrowOnError().call(requestBody);
-        if (result.ok) {
-            Logger.info(result);
-            return result.object.body.authenticationID;
-        } else {
-            Logger.error('Error while updating authentication for appId + ' + authInfo.appId + ': ' + result.errorMessage);
-        }
-    } catch (e) {
-        Logger.error('Uncaught error while updating authentication for appId + ' + authInfo.appId + ': ' + e.message + ': ' + e.stack);
+    var result = ingestionService.call(requestBody);
+    if (result.ok) {
+        return result.object.body.authenticationID;
+    } else {
+        Logger.error('Error while updating authentication for appId + ' + authInfo.appId + ': ' + result.getErrorMessage());
+        throw new Error(result.getErrorMessage());
     }
 }
 
@@ -144,15 +134,12 @@ function registerDestination(destinationInfo) {
         authenticationID: destinationInfo.authenticationID,
     };
 
-    try {
-        var result = ingestionService.setThrowOnError().call(requestBody);
-        if (result.ok) {
-            return result.object.body.destinationID;
-        } else {
-            Logger.error('Error while registering destination (indexName=' + destinationInfo.indexName + 'authenticationID=' + authenticationID + '). Response: ' + result.object.body);
-        }
-    } catch(e) {
-        Logger.error('Error while registering destination (indexName=' + destinationInfo.indexName + 'authenticationID=' + authenticationID + '):' + e.message + ': ' + e.stack);
+    var result = ingestionService.call(requestBody);
+    if (result.ok) {
+        return result.object.body.destinationID;
+    } else {
+        Logger.error('Error while registering destination (indexName=' + destinationInfo.indexName + 'authenticationID=' + destinationInfo.authenticationID + '). Response: ' + result.getErrorMessage());
+        throw new Error(result.getErrorMessage());
     }
 }
 
@@ -174,8 +161,6 @@ function updateDestination(destinationID, destinationInfo) {
     ingestionService.setRequestMethod('PATCH');
     ingestionService.setURL(baseURL + '/1/destinations/' + destinationID);
 
-    Logger.info('destination: ' + baseURL + '/1/destinations/' + destinationID)
-
     var requestBody = {
         name: destinationInfo.name,
         input: {
@@ -184,15 +169,12 @@ function updateDestination(destinationID, destinationInfo) {
         authenticationID: destinationInfo.authenticationID,
     };
 
-    try {
-        var result = ingestionService.setThrowOnError().call(requestBody);
-        if (result.ok) {
-            return result.object.body.destinationID;
-        } else {
-            Logger.error('Error while registering destination (indexName=' + destinationInfo.indexName + 'authenticationID=' + authenticationID + '). Response: ' + result.object.body);
-        }
-    } catch(e) {
-        Logger.error('Uncaught error while registering destination (indexName=' + destinationInfo.indexName + 'authenticationID=' + authenticationID + '):' + e.message + ': ' + e.stack);
+    var result = ingestionService.call(requestBody);
+    if (result.ok) {
+        return result.object.body.destinationID;
+    } else {
+        Logger.error('Error while registering destination (indexName=' + destinationInfo.indexName + 'authenticationID=' + destinationInfo.authenticationID + '). Response: ' + result.getErrorMessage());
+        throw new Error(result.getErrorMessage());
     }
 }
 
@@ -222,15 +204,12 @@ function registerTask(taskInfo) {
         },
     };
 
-    try {
-        var result = ingestionService.setThrowOnError().call(requestBody);
-        if (result.ok) {
-            return result.object.body.taskID;
-        } else {
-            Logger.error('Error while registering task ' + taskInfo.action + '(sourceID=' + taskInfo.sourceID + '; destinationID=' + taskInfo.destinationID + '). Response: ' + result.object.body);
-        }
-    } catch(e) {
-        Logger.error('Uncaught error while registering task ' + taskInfo.action + '(sourceID=' + taskInfo.sourceID + '; destinationID=' + taskInfo.destinationID + '): ' + e.message + ': ' + e.stack);
+    var result = ingestionService.call(requestBody);
+    if (result.ok) {
+        return result.object.body.taskID;
+    } else {
+        Logger.error('Error while registering task ' + taskInfo.action + '(sourceID=' + taskInfo.sourceID + '; destinationID=' + taskInfo.destinationID + '). Response: ' + result.getErrorMessage());
+        throw new Error(result.getErrorMessage());
     }
 }
 


### PR DESCRIPTION
SFCC-58

This PR adds methods to to the Ingestion API Client introduced in #33, to be able to update the Data Ingestion objects:
- `updateAuthentication`
- `updateDestination`

I've also removed the usage of `.setThrowOnError()`, to rely directly on `result.ok`.