### PR TITLE
feat: localized product model

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js
@@ -53,6 +53,32 @@ function customizeProductModel(productModel) {
     }
 }
 
+/**
+ * Customize Localized Algolia Product.
+ * Add extra properties to the product model.
+ * @param {Object} productModel - Algolia product model
+ * @param {Object} algoliaFields - The fields to index
+ */
+function customizeLocalizedProductModel(productModel, algoliaFields) {
+    var CATEGORY_ATTRIBUTE = 'CATEGORIES_NEW_ARRIVALS';
+    var CATEGORY_ID = 'newarrivals';
+
+    if (algoliaFields.includes(CATEGORY_ATTRIBUTE)) {
+        productModel[CATEGORY_ATTRIBUTE] = null;
+
+        if (!empty(productModel.categories)) {
+            for (var i = 0; i < productModel.categories.length; i += 1) {
+                var rootCategoryId = productModel.categories[i][productModel.categories[i].length - 1].id;
+                if (rootCategoryId === CATEGORY_ID) {
+                    productModel[CATEGORY_ATTRIBUTE] = createAlgoliaCategoryObject(productModel.categories[i]);
+                    break;
+                }
+            }
+        }
+    }
+}
+
 module.exports = {
-    customizeProductModel: customizeProductModel
+    customizeProductModel: customizeProductModel,
+    customizeLocalizedProductModel: customizeLocalizedProductModel
 };

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -1,0 +1,306 @@
+'use strict';
+
+var Site = require('dw/system/Site');
+var Currency = require('dw/util/Currency');
+var stringUtils = require('dw/util/StringUtils');
+var URLUtils = require('dw/web/URLUtils');
+
+var algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
+var algoliaUtils = require('*/cartridge/scripts/algolia/lib/utils');
+var algoliaProductConfig = require('*/cartridge/scripts/algolia/lib/algoliaProductConfig');
+var productModelCustomizer = require('*/cartridge/scripts/algolia/customization/productModelCustomizer');
+
+const ALGOLIA_IN_STOCK_THRESHOLD = algoliaData.getPreference('InStockThreshold');
+
+/**
+ * Get the lowest promotional price for product
+ * list all the active promotions for the product, then compares the prices and select the lowest.
+ *
+ * @param {dw.catalog.Product} product -product
+ * @returns {dw.value.Money|null} lowest price or null if no price available
+ */
+function getPromotionalPrice(product) {
+    var promotions = dw.campaign.PromotionMgr.getActivePromotions().getProductPromotions(product);
+    var lowestPromoPrice = null;
+    var promoPrices = promotions
+        .toArray()
+        .map(function (promotion) {
+            // get all promotions for this product
+            return promotion.getPromotionalPrice(product);
+        })
+        .filter(function (price) {
+            // skip promotions without price
+            return price !== dw.value.Money.NOT_AVAILABLE;
+        });
+    // find the lowest price
+    if (promoPrices.length > 0) {
+        lowestPromoPrice = promoPrices.reduce(function (a, b) {
+            return Math.min(a.value, b.value);
+        });
+    }
+    return lowestPromoPrice;
+}
+
+/**
+ * Function get Algolia Image Group of Images attributes of Product
+ * @param {dw.order.Product} product - product
+ * @param {string} viewtype - image type ('large' or 'small')
+ * @returns  {Object} - Algolia Image Group Object
+ */
+function getImagesGroup(product, viewtype) {
+    if (empty(product) || empty(viewtype)) { return null; }
+
+    var imagesList = product.getImages(viewtype);
+    if (empty(imagesList)) { return null; }
+
+    var result = {
+        _type: 'image_group',
+        images: [],
+        view_type: viewtype
+    };
+
+    var imagesListSize = imagesList.size();
+    for (var i = 0; i < imagesListSize; ++i) {
+        var image = {
+            _type: 'image',
+            alt: {},
+            dis_base_link: {},
+            title: {}
+        };
+
+        image.alt = stringUtils.trim(imagesList[i].alt);
+        image.dis_base_link = stringUtils.trim(imagesList[i].absURL.toString());
+        image.title = stringUtils.trim(imagesList[i].title);
+
+        result.images.push(image);
+    }
+
+    return result;
+}
+
+/**
+ * Function get value of object property by attribute name.
+ * An attribute name can be complex and consist of several levels.
+ * Attribute names must be separated by dots.
+ * Example: primaryCategory.ID
+ * @param {dw.object.ExtensibleObject} extensibleObject - business object
+ * @param {string} attributeName - object attribute name
+ * @returns {string|boolean|number|null} - value
+ */
+function getAttributeValue(extensibleObject, attributeName) {
+    var properties = attributeName.split('.');
+    var result = properties.reduce(function (previousValue, currentProperty) {
+        return previousValue ? previousValue[currentProperty] : null;
+    }, extensibleObject);
+
+    if ((typeof result) === 'string') {
+        result = empty(result) ? null : stringUtils.trim(algoliaUtils.escapeEmoji(result.toString()));
+    }
+    return result;
+}
+
+/**
+ * Create category tree of Product
+ * @param {dw.catalog.Category} category - category
+ * @returns {Object} - category tree
+ */
+function getCategoryFlatTree(category) {
+    if (empty(category)) return [];
+
+    var categoryTree = [];
+    var currentCategory = category;
+    categoryTree.push({
+        id: currentCategory.ID,
+        name: getAttributeValue(currentCategory, 'displayName')
+    });
+
+    while (!currentCategory.topLevel && !currentCategory.root) {
+        currentCategory = currentCategory.parent;
+        if (!currentCategory.online) {
+            break;
+        }
+        categoryTree.push({
+            id: currentCategory.ID,
+            name: getAttributeValue(currentCategory, 'displayName')
+        });
+    }
+
+    return categoryTree;
+}
+
+/**
+ * Safely gets a custom attribute from a System Object.
+ * Since attempting to return a nonexistent custom attribute throws an error in SFCC,
+ * this is the safest way to check whether an attribute exists.
+ * @param {dw.object.CustomAttributes} customAttributes The CustomAttributes object, e.g. product.getCustom()
+ * @param {string} caKey The custom attribute's key whose value we want to return
+ * @returns {*} The custom attribute value if exists,
+ *              null if the custom attribute is defined but it has no value for this specific SO,
+ *              undefined if the custom attribute is not defined at all in BM
+ */
+function safelyGetCustomAttribute(customAttributes, caKey) {
+    let customAttributeValue;
+    try {
+        customAttributeValue = customAttributes[caKey];
+    } catch(e) {
+        customAttributeValue = undefined;
+    } finally {
+        return customAttributeValue;
+    }
+}
+
+/**
+ * Handler complex and calculated Product attributes
+ */
+var aggregatedValueHandlers = {
+    categories: function (product) {
+        var productCategories = product.getOnlineCategories();
+        productCategories = empty(productCategories) ? [] : productCategories.toArray();
+
+        if (product.isVariant()) {
+            var masterProductCategories = product.masterProduct.getOnlineCategories();
+            masterProductCategories = empty(masterProductCategories) ? [] : masterProductCategories.toArray();
+            productCategories = productCategories.concat(masterProductCategories);
+        }
+
+        return productCategories
+            .map(function (category) {
+                return getCategoryFlatTree(category);
+            });
+    },
+    primary_category_id: function (product) {
+        var result = null;
+        if (empty(product.primaryCategory)) {
+            var primaryCategory = product.isVariant() ? product.masterProduct.primaryCategory : null;
+            result = empty(primaryCategory) ? null : primaryCategory.ID;
+        } else {
+            result = product.primaryCategory.ID;
+        }
+        return result;
+    },
+    color: function (product) {
+        var variationModel = product.getVariationModel();
+        var colorAttribute = variationModel.getProductVariationAttribute('color');
+        return (colorAttribute && variationModel.getSelectedValue(colorAttribute))
+            ? variationModel.getSelectedValue(colorAttribute).displayValue
+            : null;
+    },
+    refinementColor: function (product) {
+        return safelyGetCustomAttribute(product.custom, 'refinementColor')
+            ? product.custom.refinementColor.displayValue
+            : null;
+    },
+    size: function (product) {
+        var variationModel = product.getVariationModel();
+        var sizeAttribute = variationModel.getProductVariationAttribute('size');
+        return (sizeAttribute && variationModel.getSelectedValue(sizeAttribute))
+            ? variationModel.getSelectedValue(sizeAttribute).displayValue
+            : null;
+    },
+    refinementSize: function (product) {
+        return safelyGetCustomAttribute(product.custom, 'refinementSize')
+            ? product.custom.refinementSize
+            : null;
+    },
+    price: function (product) {
+        // Get price for all currencies
+        var productPrice = null;
+        var currentSession = request.getSession();
+        var siteCurrencies = Site.getCurrent().getAllowedCurrencies();
+        var siteCurrenciesSize = siteCurrencies.size();
+        var currentCurrency = currentSession.getCurrency();
+
+        for (var k = 0; k < siteCurrenciesSize; k += 1) {
+            var currency = Currency.getCurrency(siteCurrencies[k]);
+            currentSession.setCurrency(currency);
+            var price = product.productSet ? product.priceModel.minPrice : product.priceModel.price;
+            if (price.available) {
+                if (!productPrice) { productPrice = {}; }
+                productPrice[price.currencyCode] = price.value;
+            }
+        }
+        currentSession.setCurrency(currentCurrency);
+        return productPrice;
+    },
+    in_stock: function (product) {
+        let inventoryRecord = product.getAvailabilityModel().getInventoryRecord(); // can be null
+        return (inventoryRecord ? inventoryRecord.getATS().getValue() >= ALGOLIA_IN_STOCK_THRESHOLD : false);
+    },
+    image_groups: function (product) {
+        var imageGroupsArr = [];
+        var imageGroup = getImagesGroup(product, 'large');
+        if (!empty(imageGroup)) {
+            imageGroupsArr.push(imageGroup);
+        }
+
+        imageGroup = getImagesGroup(product, 'small');
+        if (!empty(imageGroup)) {
+            imageGroupsArr.push(imageGroup);
+        }
+        return imageGroupsArr.length > 0 ? imageGroupsArr : null;
+    },
+    url: function (product) {
+        // Get product page url for the current locale
+        var productPageUrl = URLUtils.url('Product-Show', 'pid', product.ID);
+        return productPageUrl ? productPageUrl.toString() : null;
+    },
+    promotionalPrice: function (product) {
+        // Get promotional price for all currencies
+        var promotionalPrice = null;
+        var currentSession = request.getSession();
+        var siteCurrencies = Site.getCurrent().getAllowedCurrencies();
+        var siteCurrenciesSize = siteCurrencies.size();
+        var currentCurrency = currentSession.getCurrency();
+
+        for (var k = 0; k < siteCurrenciesSize; k += 1) {
+            var currency = Currency.getCurrency(siteCurrencies[k]);
+            currentSession.setCurrency(currency);
+            var price = getPromotionalPrice(product);
+            if (price) {
+                if (!promotionalPrice) { promotionalPrice = {}; }
+                promotionalPrice[price.currencyCode] = price.value;
+            }
+        }
+        currentSession.setCurrency(currentCurrency);
+        return promotionalPrice;
+    }
+}
+
+/**
+ * AlgoliaLocalizedProduct class that represents a localized algoliaProduct ready to be indexed
+ * @param {dw.order.Product} product - Product
+ * @param {string} locale - The requested locale
+ * @param {Array} [fieldListOverride] (optional) if supplied, it overrides the regular list of attributes to be sent (default + customFields)
+ * @constructor
+ */
+function algoliaLocalizedProduct(product, locale, fieldListOverride) {
+    request.setLocale(locale || 'default');
+
+    // list of fields to build the object with
+    let algoliaFields;
+    if (!empty(fieldListOverride)) {
+        // use overridden list of fields
+        algoliaFields = fieldListOverride;
+    } else {
+        // use regular list of fields (default behavior)
+        const customFields = algoliaData.getSetOfArray('CustomFields');
+        algoliaFields = algoliaProductConfig.defaultAttributes.concat(customFields);
+    }
+
+    if (empty(product)) {
+        this.id = null;
+    } else {
+        for (var i = 0; i < algoliaFields.length; i += 1) {
+            var attributeName = algoliaFields[i];
+            var config = algoliaProductConfig.attributeConfig[attributeName];
+
+            if (!empty(config)) {
+                this[attributeName] = aggregatedValueHandlers[attributeName]
+                    ? aggregatedValueHandlers[attributeName](product)
+                    : getAttributeValue(product, config.attribute);
+            }
+        }
+    }
+}
+
+module.exports = algoliaLocalizedProduct;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -313,10 +313,10 @@ var aggregatedValueHandlers = {
  * @param {dw.order.Product} product - Product
  * @param {string} locale - The requested locale
  * @param {Array} [fieldListOverride] (optional) if supplied, it overrides the regular list of attributes to be sent (default + customFields)
- * @param {Object} baseProduct - A base product that contains pre-fetched properties
+ * @param {Object} baseModel - A base model object that contains some pre-fetched properties
  * @constructor
  */
-function algoliaLocalizedProduct(product, locale, fieldListOverride, baseProduct) {
+function algoliaLocalizedProduct(product, locale, fieldListOverride, baseModel) {
     request.setLocale(locale || 'default');
 
     // list of fields to build the object with
@@ -339,8 +339,8 @@ function algoliaLocalizedProduct(product, locale, fieldListOverride, baseProduct
             var config = algoliaProductConfig.attributeConfig[attributeName];
 
             if (!empty(config)) {
-                if (baseProduct && baseProduct[attributeName]) {
-                    this[attributeName] = baseProduct[attributeName];
+                if (baseModel && baseModel[attributeName]) {
+                    this[attributeName] = baseModel[attributeName];
                 } else {
                     this[attributeName] = aggregatedValueHandlers[attributeName]
                         ? aggregatedValueHandlers[attributeName](product)

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -313,9 +313,10 @@ var aggregatedValueHandlers = {
  * @param {dw.order.Product} product - Product
  * @param {string} locale - The requested locale
  * @param {Array} [fieldListOverride] (optional) if supplied, it overrides the regular list of attributes to be sent (default + customFields)
+ * @param {Object} baseProduct - A base product that contains pre-fetched properties
  * @constructor
  */
-function algoliaLocalizedProduct(product, locale, fieldListOverride) {
+function algoliaLocalizedProduct(product, locale, fieldListOverride, baseProduct) {
     request.setLocale(locale || 'default');
 
     // list of fields to build the object with
@@ -338,9 +339,13 @@ function algoliaLocalizedProduct(product, locale, fieldListOverride) {
             var config = algoliaProductConfig.attributeConfig[attributeName];
 
             if (!empty(config)) {
-                this[attributeName] = aggregatedValueHandlers[attributeName]
-                    ? aggregatedValueHandlers[attributeName](product)
-                    : getAttributeValue(product, config.attribute);
+                if (baseProduct && baseProduct[attributeName]) {
+                    this[attributeName] = baseProduct[attributeName];
+                } else {
+                    this[attributeName] = aggregatedValueHandlers[attributeName]
+                        ? aggregatedValueHandlers[attributeName](product)
+                        : getAttributeValue(product, config.attribute);
+                }
             }
         }
         if (algoliaFields.indexOf('id') >= 0) {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -343,11 +343,11 @@ function algoliaLocalizedProduct(product, locale, fieldListOverride) {
                     : getAttributeValue(product, config.attribute);
             }
         }
-        if (algoliaFields.indexOf('primary_category_id') >= 0 && algoliaFields.indexOf('categories') >= 0) {
-            this['__primary_category'] = getPrimaryCategoryHierarchicalFacets(product);
-        }
         if (algoliaFields.indexOf('id') >= 0) {
             this._tags = ['id:' + product.ID];
+        }
+        if (algoliaFields.indexOf('primary_category_id') >= 0 && algoliaFields.indexOf('categories') >= 0) {
+            this['__primary_category'] = getPrimaryCategoryHierarchicalFacets(product);
         }
         productModelCustomizer.customizeLocalizedProductModel(this, algoliaFields);
     }

--- a/test/mocks/dw/catalog/Product.js
+++ b/test/mocks/dw/catalog/Product.js
@@ -16,7 +16,7 @@ Product.prototype = {
         var result = null;
         switch (request.getLocale()) {
             case 'default': result = 'Floral Dress'; break;
-            case 'fr': result = 'Floral Dress'; break;
+            case 'fr': result = 'Robe florale'; break;
             case 'en': result = 'Floral Dress'; break;
             default: break;
         }
@@ -26,7 +26,7 @@ Product.prototype = {
         var result = null;
         switch (request.getLocale()) {
             case 'default': result = 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.'; break;
-            case 'fr': result = 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.'; break;
+            case 'fr': result = 'Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.'; break;
             case 'en': result = 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.'; break;
             default: break;
         }
@@ -46,7 +46,7 @@ Product.prototype = {
         var result = null;
         switch (request.getLocale()) {
             case 'default': result = 'Floral Dress'; break;
-            case 'fr': result = 'Floral Dress'; break;
+            case 'fr': result = 'Robe florale'; break;
             case 'en': result = 'Floral Dress'; break;
             default: break;
         }
@@ -56,7 +56,7 @@ Product.prototype = {
         var result = { source: null };
         switch (request.getLocale()) {
             case 'default': result.source = 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.'; break;
-            case 'fr': result.source = 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.'; break;
+            case 'fr': result.source = 'Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.'; break;
             case 'en': result.source = 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.'; break;
             default: break;
         }
@@ -66,7 +66,7 @@ Product.prototype = {
         var result = { source: null };
         switch (request.getLocale()) {
             case 'default': result.source = 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.'; break;
-            case 'fr': result.source = 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.'; break;
+            case 'fr': result.source = 'Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.'; break;
             case 'en': result.source = 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.'; break;
             default: break;
         }
@@ -126,7 +126,14 @@ Product.prototype.getAvailabilityModel = function() {
 Product.prototype.isVariant = function () { return false; };
 Product.prototype.custom = {
     refinementColor: {
-        displayValue: 'Pink'
+        get displayValue() {
+            switch (request.getLocale()) {
+                case 'default': return 'Pink';
+                case 'fr': return 'Rose';
+                case 'en': return 'Pink';
+                default: return 'Pink';
+            }
+        }
     },
     refinementSize: '4',
 };
@@ -138,7 +145,7 @@ Product.prototype.getOnlineCategories = function () {
                 var name = null;
                 switch (request.getLocale()) {
                     case 'default': name = 'Womens'; break;
-                    case 'fr': name = 'Womens'; break;
+                    case 'fr': name = 'Femmes'; break;
                     case 'en': name = 'Womens'; break;
                     default: break;
                 }
@@ -151,7 +158,7 @@ Product.prototype.getOnlineCategories = function () {
                     var name = null;
                     switch (request.getLocale()) {
                         case 'default': name = 'New Arrivals'; break;
-                        case 'fr': name = 'New Arrivals'; break;
+                        case 'fr': name = 'Nouveaux arrivages'; break;
                         case 'en': name = 'New Arrivals'; break;
                         default: break;
                     }
@@ -170,7 +177,7 @@ Product.prototype.getOnlineCategories = function () {
                 var name = null;
                 switch (request.getLocale()) {
                     case 'default': name = 'Bottoms'; break;
-                    case 'fr': name = 'Bottoms'; break;
+                    case 'fr': name = 'Bas'; break;
                     case 'en': name = 'Bottoms'; break;
                     default: break;
                 }
@@ -183,7 +190,7 @@ Product.prototype.getOnlineCategories = function () {
                     var name = null;
                     switch (request.getLocale()) {
                         case 'default': name = 'Clothing'; break;
-                        case 'fr': name = 'Clothing'; break;
+                        case 'fr': name = 'Vêtements'; break;
                         case 'en': name = 'Clothing'; break;
                         default: break;
                     }
@@ -196,7 +203,7 @@ Product.prototype.getOnlineCategories = function () {
                         var name = null;
                         switch (request.getLocale()) {
                             case 'default': name = 'Womens'; break;
-                            case 'fr': name = 'Womens'; break;
+                            case 'fr': name = 'Femmes'; break;
                             case 'en': name = 'Womens'; break;
                             default: break;
                         }
@@ -223,7 +230,7 @@ Product.prototype.getVariationModel = function () {
                 case 'color':
                     switch (request.getLocale()) {
                         case 'default': result = { displayValue: 'Hot Pink Combo' }; break;
-                        case 'fr': result = { displayValue: 'Hot Pink Combo' }; break;
+                        case 'fr': result = { displayValue: 'Combo rose vif' }; break;
                         case 'en': result = { displayValue: 'Hot Pink Combo' }; break;
                         default: break;
                     }
@@ -262,14 +269,14 @@ Product.prototype.getImages = function (viewtype) {
     ];
     var arrFrLarge = [
         {
-            alt: 'French Floral Dress, Hot Pink Combo, large',
+            alt: 'Robe florale, Combo rose vif, large',
             absURL: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg',
-            title: 'French Floral Dress, Hot Pink Combo'
+            title: 'Robe florale, Combo rose vif'
         },
         {
-            alt: 'French Floral Dress, Hot Pink Combo, large',
+            alt: 'Robe florale, Combo rose vif, large',
             absURL: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg',
-            title: 'French Floral Dress, Hot Pink Combo'
+            title: 'Robe florale, Combo rose vif'
         }
     ];
     var arrEnLarge = [
@@ -299,14 +306,14 @@ Product.prototype.getImages = function (viewtype) {
     ];
     var arrFrSmall = [
         {
-            alt: 'Floral Dress, Hot Pink Combo, small',
+            alt: 'Robe florale, Combo rose vif, small',
             absURL: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg',
-            title: 'Floral Dress, Hot Pink Combo'
+            title: 'Robe florale, Combo rose vif'
         },
         {
-            alt: 'Floral Dress, Hot Pink Combo, small',
+            alt: 'Robe florale, Combo rose vif, small',
             absURL: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg',
-            title: 'Floral Dress, Hot Pink Combo'
+            title: 'Robe florale, Combo rose vif'
         }
     ];
     var arrEnSmall = [

--- a/test/mocks/dw/catalog/Product.js
+++ b/test/mocks/dw/catalog/Product.js
@@ -100,7 +100,6 @@ Product.prototype = {
     }
 };
 Product.prototype.ID = '701644031206M';
-Product.prototype.primaryCategory = { ID: 'womens' };
 Product.prototype.online = true;
 Product.prototype.searchable = true;
 Product.prototype.UPC = '701644031206';
@@ -137,6 +136,59 @@ Product.prototype.custom = {
     },
     refinementSize: '4',
 };
+var primaryCategory = {
+    ID: 'womens-clothing-bottoms',
+    get displayName() {
+        var name = null;
+        switch (request.getLocale()) {
+            case 'default': name = 'Bottoms'; break;
+            case 'fr': name = 'Bas'; break;
+            case 'en': name = 'Bottoms'; break;
+            default: break;
+        }
+        return name;
+    },
+    online: true,
+    root: false,
+    parent: {
+        ID: 'womens-clothing',
+        get displayName() {
+            var name = null;
+            switch (request.getLocale()) {
+                case 'default': name = 'Clothing'; break;
+                case 'fr': name = 'Vêtements'; break;
+                case 'en': name = 'Clothing'; break;
+                default: break;
+            }
+            return name;
+        },
+        online: true,
+        root: false,
+        parent: {
+            ID: 'womens',
+            get displayName() {
+                var name = null;
+                switch (request.getLocale()) {
+                    case 'default': name = 'Womens'; break;
+                    case 'fr': name = 'Femmes'; break;
+                    case 'en': name = 'Womens'; break;
+                    default: break;
+                }
+                return name;
+            },
+            online: true,
+            root: true,
+            parent: {
+                ID: 'root',
+                displayName: 'Storefront Catalog - EN'
+            }
+        }
+    }
+}
+Product.prototype.primaryCategory = primaryCategory;
+Product.prototype.getPrimaryCategory = function() {
+    return primaryCategory;
+};
 Product.prototype.getOnlineCategories = function () {
     var result = [
         {
@@ -171,52 +223,7 @@ Product.prototype.getOnlineCategories = function () {
                 }
             }
         },
-        {
-            ID: 'womens-clothing-bottoms',
-            get displayName() {
-                var name = null;
-                switch (request.getLocale()) {
-                    case 'default': name = 'Bottoms'; break;
-                    case 'fr': name = 'Bas'; break;
-                    case 'en': name = 'Bottoms'; break;
-                    default: break;
-                }
-                return name;
-            },
-            root: false,
-            parent: {
-                ID: 'womens-clothing',
-                get displayName() {
-                    var name = null;
-                    switch (request.getLocale()) {
-                        case 'default': name = 'Clothing'; break;
-                        case 'fr': name = 'Vêtements'; break;
-                        case 'en': name = 'Clothing'; break;
-                        default: break;
-                    }
-                    return name;
-                },
-                root: false,
-                parent: {
-                    ID: 'womens',
-                    get displayName() {
-                        var name = null;
-                        switch (request.getLocale()) {
-                            case 'default': name = 'Womens'; break;
-                            case 'fr': name = 'Femmes'; break;
-                            case 'en': name = 'Womens'; break;
-                            default: break;
-                        }
-                        return name;
-                    },
-                    root: true,
-                    parent: {
-                        ID: 'root',
-                        displayName: 'Storefront Catalog - EN'
-                    }
-                }
-            }
-        }
+        primaryCategory,
     ];
     result.toArray = function () { return result; };
     return result;

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -82,7 +82,7 @@ describe('algoliaLocalizedProduct', function () {
         let algoliaProductModel = {
             id: '701644031206M',
             in_stock: true,
-            primary_category_id: 'womens',
+            primary_category_id: 'womens-clothing-bottoms',
             price: {
                 USD: 129,
                 EUR: 92.88
@@ -98,6 +98,14 @@ describe('algoliaLocalizedProduct', function () {
                     {
                         id: 'womens-clothing-bottoms',
                         name: 'Bottoms',
+                    },
+                    {
+                        id: 'womens-clothing',
+                        name: 'Clothing',
+                    },
+                    {
+                        id: 'womens',
+                        name: 'Womens',
                     }
                 ]
             ],
@@ -164,7 +172,7 @@ describe('algoliaLocalizedProduct', function () {
         let algoliaProductModel = {
             id: '701644031206M',
             in_stock: true,
-            primary_category_id: 'womens',
+            primary_category_id: 'womens-clothing-bottoms',
             price: {
                 USD: 129,
                 EUR: 92.88
@@ -180,6 +188,14 @@ describe('algoliaLocalizedProduct', function () {
                     {
                         id: 'womens-clothing-bottoms',
                         name: 'Bas',
+                    },
+                    {
+                        id: 'womens-clothing',
+                        name: 'Vêtements',
+                    },
+                    {
+                        id: 'womens',
+                        name: 'Femmes',
                     }
                 ]
             ],

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -76,8 +76,8 @@ const AlgoliaLocalizedProduct = require('../../../../../../cartridges/int_algoli
 
 describe('algoliaLocalizedProduct', function () {
     test('default locale', function () {
-        let product = new ProductMock();
-        let algoliaProductModel = {
+        const product = new ProductMock();
+        const algoliaProductModel = {
             objectID: '701644031206M',
             id: '701644031206M',
             in_stock: true,
@@ -175,8 +175,8 @@ describe('algoliaLocalizedProduct', function () {
     });
 
     test('fr locale', function () {
-        let product = new ProductMock();
-        let algoliaProductModel = {
+        const product = new ProductMock();
+        const algoliaProductModel = {
             objectID: '701644031206M',
             id: '701644031206M',
             in_stock: true,
@@ -273,15 +273,37 @@ describe('algoliaLocalizedProduct', function () {
         expect(new AlgoliaLocalizedProduct(product, 'fr')).toEqual(algoliaProductModel);
     });
 
-    test('en locale + fieldListOverride', function () {
-        let product = new ProductMock();
-        let algoliaProductModel = {
+    test('fieldListOverride', function () {
+        const product = new ProductMock();
+        const algoliaProductModel = {
             objectID: '701644031206M',
             price: {
                 USD: 129,
                 EUR: 92.88
             },
         };
-        expect(new AlgoliaLocalizedProduct(product, 'fr', ['price'])).toEqual(algoliaProductModel);
+        expect(new AlgoliaLocalizedProduct(product, undefined, ['price'])).toEqual(algoliaProductModel);
+    });
+
+    test('baseProduct', function () {
+        const product = new ProductMock();
+        const baseProduct = {
+            UPC: 'Test UPC',
+            price: {
+                USD: 1,
+                EUR: 0.93
+            },
+            name: 'Test name',
+        }
+        const algoliaProductModel = {
+            objectID: '701644031206M',
+            UPC: 'Test UPC',
+            price: {
+                USD: 1,
+                EUR: 0.93
+            },
+            name: 'Test name',
+        };
+        expect(new AlgoliaLocalizedProduct(product, 'default', ['price', 'UPC', 'name'], baseProduct)).toEqual(algoliaProductModel);
     });
 });

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -285,9 +285,9 @@ describe('algoliaLocalizedProduct', function () {
         expect(new AlgoliaLocalizedProduct(product, undefined, ['price'])).toEqual(algoliaProductModel);
     });
 
-    test('baseProduct', function () {
+    test('baseModel', function () {
         const product = new ProductMock();
-        const baseProduct = {
+        const baseModel = {
             UPC: 'Test UPC',
             price: {
                 USD: 1,
@@ -295,7 +295,7 @@ describe('algoliaLocalizedProduct', function () {
             },
             name: 'Test name',
         }
-        const algoliaProductModel = {
+        const expectedProductModel = {
             objectID: '701644031206M',
             UPC: 'Test UPC',
             price: {
@@ -304,6 +304,6 @@ describe('algoliaLocalizedProduct', function () {
             },
             name: 'Test name',
         };
-        expect(new AlgoliaLocalizedProduct(product, 'default', ['price', 'UPC', 'name'], baseProduct)).toEqual(algoliaProductModel);
+        expect(new AlgoliaLocalizedProduct(product, 'default', ['price', 'UPC', 'name'], baseModel)).toEqual(expectedProductModel);
     });
 });

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -69,9 +69,7 @@ jest.mock('*/cartridge/scripts/algolia/lib/algoliaProductConfig', () => {
     return jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig');
 }, {virtual: true});
 jest.mock('*/cartridge/scripts/algolia/customization/productModelCustomizer', () => {
-    return {
-        customizeProductModel: function (productModel) { return productModel; }
-    }
+    return jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer');
 }, {virtual: true});
 
 const AlgoliaLocalizedProduct = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct');
@@ -80,6 +78,7 @@ describe('algoliaLocalizedProduct', function () {
     test('default locale', function () {
         let product = new ProductMock();
         let algoliaProductModel = {
+            objectID: '701644031206M',
             id: '701644031206M',
             in_stock: true,
             primary_category_id: 'womens-clothing-bottoms',
@@ -109,6 +108,11 @@ describe('algoliaLocalizedProduct', function () {
                     }
                 ]
             ],
+            __primary_category: {
+                0: 'Womens',
+                1: 'Womens > Clothing',
+                2: 'Womens > Clothing > Bottoms',
+            },
             brand: null,
             image_groups: [
                 {
@@ -163,6 +167,9 @@ describe('algoliaLocalizedProduct', function () {
             refinementColor: 'Pink',
             size: '4',
             refinementSize: '4',
+            _tags: [
+                'id:701644031206M',
+            ],
         };
         expect(new AlgoliaLocalizedProduct(product)).toEqual(algoliaProductModel);
     });
@@ -170,6 +177,7 @@ describe('algoliaLocalizedProduct', function () {
     test('fr locale', function () {
         let product = new ProductMock();
         let algoliaProductModel = {
+            objectID: '701644031206M',
             id: '701644031206M',
             in_stock: true,
             primary_category_id: 'womens-clothing-bottoms',
@@ -199,6 +207,11 @@ describe('algoliaLocalizedProduct', function () {
                     }
                 ]
             ],
+            __primary_category: {
+                0: 'Femmes',
+                1: 'Femmes > Vêtements',
+                2: 'Femmes > Vêtements > Bas',
+            },
             brand: null,
             image_groups: [
                 {
@@ -253,6 +266,9 @@ describe('algoliaLocalizedProduct', function () {
             refinementColor: 'Rose',
             size: '4',
             refinementSize: '4',
+            _tags: [
+                'id:701644031206M',
+            ],
         };
         expect(new AlgoliaLocalizedProduct(product, 'fr')).toEqual(algoliaProductModel);
     });
@@ -260,12 +276,12 @@ describe('algoliaLocalizedProduct', function () {
     test('en locale + fieldListOverride', function () {
         let product = new ProductMock();
         let algoliaProductModel = {
-            id: '701644031206M',
+            objectID: '701644031206M',
             price: {
                 USD: 129,
                 EUR: 92.88
             },
         };
-        expect(new AlgoliaLocalizedProduct(product, 'fr', ['id', 'price'])).toEqual(algoliaProductModel);
+        expect(new AlgoliaLocalizedProduct(product, 'fr', ['price'])).toEqual(algoliaProductModel);
     });
 });

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -1,0 +1,255 @@
+'use strict';
+
+var GlobalMock = require('../../../../../mocks/global');
+var ProductMock = require('../../../../../mocks/dw/catalog/Product');
+
+global.empty = GlobalMock.empty;
+global.request = new GlobalMock.RequestMock();
+
+jest.mock('dw/system/Site', () => {
+    return {
+        getCurrent: function () {
+            return {
+                getAllowedLocales: function () {
+                    var arr = ['default', 'fr', 'en'];
+                    arr.size = function () {
+                        return arr.length;
+                    };
+                    return arr;
+                },
+                getAllowedCurrencies: function () {
+                    var arr = [
+                        { currencyCode: 'USD' },
+                        { currencyCode: 'EUR' }
+                    ];
+                    arr.size = function () {
+                        return arr.length;
+                    };
+                    return arr;
+                }
+            };
+        }
+    }
+}, {virtual: true});
+jest.mock('dw/util/Currency', () => {
+    return {
+        getCurrency: function (currency) { return currency; }
+    }
+}, {virtual: true});
+jest.mock('dw/util/StringUtils', () => {
+    return {
+        trim: function (str) { return str; }
+    }
+}, {virtual: true});
+jest.mock('dw/web/URLUtils', () => {
+    return {
+        url: function(endpoint, param, id) {
+            var relURL = '/on/demandware.store/Sites-Algolia_SFRA-Site/';
+            return relURL + global.request.getLocale() + '/' + endpoint + '?' + param + '=' + id;
+        }
+    }
+}, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => {
+    return {
+        getSetOfArray: function (id) {
+            return id === 'CustomFields'
+                ? ['url', 'UPC', 'searchable', 'variant', 'color', 'refinementColor', 'size', 'refinementSize', 'brand', 'online', 'pageDescription', 'pageKeywords',
+                    'pageTitle', 'short_description', 'name', 'long_description', 'image_groups']
+                : null;
+        },
+        getPreference: function (id) {
+            return id === 'InStockThreshold' ? 1 : null;
+        }
+    }
+}, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/lib/utils', () => {
+    return jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/utils');
+}, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/lib/algoliaProductConfig', () => {
+    return jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig');
+}, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/customization/productModelCustomizer', () => {
+    return {
+        customizeProductModel: function (productModel) { return productModel; }
+    }
+}, {virtual: true});
+
+const AlgoliaLocalizedProduct = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct');
+
+describe('algoliaLocalizedProduct', function () {
+    test('default locale', function () {
+        let product = new ProductMock();
+        let algoliaProductModel = {
+            id: '701644031206M',
+            in_stock: true,
+            primary_category_id: 'womens',
+            price: {
+                USD: 129,
+                EUR: 92.88
+            },
+            categories: [
+                [
+                    {
+                        id: 'newarrivals-womens',
+                        name: 'Womens',
+                    }
+                ],
+                [
+                    {
+                        id: 'womens-clothing-bottoms',
+                        name: 'Bottoms',
+                    }
+                ]
+            ],
+            brand: null,
+            image_groups: [
+                {
+                    _type: 'image_group',
+                    images: [
+                        {
+                            _type: 'image',
+                            alt: 'Floral Dress, Hot Pink Combo, large',
+                            dis_base_link: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg',
+                            title: 'Floral Dress, Hot Pink Combo',
+                        },
+                        {
+                            _type: 'image',
+                            alt: 'Floral Dress, Hot Pink Combo, large',
+                            dis_base_link: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg',
+                            title: 'Floral Dress, Hot Pink Combo',
+                        }
+                    ],
+                    view_type: 'large'
+                },
+                {
+                    _type: 'image_group',
+                    images: [
+                        {
+                            _type: 'image',
+                            alt: 'Floral Dress, Hot Pink Combo, small',
+                            dis_base_link: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg',
+                            title: 'Floral Dress, Hot Pink Combo',
+                        },
+                        {
+                            _type: 'image',
+                            alt: 'Floral Dress, Hot Pink Combo, small',
+                            dis_base_link: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg',
+                            title: 'Floral Dress, Hot Pink Combo',
+                        }
+                    ],
+                    view_type: 'small'
+                }
+            ],
+            long_description: 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.',
+            name: 'Floral Dress',
+            online: true,
+            pageDescription: 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.',
+            pageKeywords: null,
+            pageTitle: 'Floral Dress',
+            searchable: true,
+            short_description: 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.',
+            url: '/on/demandware.store/Sites-Algolia_SFRA-Site/default/Product-Show?pid=701644031206M',
+            UPC: '701644031206',
+            variant: true,
+            color: 'Hot Pink Combo',
+            refinementColor: 'Pink',
+            size: '4',
+            refinementSize: '4',
+        };
+        expect(new AlgoliaLocalizedProduct(product)).toEqual(algoliaProductModel);
+    });
+
+    test('fr locale', function () {
+        let product = new ProductMock();
+        let algoliaProductModel = {
+            id: '701644031206M',
+            in_stock: true,
+            primary_category_id: 'womens',
+            price: {
+                USD: 129,
+                EUR: 92.88
+            },
+            categories: [
+                [
+                    {
+                        id: 'newarrivals-womens',
+                        name: 'Femmes',
+                    }
+                ],
+                [
+                    {
+                        id: 'womens-clothing-bottoms',
+                        name: 'Bas',
+                    }
+                ]
+            ],
+            brand: null,
+            image_groups: [
+                {
+                    _type: 'image_group',
+                    images: [
+                        {
+                            _type: 'image',
+                            alt: 'Robe florale, Combo rose vif, large',
+                            dis_base_link: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg',
+                            title: 'Robe florale, Combo rose vif',
+                        },
+                        {
+                            _type: 'image',
+                            alt: 'Robe florale, Combo rose vif, large',
+                            dis_base_link: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg',
+                            title: 'Robe florale, Combo rose vif',
+                        }
+                    ],
+                    view_type: 'large'
+                },
+                {
+                    _type: 'image_group',
+                    images: [
+                        {
+                            _type: 'image',
+                            alt: 'Robe florale, Combo rose vif, small',
+                            dis_base_link: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg',
+                            title: 'Robe florale, Combo rose vif',
+                        },
+                        {
+                            _type: 'image',
+                            alt: 'Robe florale, Combo rose vif, small',
+                            dis_base_link: 'https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg',
+                            title: 'Robe florale, Combo rose vif',
+                        }
+                    ],
+                    view_type: 'small'
+                }
+            ],
+            long_description: 'Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.',
+            name: 'Robe florale',
+            online: true,
+            pageDescription: 'Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.',
+            pageKeywords: null,
+            pageTitle: 'Robe florale',
+            searchable: true,
+            short_description: 'Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.',
+            url: '/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Product-Show?pid=701644031206M',
+            UPC: '701644031206',
+            variant: true,
+            color: 'Combo rose vif',
+            refinementColor: 'Rose',
+            size: '4',
+            refinementSize: '4',
+        };
+        expect(new AlgoliaLocalizedProduct(product, 'fr')).toEqual(algoliaProductModel);
+    });
+
+    test('en locale + fieldListOverride', function () {
+        let product = new ProductMock();
+        let algoliaProductModel = {
+            id: '701644031206M',
+            price: {
+                USD: 129,
+                EUR: 92.88
+            },
+        };
+        expect(new AlgoliaLocalizedProduct(product, 'fr', ['id', 'price'])).toEqual(algoliaProductModel);
+    });
+});

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaProduct.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaProduct.js
@@ -83,7 +83,7 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
                         id: 'newarrivals-womens',
                         name: {
                             default: 'Womens',
-                            fr: 'Womens',
+                            fr: 'Femmes',
                             en: 'Womens'
                         }
                     }
@@ -93,7 +93,7 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
                         id: 'womens-clothing-bottoms',
                         name: {
                             default: 'Bottoms',
-                            fr: 'Bottoms',
+                            fr: 'Bas',
                             en: 'Bottoms'
                         }
                     }
@@ -112,7 +112,7 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
                             _type: 'image',
                             alt: {
                                 default: 'Floral Dress, Hot Pink Combo, large',
-                                fr: 'French Floral Dress, Hot Pink Combo, large',
+                                fr: 'Robe florale, Combo rose vif, large',
                                 en: 'Floral Dress, Hot Pink Combo, large'
                             },
                             dis_base_link: {
@@ -122,7 +122,7 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
                             },
                             title: {
                                 default: 'Floral Dress, Hot Pink Combo',
-                                fr: 'French Floral Dress, Hot Pink Combo',
+                                fr: 'Robe florale, Combo rose vif',
                                 en: 'Floral Dress, Hot Pink Combo'
                             }
                         },
@@ -130,7 +130,7 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
                             _type: 'image',
                             alt: {
                                 default: 'Floral Dress, Hot Pink Combo, large',
-                                fr: 'French Floral Dress, Hot Pink Combo, large',
+                                fr: 'Robe florale, Combo rose vif, large',
                                 en: 'Floral Dress, Hot Pink Combo, large'
                             },
                             dis_base_link: {
@@ -140,7 +140,7 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
                             },
                             title: {
                                 default: 'Floral Dress, Hot Pink Combo',
-                                fr: 'French Floral Dress, Hot Pink Combo',
+                                fr: 'Robe florale, Combo rose vif',
                                 en: 'Floral Dress, Hot Pink Combo'
                             }
                         }
@@ -154,7 +154,7 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
                             _type: 'image',
                             alt: {
                                 default: 'Floral Dress, Hot Pink Combo, small',
-                                fr: 'Floral Dress, Hot Pink Combo, small',
+                                fr: 'Robe florale, Combo rose vif, small',
                                 en: 'Floral Dress, Hot Pink Combo, small'
                             },
                             dis_base_link: {
@@ -164,7 +164,7 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
                             },
                             title: {
                                 default: 'Floral Dress, Hot Pink Combo',
-                                fr: 'Floral Dress, Hot Pink Combo',
+                                fr: 'Robe florale, Combo rose vif',
                                 en: 'Floral Dress, Hot Pink Combo'
                             }
                         },
@@ -172,7 +172,7 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
                             _type: 'image',
                             alt: {
                                 default: 'Floral Dress, Hot Pink Combo, small',
-                                fr: 'Floral Dress, Hot Pink Combo, small',
+                                fr: 'Robe florale, Combo rose vif, small',
                                 en: 'Floral Dress, Hot Pink Combo, small'
                             },
                             dis_base_link: {
@@ -182,7 +182,7 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
                             },
                             title: {
                                 default: 'Floral Dress, Hot Pink Combo',
-                                fr: 'Floral Dress, Hot Pink Combo',
+                                fr: 'Robe florale, Combo rose vif',
                                 en: 'Floral Dress, Hot Pink Combo'
                             }
                         }
@@ -192,18 +192,18 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
             ],
             long_description: {
                 default: 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.',
-                fr: 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.',
+                fr: 'Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.',
                 en: 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.'
             },
             name: {
                 default: 'Floral Dress',
-                fr: 'Floral Dress',
+                fr: 'Robe florale',
                 en: 'Floral Dress'
             },
             online: true,
             pageDescription: {
                 default: 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.',
-                fr: 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.',
+                fr: 'Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.',
                 en: 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.'
             },
             pageKeywords: {
@@ -213,13 +213,13 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
             },
             pageTitle: {
                 default: 'Floral Dress',
-                fr: 'Floral Dress',
+                fr: 'Robe florale',
                 en: 'Floral Dress'
             },
             searchable: true,
             short_description: {
                 default: 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.',
-                fr: 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.',
+                fr: 'Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.',
                 en: 'Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.'
             },
             url: {
@@ -231,12 +231,12 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
             variant: true,
             color: {
                 default: 'Hot Pink Combo',
-                fr: 'Hot Pink Combo',
+                fr: 'Combo rose vif',
                 en: 'Hot Pink Combo'
             },
             refinementColor: {
                 default: 'Pink',
-                fr: 'Pink',
+                fr: 'Rose',
                 en: 'Pink'
             },
             size: {

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaProduct.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaProduct.js
@@ -72,7 +72,7 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
         let algoliaProductModel = {
             id: '701644031206M',
             in_stock: true,
-            primary_category_id: 'womens',
+            primary_category_id: 'womens-clothing-bottoms',
             price: {
                 USD: 129,
                 EUR: 92.88
@@ -95,6 +95,22 @@ describe('algoliaProduct module - Test Algolia Product model', function () {
                             default: 'Bottoms',
                             fr: 'Bas',
                             en: 'Bottoms'
+                        }
+                    },
+                    {
+                        id: 'womens-clothing',
+                        name: {
+                            default: 'Clothing',
+                            fr: 'Vêtements',
+                            en: 'Clothing'
+                        },
+                    },
+                    {
+                        id: 'womens',
+                        name: {
+                            default: 'Womens',
+                            fr: 'Femmes',
+                            en: 'Womens'
                         }
                     }
                 ]


### PR DESCRIPTION
SFCC-114

Introduce new product model: `AlgoliaLocalizedProduct`. This model is meant to be a final localized record ready to be indexed into Algolia.
It's a copy of the existing `AlgoliaProduct` with the following changes:
- The locale is set once and all properties are fetched with this single locale. For each attribute, instead an object of localized values, the properties now host the final value:
  ```diff
  - { "name": { "default": "Dress", "en": "Dress", "fr": "Robe" } }
  + { "name": "Dress" }
  ```
  - Hence, `getAttributeLocalizedValues()` has been removed
- Some values that were computed by the indexing pipeline are now computed by the model:
  - `objectID`
  - `__primary_category`: a `getPrimaryCategoryHierarchicalFacets()` methods builds [hierarchical facets](https://www.algolia.com/doc/guides/managing-results/refine-results/faceting/#hierarchical-facets) for the primary category. The same logic has been kept: it's computed only if the requested fields include the `primary_category_id` and the `categories`
  - `_tags`
- `customizeLocalizedProductModel` is the same than `customizeProductModel` but it checks if the field is included first (`CATEGORIES_NEW_ARRIVALS` is an undocumented field that we should maybe deprecate)

### Tests :test_tube: 

- Updated the `Product` mock with french translations
- Created `algoliaLocalizedProduct.js`, which is similar to `algoliaProduct.js` but using Jest mocking.