### PR TITLE
SFCC-89: Switch absolute product image URLs to relative ones

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/job/categoryIndexJob.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/job/categoryIndexJob.js
@@ -64,7 +64,7 @@ function getCategoryUrl(category) {
  * @returns {string} - Url of the image
  */
 function getImageUrl(image) {
-    return image ? image.getHttpsURL().toString() : null;
+    return image ? image.getURL().toString() : null;
 }
 
 /**

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaProduct.js
@@ -78,7 +78,7 @@ function getImagesGroup(product, viewtype) {
             request.setLocale(localeName);
             var imageItems = product.getImages(viewtype);
             image.alt[localeName] = stringUtils.trim(imageItems[i].alt);
-            image.dis_base_link[localeName] = stringUtils.trim(imageItems[i].absURL.toString());
+            image.dis_base_link[localeName] = stringUtils.trim(imageItems[i].getURL().toString());
             image.title[localeName] = stringUtils.trim(imageItems[i].title);
         }
 

--- a/test/mocks/dw/catalog/Product.js
+++ b/test/mocks/dw/catalog/Product.js
@@ -251,36 +251,36 @@ Product.prototype.getImages = function (viewtype) {
     var arrDefaultLarge = [
         {
             alt: 'Floral Dress, Hot Pink Combo, large',
-            absURL: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg',
+            getURL: function() { return '/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg'},
             title: 'Floral Dress, Hot Pink Combo'
         },
         {
             alt: 'Floral Dress, Hot Pink Combo, large',
-            absURL: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg',
+            getURL: function() { return '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg'},
             title: 'Floral Dress, Hot Pink Combo'
         }
     ];
     var arrFrLarge = [
         {
             alt: 'French Floral Dress, Hot Pink Combo, large',
-            absURL: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg',
+            getURL: function() { return '/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg'},
             title: 'French Floral Dress, Hot Pink Combo'
         },
         {
             alt: 'French Floral Dress, Hot Pink Combo, large',
-            absURL: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg',
+            getURL: function() { return '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg'},
             title: 'French Floral Dress, Hot Pink Combo'
         }
     ];
     var arrEnLarge = [
         {
             alt: 'Floral Dress, Hot Pink Combo, large',
-            absURL: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg',
+            getURL: function() { return '/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg'},
             title: 'Floral Dress, Hot Pink Combo'
         },
         {
             alt: 'Floral Dress, Hot Pink Combo, large',
-            absURL: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg',
+            getURL: function() { return '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg'},
             title: 'Floral Dress, Hot Pink Combo'
         }
     ];
@@ -288,36 +288,36 @@ Product.prototype.getImages = function (viewtype) {
     var arrDefaultSmall = [
         {
             alt: 'Floral Dress, Hot Pink Combo, small',
-            absURL: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg',
+            getURL: function() { return '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg'},
             title: 'Floral Dress, Hot Pink Combo'
         },
         {
             alt: 'Floral Dress, Hot Pink Combo, small',
-            absURL: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg',
+            getURL: function() { return '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg'},
             title: 'Floral Dress, Hot Pink Combo'
         }
     ];
     var arrFrSmall = [
         {
             alt: 'Floral Dress, Hot Pink Combo, small',
-            absURL: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg',
+            getURL: function() { return '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg'},
             title: 'Floral Dress, Hot Pink Combo'
         },
         {
             alt: 'Floral Dress, Hot Pink Combo, small',
-            absURL: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg',
+            getURL: function() { return '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg'},
             title: 'Floral Dress, Hot Pink Combo'
         }
     ];
     var arrEnSmall = [
         {
             alt: 'Floral Dress, Hot Pink Combo, small',
-            absURL: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg',
+            getURL: function() { return '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg'},
             title: 'Floral Dress, Hot Pink Combo'
         },
         {
             alt: 'Floral Dress, Hot Pink Combo, small',
-            absURL: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg',
+            getURL: function() { return '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg'},
             title: 'Floral Dress, Hot Pink Combo'
         }
     ];

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaProduct.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaProduct.js
@@ -115,9 +115,9 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
                                 en: 'Floral Dress, Hot Pink Combo, large'
                             },
                             dis_base_link: {
-                                default: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg',
-                                fr: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg',
-                                en: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg'
+                                default: '/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg',
+                                fr: '/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg',
+                                en: '/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg'
                             },
                             title: {
                                 default: 'Floral Dress, Hot Pink Combo',
@@ -133,9 +133,9 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
                                 en: 'Floral Dress, Hot Pink Combo, large'
                             },
                             dis_base_link: {
-                                default: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg',
-                                fr: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg',
-                                en: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg'
+                                default: '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg',
+                                fr: '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg',
+                                en: '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg'
                             },
                             title: {
                                 default: 'Floral Dress, Hot Pink Combo',
@@ -157,9 +157,9 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
                                 en: 'Floral Dress, Hot Pink Combo, small'
                             },
                             dis_base_link: {
-                                default: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg',
-                                fr: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg',
-                                en: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg'
+                                default: '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg',
+                                fr: '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg',
+                                en: '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg'
                             },
                             title: {
                                 default: 'Floral Dress, Hot Pink Combo',
@@ -175,9 +175,9 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
                                 en: 'Floral Dress, Hot Pink Combo, small'
                             },
                             dis_base_link: {
-                                default: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg',
-                                fr: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg',
-                                en: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg'
+                                default: '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg',
+                                fr: '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg',
+                                en: '/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg'
                             },
                             title: {
                                 default: 'Floral Dress, Hot Pink Combo',


### PR DESCRIPTION
Changing image URLs in addition to product URLs warrant additional discussions as there can be clients who serve their images from external sources. We should investigate if any clients have such a setup.

- product image URLs are now exported as relative URLs
- adjusted unit tests