### PR TITLE
SFCC-123: Master attribute propagation improvement for AlgoliaProductsDeltaExport

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
@@ -449,11 +449,9 @@ function isObjectsArrayEmpty(objectsArray) {
  * @returns {Object} The result object containing `success` (boolean) and `nrProductsRead` (number)
  */
 function updateCPObjectFromXML(xmlFile, changedProducts, resourceType) {
-    var ProductMgr = require('dw/catalog/ProductMgr');
     var XMLStreamReader = require('dw/io/XMLStreamReader');
     var XMLStreamConstants = require('dw/io/XMLStreamConstants');
     var FileReader = require('dw/io/FileReader');
-    var productFilter = require('*/cartridge/scripts/algolia/filters/productFilter');
     var catalogID;
     var resultObj = {
         nrProductsRead: 0,
@@ -477,32 +475,8 @@ function updateCPObjectFromXML(xmlFile, changedProducts, resourceType) {
                                 var mode = xmlStreamReader.getAttributeValue(null, 'mode'); // <product mode="delete">
                                 var isAvailable = mode !== 'delete';
 
-                                let product = ProductMgr.getProduct(productID);
-
-                                if (!empty(product) && product.isMaster()) {
-                                    // if the product is a master, include its variants in changedProducts instead
-                                    // as changes to the master can be inherited by its variants (and masters shouldn't be indexed)
-                                    let variants = product.getVariants().toArray();
-
-                                    for (let i = 0; i < variants.length; i++) {
-                                        let variant = variants[i];
-
-                                        // adding new productID to structure or updating it if key already exists
-                                        if (productFilter.isInclude(variant)) {
-                                            _updateOrAddValue(changedProducts, variant.ID, isAvailable);
-                                        }
-                                    }
-                                } else if (!empty(product)) { // product exists and is a variant
-                                    if (productFilter.isInclude(product)) {
-                                        _updateOrAddValue(changedProducts, productID, isAvailable);
-                                    }
-                                } else { // product doesn't exist (getProduct() returned null)
-                                    // If product no longer exists at the time of the query, mark it for deletion from the index.
-                                    // Deleting a master in B2C will cause its variants to be deleted as well.
-                                    // Fortunately doing this will cause the master's variants to be included in the B2C delta XML file with mode="delete",
-                                    // otherwise there would be no way to retrieve a deleted master's variants (since the product can no longer be retrieved with getProduct()).
-                                    _updateOrAddValue(changedProducts, productID, false);
-                                }
+                                // adding new productID to structure or updating it if key already exists
+                                _updateOrAddValue(changedProducts, productID, isAvailable);
 
                                 resultObj.nrProductsRead++;
                             }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendDeltaExportProducts.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendDeltaExportProducts.js
@@ -80,7 +80,7 @@ function sendDeltaExportProducts(parameters) {
     var fileHelper = require('*/cartridge/scripts/algolia/helper/fileHelper');
 
     var AlgoliaProduct = require('*/cartridge/scripts/algolia/model/algoliaProduct');
-
+    var productFilter = require('*/cartridge/scripts/algolia/filters/productFilter');
 
     // initializing log data
     const updateLogType = 'LastProductDeltaSyncLog';
@@ -257,8 +257,10 @@ function sendDeltaExportProducts(parameters) {
                 var product = ProductMgr.getProduct(productID); // get product from database, send remove request to Algolia if null
 
                 if (!empty(product)) {
-                    var algoliaProduct = new AlgoliaProduct(product);
-                    productUpdateObj = new jobHelper.UpdateProductModel(algoliaProduct);
+                    if (productFilter.isInclude(product)) {
+                        var algoliaProduct = new AlgoliaProduct(product);
+                        productUpdateObj = new jobHelper.UpdateProductModel(algoliaProduct);
+                    }
 
                 } else { // the data from the delta export about this product is stale, product can no longer be found in the database -- send a remove request
                     productUpdateObj = new jobHelper.DeleteProductModel(productID);

--- a/metadata/algolia/jobs.xml
+++ b/metadata/algolia/jobs.xml
@@ -82,7 +82,7 @@ Make sure to contact SFCC Support to enable delta exports on your instance.</des
                     <parameter name="CatalogIDs" job-parameter-ref="catalogIDs"/>
                     <parameter name="Consumers" job-parameter-ref="consumer"/>
                     <parameter name="ExportFile" job-parameter-ref="deltaExportJobName"/>
-                    <parameter name="MasterProductExport">false</parameter>
+                    <parameter name="MasterProductExport">true</parameter>
                 </parameters>
             </step>
             <step step-id="sendDeltaExportProducts" type="custom.algoliaSendDeltaExportProducts" enforce-restart="false">


### PR DESCRIPTION
Found a better way to handle attribute propagation to the variants when a master's attribute is changed (see #52 for the original PR).
There's a parameter that can be used to make the B2C delta export job add a master's variants to its output (via the `MasterProductExport` parameter of the `CatalogDeltaExport` system job step), so there's no need to handle this on our end by forcefully adding the variants of masters to the list of exported products.
The end result is the same, but this method should be a bit faster since we can eliminate one of the early `ProductMgr.getProduct()` calls to determine the master's variants.

Reverted most of the previous changes to `jobHelper` (from #52) since they are not needed anymore, except for the product filtering, which I moved to `sendDeltaExportProducts.js` (also no need for it to be in `jobHelper` anymore).
The reverted code is functionally equivalent to what `MasterProductExport` does, which is now set to `true` by default.