### PR TITLE
SFCC-97: Removed Read Host Base URL custom site preference

### DIFF
--- a/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
+++ b/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
@@ -41,7 +41,6 @@ function handleSettings() {
         algoliaData.setPreference('Enable', algoliaEnable);
         algoliaData.setPreference('ApplicationID', params.ApplicationID.value);
         algoliaData.setSetOfStrings('CustomFields', params.CustomFields.value);
-        algoliaData.setPreference('HostBase', params.HostBase.value);
         algoliaData.setPreference('InStockThreshold', params.InStockThreshold.value * 1);
         algoliaData.setPreference('SearchApiKey', params.SearchApiKey.value);
         algoliaData.setPreference('AdminApiKey', params.AdminApiKey.value);

--- a/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
+++ b/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
@@ -78,16 +78,6 @@
                     </td>
                 </tr>
 
-                <iscomment> Algolia_HostBase </iscomment>
-                <tr>
-                    <td class="table_detail w s" width="70%" nowrap="nowrap" colspan="1">
-                        <isprint value="${Resource.msg('algolia.label.preference.baseurl', 'algolia', null)}" encoding="jshtml" />
-                    </td>
-                    <td class="table_detail w e s" nowrap="nowrap">
-                        <input type="text" value="${pdict.algoliaData.getPreference('HostBase') ? pdict.algoliaData.getPreference('HostBase') : ''}" id="HostBase" name="HostBase" />
-                    </td>
-                </tr>
-
                 <iscomment> Algolia_InStockThreshold </iscomment>
                 <tr>
                     <td class="table_detail w s" width="70%" nowrap="nowrap" colspan="1">

--- a/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
+++ b/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
@@ -37,7 +37,6 @@ algolia.label.preference.enable=Enable Algolia
 algolia.label.preference.applicationid=Application ID
 algolia.label.preference.searchkey=Search API key
 algolia.label.preference.adminkey=Admin API key
-algolia.label.preference.baseurl=Read Host Base Url
 algolia.label.preference.instock=InStock Threshold
 algolia.label.preference.custom=Custom Fields
 algolia.label.preference.indexprefix=Index Prefix. If set, it replaces the default index prefix: < hostname >__< siteID >

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData.js
@@ -59,7 +59,6 @@ const clientSideData = {
 //   ApplicationID          ║ Identifies the application for this site          ║ String
 //   SearchApiKey           ║ Authorization key for Algolia                     ║ String
 //   AdminApiKey            ║ Authorization Admin key for Algolia               ║ String
-//   HostBase               ║ Host for read operations                          ║ String
 //   CustomFields           ║ Any additional attributes of Product Object       ║ Set-of-string
 //   InStockThreshold       ║ Stock Threshold                                   ║ Double
 //   IndexPrefix            ║ Optional prefix for the index name                ║ String

--- a/metadata/algolia/meta/system-objecttype-extensions.xml
+++ b/metadata/algolia/meta/system-objecttype-extensions.xml
@@ -136,15 +136,6 @@
                 <externally-managed-flag>false</externally-managed-flag>
             </attribute-definition>
 
-            <attribute-definition attribute-id="Algolia_HostBase">
-                <display-name xml:lang="x-default">Read Host Base Url</display-name>
-                <description xml:lang="x-default">Host for read operations</description>
-                <type>string</type>
-                <mandatory-flag>false</mandatory-flag>
-                <externally-managed-flag>false</externally-managed-flag>
-                <min-length>0</min-length>
-            </attribute-definition>
-
             <attribute-definition attribute-id="Algolia_InStockThreshold">
                 <display-name xml:lang="x-default">InStock Threshold</display-name>
                 <description xml:lang="x-default">Stock Threshold</description>
@@ -206,7 +197,6 @@ Setting this preference replaces the first two segments, the final index name be
                 <attribute attribute-id="Algolia_ApplicationID"/>
                 <attribute attribute-id="Algolia_SearchApiKey"/>
                 <attribute attribute-id="Algolia_AdminApiKey"/>
-                <attribute attribute-id="Algolia_HostBase"/>
                 <attribute attribute-id="Algolia_InStockThreshold"/>
                 <attribute attribute-id="Algolia_CustomFields"/>
                 <attribute attribute-id="Algolia_IndexPrefix"/>


### PR DESCRIPTION
The Read Host Base URL custom site preference (`Algolia_HostBase`) is not used for anything, the service URLs are stored in their respective service configurations.