### PR TITLE
feat: update sendProductUpdates job to direct indexing

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
@@ -336,7 +336,7 @@ function UpdateProductModel(algoliaProduct) {
 
 /**
  * Operation class that represents an Algolia batch operation: https://www.algolia.com/doc/rest-api/search/#batch-write-operations
- * @param {string} action - Operation to perform: addObject, updateObject, deleteObject
+ * @param {string} action - Operation to perform: addObject, partialUpdateObject, deleteObject, ...
  * @param {Object} algoliaObject - Algolia object to index
  * @param {string} indexName - The index to target
  * @constructor

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
@@ -335,6 +335,26 @@ function UpdateProductModel(algoliaProduct) {
 }
 
 /**
+ * Operation class that represents an Algolia batch operation: https://www.algolia.com/doc/rest-api/search/#batch-write-operations
+ * @param {string} action - Operation to perform: addObject, updateObject, deleteObject
+ * @param {Object} algoliaObject - Algolia object to index
+ * @param {string} indexName - The index to target
+ * @constructor
+ */
+function AlgoliaOperation(action, algoliaObject, indexName) {
+    this.action = action;
+    if (indexName) {
+        this.indexName = indexName;
+    }
+    this.body = {};
+
+    var keys = Object.keys(algoliaObject);
+    for (var i = 0; i < keys.length; i += 1) {
+        this.body[keys[i]] = algoliaObject[keys[i]];
+    }
+}
+
+/**
  * Constructs a model for products that are to be deleted from the Algolia index
  * @param {string} productID productID
  * @returns {Object} The object to be sent to Algolia
@@ -553,6 +573,7 @@ module.exports = {
     logFileInfo: logFileInfo,
     checkAlgoliaFolder: checkAlgoliaFolder,
 
+    AlgoliaOperation: AlgoliaOperation,
     UpdateProductModel: UpdateProductModel,
     DeleteProductModel: DeleteProductModel,
     writeObjectToXMLStream: writeObjectToXMLStream,

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData.js
@@ -224,10 +224,11 @@ function getIndexPrefix() {
  * If custom site preference Algolia_IndexPrefix is set in BM,
  * its value will be used as a prefix instead of the first part of the hostname and the siteID
  * @param {string} type type of indices: products | categories
+ * @param {string} locale optional: requested locale
  * @returns {string} index name
  */
-function calculateIndexName(type) {
-    return getIndexPrefix() + '__' + type + '__' + request.getLocale();
+function calculateIndexName(type, locale) {
+    return getIndexPrefix() + '__' + type + '__' + (locale || request.getLocale());
 }
 
 /**

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js
@@ -2,7 +2,6 @@
 
 var Site = require('dw/system/Site');
 var ProductMgr = require('dw/catalog/ProductMgr');
-var Status = require('dw/system/Status');
 var logger;
 
 // job step parameters

--- a/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
@@ -8,7 +8,7 @@ const retryableCall = require('*/cartridge/scripts/algolia/helper/retryStrategy'
 const logger = require('dw/system/Logger').getLogger('algolia');
 
 /**
- * Send a batch of objects to Algolia Indexing API
+ * Send a batch of objects to Algolia Indexing API: https://www.algolia.com/doc/rest-api/search/#batch-write-operations
  * @param {string} indexName - name of the index to target
  * @param {Array} requestsArray - array of requests to send to Algolia
  * @returns {dw.system.Status} - successful Status to send
@@ -34,4 +34,32 @@ function sendBatch(indexName, requestsArray) {
     return result;
 }
 
+/**
+ * Send a batch of objects to Algolia Indexing API (multiple indices):
+ * https://www.algolia.com/doc/rest-api/search/#batch-write-operations-multiple-indices
+ * @param {AlgoliaOperation[]} requestsArray - array of requests to send to Algolia. Each operation must contain the `indexName` to target.
+ * @returns {dw.system.Status} - successful Status to send
+ */
+function sendMultiIndicesBatch(requestsArray) {
+    var indexingService = algoliaIndexingService.getService();
+
+    var result = retryableCall(
+        indexingService,
+        {
+            method: 'POST',
+            path: '/1/indexes/*/batch',
+            body: {
+                requests: requestsArray,
+            }
+        }
+    );
+
+    if (!result.ok) {
+        logger.error(result.getErrorMessage());
+    }
+
+    return result;
+}
+
 module.exports.sendBatch = sendBatch;
+module.exports.sendMultiIndicesBatch = sendMultiIndicesBatch;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,6 @@
+// Initialize some default mocks for all tests.
+
+// System classes
 jest.mock('dw/system/Logger', () => {
     return {
         info: jest.fn(),
@@ -11,3 +14,38 @@ jest.mock('dw/system/Logger', () => {
     }
 },
 {virtual: true});
+jest.mock('dw/system/Status', () => {}, {virtual: true});
+jest.mock('dw/system/Transaction', () => {}, {virtual: true});
+jest.mock('dw/system/System', () => {}, {virtual: true});
+jest.mock('dw/web/Resource', () => {
+    return {
+        msg: function() {}
+    }
+}, {virtual: true});
+
+// The following are not mocks, it points SFCC relative requires to the actual files
+// https://developer.salesforce.com/docs/commerce/b2c-commerce/guide/usingjavascriptmodules.html#path-lookup-behavior-of-the-require-method
+jest.mock('*/cartridge/scripts/algolia/customization/productModelCustomizer', () => {
+    return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer');
+}, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/filters/productFilter', () => {
+    return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/filters/productFilter');
+}, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/helper/jobHelper', () => {
+    return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper');
+}, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/helper/sendHelper', () => {
+    return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/helper/sendHelper');
+}, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/lib/algoliaProductConfig', () => {
+    return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig');
+}, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/lib/utils', () => {
+    return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/lib/utils');
+}, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/lib/algoliaConstants', () => {
+    return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaConstants');
+}, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/model/algoliaLocalizedProduct', () => {
+    return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct');
+}, {virtual: true});

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,4 +1,7 @@
 {
+    "parserOptions": {
+        "ecmaVersion": 2021
+    },
     "env": {
         "mocha": true
     },

--- a/test/mocks/global.js
+++ b/test/mocks/global.js
@@ -9,7 +9,13 @@ function empty(obj) {
 
 function CurrentSession() {
     this.currency = {
-        currencyCode: 'USD'
+        currencyCode: 'USD',
+        getCurrencyCode: function() {
+            return 'USD';
+        },
+        getSymbol: function() {
+            return '$';
+        }
     };
     this.getCurrency = function () {
         return this.currency;

--- a/test/unit/int_algolia/scripts/algolia/algoliaIndexingAPI.test.js
+++ b/test/unit/int_algolia/scripts/algolia/algoliaIndexingAPI.test.js
@@ -23,6 +23,29 @@ test('sendBatch', () => {
     const algoliaRequests = [
         {
             action: 'addObject',
+            body: { firstname: 'Jimmie', lastname: 'Barninger' }
+        },
+        {
+            action: 'addObject',
+            body: { firstname: 'Warren', lastname: 'Speach' }
+        }
+    ];
+
+    indexingAPI.sendBatch(indexName, algoliaRequests);
+
+    expect(mockRetryableCall).toHaveBeenCalledWith(mockService, {
+        method: 'POST',
+        path: '/1/indexes/' + indexName + '/batch',
+        body: {
+            requests: algoliaRequests
+        }
+    });
+});
+
+test('sendMultiIndicesBatch', () => {
+    const algoliaRequests = [
+        {
+            action: 'addObject',
             indexName: 'index1',
             body: { firstname: 'Jimmie', lastname: 'Barninger' }
         },
@@ -33,11 +56,11 @@ test('sendBatch', () => {
         }
     ];
 
-    indexingAPI.sendBatch(indexName, algoliaRequests);
+    indexingAPI.sendMultiIndicesBatch(algoliaRequests);
 
     expect(mockRetryableCall).toHaveBeenCalledWith(mockService, {
         method: 'POST',
-        path: '/1/indexes/' + indexName + '/batch',
+        path: '/1/indexes/*/batch',
         body: {
             requests: algoliaRequests
         }

--- a/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/sendChunkOrientedProductUpdates.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/sendChunkOrientedProductUpdates.test.js.snap
@@ -1,0 +1,300 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`process 1`] = `
+[
+  AlgoliaOperation {
+    "action": "partialUpdateObject",
+    "body": {
+      "UPC": "701644031206",
+      "__primary_category": {
+        "0": "Womens",
+        "1": "Womens > Clothing",
+        "2": "Womens > Clothing > Bottoms",
+      },
+      "_tags": [
+        "id:701644031206M",
+      ],
+      "brand": null,
+      "categories": [
+        [
+          {
+            "id": "newarrivals-womens",
+            "name": "Womens",
+          },
+        ],
+        [
+          {
+            "id": "womens-clothing-bottoms",
+            "name": "Bottoms",
+          },
+          {
+            "id": "womens-clothing",
+            "name": "Clothing",
+          },
+          {
+            "id": "womens",
+            "name": "Womens",
+          },
+        ],
+      ],
+      "color": "Hot Pink Combo",
+      "id": "701644031206M",
+      "image_groups": [
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "large",
+        },
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "small",
+        },
+      ],
+      "in_stock": true,
+      "long_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "name": "Floral Dress",
+      "objectID": "701644031206M",
+      "online": true,
+      "pageDescription": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "pageKeywords": null,
+      "pageTitle": "Floral Dress",
+      "price": {
+        "EUR": 92.88,
+        "USD": 129,
+      },
+      "primary_category_id": "womens-clothing-bottoms",
+      "refinementColor": "Pink",
+      "refinementSize": "4",
+      "searchable": true,
+      "short_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "size": "4",
+      "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Product-Show?pid=701644031206M",
+      "variant": true,
+    },
+    "indexName": "test_index___products__default",
+  },
+  AlgoliaOperation {
+    "action": "partialUpdateObject",
+    "body": {
+      "UPC": "701644031206",
+      "__primary_category": {
+        "0": "Femmes",
+        "1": "Femmes > Vêtements",
+        "2": "Femmes > Vêtements > Bas",
+      },
+      "_tags": [
+        "id:701644031206M",
+      ],
+      "brand": null,
+      "categories": [
+        [
+          {
+            "id": "newarrivals-womens",
+            "name": "Femmes",
+          },
+        ],
+        [
+          {
+            "id": "womens-clothing-bottoms",
+            "name": "Bas",
+          },
+          {
+            "id": "womens-clothing",
+            "name": "Vêtements",
+          },
+          {
+            "id": "womens",
+            "name": "Femmes",
+          },
+        ],
+      ],
+      "color": "Combo rose vif",
+      "id": "701644031206M",
+      "image_groups": [
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "large",
+        },
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "small",
+        },
+      ],
+      "in_stock": true,
+      "long_description": "Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.",
+      "name": "Robe florale",
+      "objectID": "701644031206M",
+      "online": true,
+      "pageDescription": "Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.",
+      "pageKeywords": null,
+      "pageTitle": "Robe florale",
+      "price": {
+        "EUR": 92.88,
+        "USD": 129,
+      },
+      "primary_category_id": "womens-clothing-bottoms",
+      "refinementColor": "Rose",
+      "refinementSize": "4",
+      "searchable": true,
+      "short_description": "Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.",
+      "size": "4",
+      "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Product-Show?pid=701644031206M",
+      "variant": true,
+    },
+    "indexName": "test_index___products__fr",
+  },
+  AlgoliaOperation {
+    "action": "partialUpdateObject",
+    "body": {
+      "UPC": "701644031206",
+      "__primary_category": {
+        "0": "Womens",
+        "1": "Womens > Clothing",
+        "2": "Womens > Clothing > Bottoms",
+      },
+      "_tags": [
+        "id:701644031206M",
+      ],
+      "brand": null,
+      "categories": [
+        [
+          {
+            "id": "newarrivals-womens",
+            "name": "Womens",
+          },
+        ],
+        [
+          {
+            "id": "womens-clothing-bottoms",
+            "name": "Bottoms",
+          },
+          {
+            "id": "womens-clothing",
+            "name": "Clothing",
+          },
+          {
+            "id": "womens",
+            "name": "Womens",
+          },
+        ],
+      ],
+      "color": "Hot Pink Combo",
+      "id": "701644031206M",
+      "image_groups": [
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "large",
+        },
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "small",
+        },
+      ],
+      "in_stock": true,
+      "long_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "name": "Floral Dress",
+      "objectID": "701644031206M",
+      "online": true,
+      "pageDescription": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "pageKeywords": null,
+      "pageTitle": "Floral Dress",
+      "price": {
+        "EUR": 92.88,
+        "USD": 129,
+      },
+      "primary_category_id": "womens-clothing-bottoms",
+      "refinementColor": "Pink",
+      "refinementSize": "4",
+      "searchable": true,
+      "short_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "size": "4",
+      "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/en/Product-Show?pid=701644031206M",
+      "variant": true,
+    },
+    "indexName": "test_index___products__en",
+  },
+]
+`;

--- a/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedProductUpdates.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedProductUpdates.test.js
@@ -1,0 +1,126 @@
+const GlobalMock = require('../../../../../mocks/global');
+const ProductMock = require('../../../../../mocks/dw/catalog/Product');
+
+global.empty = GlobalMock.empty;
+global.request = new GlobalMock.RequestMock();
+
+jest.mock('dw/system/Site', () => {
+    return {
+        getCurrent: function () {
+            return {
+                getID: function() {
+                    return 'Test-Site'
+                },
+                getName: function() {
+                    return 'Name of the Test-Site'
+                },
+                getAllowedLocales: function () {
+                    var arr = ['default', 'fr', 'en'];
+                    arr.size = function () {
+                        return arr.length;
+                    };
+                    arr.toArray = function () {
+                        return arr;
+                    };
+                    return arr;
+                },
+                getAllowedCurrencies: function () {
+                    var arr = [
+                        { currencyCode: 'USD' },
+                        { currencyCode: 'EUR' }
+                    ];
+                    arr.size = function () {
+                        return arr.length;
+                    };
+                    return arr;
+                },
+                getCustomPreferenceValue: function(id) {
+                    switch(id) {
+                        case 'Algolia_IndexPrefix':
+                            return 'test_index_';
+                        default:
+                            return null;
+                    }
+                }
+            };
+        }
+    }
+}, {virtual: true});
+jest.mock('dw/util/Currency', () => {
+    return {
+        getCurrency: function (currency) { return currency; }
+    }
+}, {virtual: true});
+jest.mock('dw/util/StringUtils', () => {
+    return {
+        trim: function (str) { return str; }
+    }
+}, {virtual: true});
+jest.mock('dw/web/URLUtils', () => {
+    return {
+        url: function(endpoint, param, id) {
+            var relURL = '/on/demandware.store/Sites-Algolia_SFRA-Site/';
+            return relURL + global.request.getLocale() + '/' + endpoint + '?' + param + '=' + id;
+        },
+        staticURL: function(url) {
+            return url;
+        }
+    }
+}, {virtual: true});
+jest.mock('dw/catalog/ProductMgr', () => {
+    return {
+        queryAllSiteProducts: function() {}
+    }
+}, {virtual: true});
+
+jest.mock('*/cartridge/scripts/algolia/helper/logHelper', () => {}, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => {
+    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData');
+    return {
+        ...originalModule,
+        getSetOfArray: function (id) {
+            return id === 'CustomFields'
+                ? ['url', 'UPC', 'searchable', 'variant', 'color', 'refinementColor', 'size', 'refinementSize', 'brand', 'online', 'pageDescription', 'pageKeywords',
+                    'pageTitle', 'short_description', 'name', 'long_description', 'image_groups']
+                : null;
+        },
+    }
+}, {virtual: true});
+jest.mock('*/cartridge/scripts/services/algoliaIndexingService', () => {}, {virtual: true});
+const mockSendMultiIndicesBatch = jest.fn().mockReturnValue({ ok: true });
+jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
+    return {
+        sendMultiIndicesBatch: mockSendMultiIndicesBatch,
+    }
+}, {virtual: true});
+
+const job = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates');
+
+test('process', () => {
+    job.beforeStep({ resourceType: 'test' });
+    var algoliaOperations = job.process(new ProductMock());
+    expect(algoliaOperations).toMatchSnapshot();
+});
+
+test('send', () => {
+    job.beforeStep({ resourceType: 'test' });
+
+    const algoliaOperationsChunk = [];
+    for (let i = 0; i < 3; ++i) {
+        const algoliaOperations = [
+            { action: 'addObject', indexName: 'test_en', body: { id: `${i}` } },
+            { action: 'addObject', indexName: 'test_fr', body: { id: `${i}` } },
+        ];
+        algoliaOperations.toArray = function () {
+            return algoliaOperations;
+        };
+        algoliaOperationsChunk.push(algoliaOperations);
+    }
+    algoliaOperationsChunk.toArray = function () {
+        return algoliaOperationsChunk;
+    };
+
+    job.send(algoliaOperationsChunk);
+
+    expect(mockSendMultiIndicesBatch).toHaveBeenCalledWith(algoliaOperationsChunk.flat());
+});


### PR DESCRIPTION
Update the `sendProductUpdates` job step to use the new model (https://github.com/algolia/algoliasearch-sfcc-b2c/pull/62) and the Algolia API client (https://github.com/algolia/algoliasearch-sfcc-b2c/pull/60), to push products records directly to Algolia.

### Changes

- new `AlgoliaOperation` object, which match the payload expected by the Algolia batch API: https://www.algolia.com/doc/rest-api/search/#batch-write-operations-multiple-indices
- update `algoliaIndexingAPI` client, to be able to do multi-indices batch operations. This permits to have less logic in the job when we construct the batches
- update the `sendProductUpdates` job:
  - the `process` function, for each Product, builds an array of `AlgoliaOperation` (one per locale), each targettng its own index name
  - the `send` function concatenate those arrays (which are transformed in List in between) and send those batches
  - some optimizations are done: at the beginning of the process, we compute the non-localized attributes so the `process` function can build a baseModel with those attributes, to avoid refetching them for each locale

### Tests :test_tube: 

Added unit tests for the two main job steps: `read` and `process`
The job is using a lot of system calls so there was a lot of mocks to add, but big part of them are doing nothing. I've put those empty mocks in `jest.setup.js` so they will be available for other tests. The mocks that have an implementation are directly in the test file.

- to test the `read` function, I'm passing the exiting `ProductMock` to it and did a snapshot testing so what the method is producing is visual
- for the `process` function, I've built a dummy chunk of AlgoliaOperations, and I check that the API client is correctly called with a flatten array of operations
