### PR TITLE
Made job logs less noisy

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/services/algoliaServiceHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/services/algoliaServiceHelper.js
@@ -129,7 +129,9 @@ function callJsonService(title, service, params) {
         } else {
             // statusItem.setStatus(Status.ERROR);
             statusItem.addDetail('object', {});
-            logger.warn('Response is not JSON. Method: {0}. Result: {1}', title, result.object.response);
+            if (result.object && result.object.response) {
+                logger.warn('Response is not JSON. Method: {0}. Result: {1}', title, result.object.response);
+            }
         }
     } else {
         statusItem.setStatus(Status.ERROR);


### PR DESCRIPTION
Removed a recurring message from job logs which doesn't hold any information:
`"Response is not JSON. Method: {0}. Result: {1}"`

Previously the code behaved as if it was expecting a JSON response from Stream and logged the above message otherwise. Since Stream doesn't return a JSON by default (only a 200 with an empty body), logging this message is not necessary.

The message will still be logged if there's a response body, but will be omitted if there isn't one.