### PR TITLE
in_stock change

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaProduct.js
@@ -259,12 +259,8 @@ var aggregatedValueHandlers = {
         return productPrice;
     },
     in_stock: function (product) {
-        // the in_stock property now exports a boolean indicating whether the number of products in stock
-        // (ATS or available to sell) is higher than the threshold set in the custom site preference Algolia_InStockThreshold,
-        // as originally intended. The previous logic was flawed in that it compared the sitepref to product.availabilityModel.availability,
-        // which is a number between 0 and 1 and does not represent the number of products in stock.
         let inventoryRecord = product.getAvailabilityModel().getInventoryRecord(); // can be null
-        return (inventoryRecord ? inventoryRecord.getATS().getValue() > ALGOLIA_IN_STOCK_THRESHOLD : false);
+        return (inventoryRecord ? inventoryRecord.getATS().getValue() >= ALGOLIA_IN_STOCK_THRESHOLD : false);
     },
     image_groups: function (product) {
         // Get all image Groups of product for all locales


### PR DESCRIPTION
- `in_stock` is now exported as true only if ATS is greater than or equal to `Algolia_InStockThreshold`
- removed explanatory comment