### PR TITLE
feat: introduce category model

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/utils.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/utils.js
@@ -47,7 +47,30 @@ function escapeEmoji(str) {
     });
 }
 
+/**
+ * forEach method for dw.util.Collection subclass instances
+ * @param {dw.util.Collection} collection - Collection subclass instance to map over
+ * @param {Function} callback - Callback function for each item
+ * @param {Object} [scope] - Optional execution scope to pass to callback
+ * @returns {void}
+ */
+function forEach(collection, callback, scope) {
+    var iterator = collection.iterator();
+    var index = 0;
+    var item = null;
+    while (iterator.hasNext()) {
+        item = iterator.next();
+        if (scope) {
+            callback.call(scope, item, index, collection);
+        } else {
+            callback(item, index, collection);
+        }
+        index += 1;
+    }
+}
+
 module.exports = {
     getCategoryDisplayNamePath: getCategoryDisplayNamePath,
-    escapeEmoji: escapeEmoji
+    escapeEmoji: escapeEmoji,
+    forEach: forEach
 };

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedCategory.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedCategory.js
@@ -1,0 +1,80 @@
+var URLUtils = require('dw/web/URLUtils');
+var forEach = require('../lib/utils').forEach;
+
+/**
+ * Get category url
+ * @param {dw.catalog.Category} category - Current category
+ * @returns {string} - Url of the category
+ */
+function getCategoryUrl(category) {
+    return category.custom && 'alternativeUrl' in category.custom && category.custom.alternativeUrl
+        ? (category.custom.alternativeUrl.toString()).replace(/&amp;/g, '&')
+        : URLUtils.https('Search-Show', 'cgid', category.getID()).toString();
+}
+
+/**
+ * Get category ID
+ * @param {string} catalogId - Catalog ID
+ * @param {dw.catalog.Category} category - Current category
+ * @returns {string} - Final ID of the category
+ */
+function getCategoryId(catalogId, category) {
+    return catalogId + '/' + category.ID;
+}
+
+/**
+ * Get image url
+ * @param {dw.content.MediaFile} image - MediaFile
+ * @returns {string} - Url of the image
+ */
+function getImageUrl(image) {
+    return image ? image.getHttpsURL().toString() : null;
+}
+
+/**
+ * AlgoliaLocalizedCategory class that represents a localized category ready to be indexed
+ * @param {dw.catalog.Category} category - A single category
+ * @param {string} catalogId - ID of site catalog
+ * @param {string} locale - the requested locale
+ * @constructor
+ */
+function algoliaLocalizedCategory(category, catalogId, locale) {
+    request.setLocale(locale|| 'default');
+
+    this.objectID = getCategoryId(catalogId, category);
+    this.id = getCategoryId(catalogId, category);
+    this.name = category.getDisplayName();
+    if (category.getDescription()) {
+        this.description = category.getDescription();
+    }
+    var image = getImageUrl(category.getImage());
+    if (image) {
+        this.image = image;
+    }
+    var parent = category.getParent();
+    if (parent && !parent.root) {
+        this.parent_category_id = getCategoryId(catalogId, parent);
+    }
+    var thumbnail = getImageUrl(category.getThumbnail());
+    if (thumbnail) {
+        this.thumbnail = thumbnail;
+    }
+
+    var subCategories = category.getOnlineSubCategories();
+
+    var that = this;
+    forEach(subCategories, function (subcategory) {
+        if (subcategory.custom && subcategory.custom.showInMenu
+          && (subcategory.hasOnlineProducts() || subcategory.hasOnlineSubCategories())) {
+            if (!that.subCategories) {
+                that.subCategories = [];
+            }
+            that.subCategories.push(getCategoryId(catalogId, subcategory));
+        }
+    });
+
+    this.url = getCategoryUrl(category);
+    this._tags = ['id:' + this.id];
+}
+
+module.exports = algoliaLocalizedCategory;

--- a/test/mocks/dw/catalog/Category.js
+++ b/test/mocks/dw/catalog/Category.js
@@ -1,0 +1,72 @@
+var Category = function ({ name, parent, subcategories}) {
+    this.ID = `storefront-catalog-m-en/${name.split(' ').join('-').toLowerCase()}`;
+    this.parent = parent;
+    this.subcategories = subcategories;
+
+    this.getID = function() {
+        return this.ID;
+    }
+    this.getDisplayName = function() {
+        switch (request.getLocale()) {
+            case 'fr': return `Nom français de ${name}`;
+            case 'en': return `English name of ${name}`;
+            default: return name;
+        }
+    }
+    this.getDescription = function() {
+        switch (request.getLocale()) {
+            case 'fr': return `Description française de ${name}`;
+            case 'en': return `English description of ${name}`;
+            default: return `Description of ${name}`;
+        }
+    }
+    this.getImage = function() {
+        return {
+            getHttpsURL: function() {
+                return `http://example.com/${name.split(' ').join('-').toLowerCase()}.jpg`;
+            }
+        }
+    }
+    this.getThumbnail = function() {
+        return {
+            getHttpsURL: function() {
+                return `http://example.com/${name.split(' ').join('-').toLowerCase()}-thumbnail.jpg`;
+            }
+        }
+    }
+    this.getParent = function() {
+        return this.parent || { root: true };
+    }
+    this.getOnlineSubCategories= function() {
+        return new Collection(this.subcategories || []);
+    }
+    this.custom = {
+        showInMenu: true,
+    }
+    this.hasOnlineProducts= function() {
+        return true;
+    }
+};
+
+// Mock of dw.util.Collection
+const Collection = function(values) {
+    this.values = values;
+    const that = this;
+
+    this.iterator = function() {
+        let nextIndex = 0;
+
+        return {
+            hasNext() {
+                return nextIndex < that.values.length;
+            },
+            next() {
+                if (nextIndex < that.values.length) {
+                    return that.values[nextIndex++];
+                }
+            },
+        };
+    }
+}
+
+module.exports = Category;

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedCategory.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedCategory.test.js
@@ -16,13 +16,20 @@ jest.mock('dw/web/URLUtils', () => {
 const AlgoliaLocalizedCategory = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedCategory');
 
 describe('algoliaLocalizedCategory', function () {
-    test('default locale', function () {
-        const catalogId = 'testCatalog';
-        const category = new CategoryMock({ name: 'Electronics' });
-        const subcategory = new CategoryMock({ name: 'Digital Cameras', parent: category });
-        const subcategory2 = new CategoryMock({ name: 'Gaming', parent: category });
-        category.subcategories = [subcategory, subcategory2];
+    // We define categories mocks that represent the following categories hierarchy:
+    // Electronics
+    // |__Digital Cameras
+    // |__Audio
+    //    |__Headphones
+    const catalogId = 'testCatalog';
+    const category = new CategoryMock({ name: 'Electronics' });
+    const subcategory1 = new CategoryMock({ name: 'Digital Cameras', parent: category });
+    const subcategory2 = new CategoryMock({ name: 'Audio', parent: category });
+    const subsubcategory2 = new CategoryMock({ name: 'Headphones', parent: subcategory2 });
+    category.subcategories = [subcategory1, subcategory2];
+    subcategory2.subcategories = [subsubcategory2];
 
+    test('default locale', function () {
         const expectedParentCategoryModel = {
             objectID: 'testCatalog/storefront-catalog-m-en/electronics',
             id: 'testCatalog/storefront-catalog-m-en/electronics',
@@ -33,7 +40,7 @@ describe('algoliaLocalizedCategory', function () {
             url: '/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/electronics',
             subCategories: [
                 "testCatalog/storefront-catalog-m-en/digital-cameras",
-                "testCatalog/storefront-catalog-m-en/gaming",
+                "testCatalog/storefront-catalog-m-en/audio",
             ],
             _tags: ['id:testCatalog/storefront-catalog-m-en/electronics'],
         }
@@ -50,29 +57,26 @@ describe('algoliaLocalizedCategory', function () {
             parent_category_id: 'testCatalog/storefront-catalog-m-en/electronics',
             _tags: ['id:testCatalog/storefront-catalog-m-en/digital-cameras'],
         }
-        expect(new AlgoliaLocalizedCategory(subcategory, catalogId)).toEqual(expectedSubCategoryModel);
+        expect(new AlgoliaLocalizedCategory(subcategory1, catalogId)).toEqual(expectedSubCategoryModel);
 
         const expectedSubCategory2Model = {
-            objectID: 'testCatalog/storefront-catalog-m-en/gaming',
-            id: 'testCatalog/storefront-catalog-m-en/gaming',
-            name: 'Gaming',
-            description: 'Description of Gaming',
-            image: 'http://example.com/gaming.jpg',
-            thumbnail: 'http://example.com/gaming-thumbnail.jpg',
-            url: '/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/gaming',
+            objectID: 'testCatalog/storefront-catalog-m-en/audio',
+            id: 'testCatalog/storefront-catalog-m-en/audio',
+            name: 'Audio',
+            description: 'Description of Audio',
+            image: 'http://example.com/audio.jpg',
+            thumbnail: 'http://example.com/audio-thumbnail.jpg',
+            url: '/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/audio',
             parent_category_id: 'testCatalog/storefront-catalog-m-en/electronics',
-            _tags: ['id:testCatalog/storefront-catalog-m-en/gaming'],
+            subCategories: [
+                "testCatalog/storefront-catalog-m-en/headphones",
+            ],
+            _tags: ['id:testCatalog/storefront-catalog-m-en/audio'],
         }
         expect(new AlgoliaLocalizedCategory(subcategory2, catalogId)).toEqual(expectedSubCategory2Model);
     });
 
     test('french locale', function () {
-        const catalogId = 'testCatalog';
-        const category = new CategoryMock({ name: 'Electronics' });
-        const subcategory = new CategoryMock({ name: 'Digital Cameras', parent: category });
-        const subcategory2 = new CategoryMock({ name: 'Gaming', parent: category });
-        category.subcategories = [subcategory, subcategory2];
-
         const expectedParentCategoryModel = {
             objectID: 'testCatalog/storefront-catalog-m-en/electronics',
             id: 'testCatalog/storefront-catalog-m-en/electronics',
@@ -83,7 +87,7 @@ describe('algoliaLocalizedCategory', function () {
             url: '/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/electronics',
             subCategories: [
                 "testCatalog/storefront-catalog-m-en/digital-cameras",
-                "testCatalog/storefront-catalog-m-en/gaming",
+                "testCatalog/storefront-catalog-m-en/audio",
             ],
             _tags: ['id:testCatalog/storefront-catalog-m-en/electronics'],
         }
@@ -100,19 +104,35 @@ describe('algoliaLocalizedCategory', function () {
             parent_category_id: 'testCatalog/storefront-catalog-m-en/electronics',
             _tags: ['id:testCatalog/storefront-catalog-m-en/digital-cameras'],
         }
-        expect(new AlgoliaLocalizedCategory(subcategory, catalogId, 'fr')).toEqual(expectedSubCategoryModel);
+        expect(new AlgoliaLocalizedCategory(subcategory1, catalogId, 'fr')).toEqual(expectedSubCategoryModel);
 
         const expectedSubCategory2Model = {
-            objectID: 'testCatalog/storefront-catalog-m-en/gaming',
-            id: 'testCatalog/storefront-catalog-m-en/gaming',
-            name: 'Nom français de Gaming',
-            description: 'Description française de Gaming',
-            image: 'http://example.com/gaming.jpg',
-            thumbnail: 'http://example.com/gaming-thumbnail.jpg',
-            url: '/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/gaming',
+            objectID: 'testCatalog/storefront-catalog-m-en/audio',
+            id: 'testCatalog/storefront-catalog-m-en/audio',
+            name: 'Nom français de Audio',
+            description: 'Description française de Audio',
+            image: 'http://example.com/audio.jpg',
+            thumbnail: 'http://example.com/audio-thumbnail.jpg',
+            url: '/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/audio',
             parent_category_id: 'testCatalog/storefront-catalog-m-en/electronics',
-            _tags: ['id:testCatalog/storefront-catalog-m-en/gaming'],
+            subCategories: [
+                "testCatalog/storefront-catalog-m-en/headphones",
+            ],
+            _tags: ['id:testCatalog/storefront-catalog-m-en/audio'],
         }
         expect(new AlgoliaLocalizedCategory(subcategory2, catalogId, 'fr')).toEqual(expectedSubCategory2Model);
+
+        const expectedSubSubCategory2Model = {
+            objectID: 'testCatalog/storefront-catalog-m-en/headphones',
+            id: 'testCatalog/storefront-catalog-m-en/headphones',
+            name: 'Nom français de Headphones',
+            description: 'Description française de Headphones',
+            image: 'http://example.com/headphones.jpg',
+            thumbnail: 'http://example.com/headphones-thumbnail.jpg',
+            url: '/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/headphones',
+            parent_category_id: 'testCatalog/storefront-catalog-m-en/audio',
+            _tags: ['id:testCatalog/storefront-catalog-m-en/headphones'],
+        }
+        expect(new AlgoliaLocalizedCategory(subsubcategory2, catalogId, 'fr')).toEqual(expectedSubSubCategory2Model);
     });
 });

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedCategory.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedCategory.test.js
@@ -1,0 +1,118 @@
+var GlobalMock = require('../../../../../mocks/global');
+var CategoryMock = require('../../../../../mocks/dw/catalog/Category');
+
+global.empty = GlobalMock.empty;
+global.request = new GlobalMock.RequestMock();
+
+jest.mock('dw/web/URLUtils', () => {
+    return {
+        https: function(endpoint, param, id) {
+            var relURL = '/on/demandware.store/Sites-Algolia_SFRA-Site/';
+            return relURL + global.request.getLocale() + '/' + endpoint + '?' + param + '=' + id;
+        }
+    }
+}, {virtual: true});
+
+const AlgoliaLocalizedCategory = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedCategory');
+
+describe('algoliaLocalizedCategory', function () {
+    test('default locale', function () {
+        const catalogId = 'testCatalog';
+        const category = new CategoryMock({ name: 'Electronics' });
+        const subcategory = new CategoryMock({ name: 'Digital Cameras', parent: category });
+        const subcategory2 = new CategoryMock({ name: 'Gaming', parent: category });
+        category.subcategories = [subcategory, subcategory2];
+
+        const expectedParentCategoryModel = {
+            objectID: 'testCatalog/storefront-catalog-m-en/electronics',
+            id: 'testCatalog/storefront-catalog-m-en/electronics',
+            name: 'Electronics',
+            description: 'Description of Electronics',
+            image: 'http://example.com/electronics.jpg',
+            thumbnail: 'http://example.com/electronics-thumbnail.jpg',
+            url: '/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/electronics',
+            subCategories: [
+                "testCatalog/storefront-catalog-m-en/digital-cameras",
+                "testCatalog/storefront-catalog-m-en/gaming",
+            ],
+            _tags: ['id:testCatalog/storefront-catalog-m-en/electronics'],
+        }
+        expect(new AlgoliaLocalizedCategory(category, catalogId)).toEqual(expectedParentCategoryModel);
+
+        const expectedSubCategoryModel = {
+            objectID: 'testCatalog/storefront-catalog-m-en/digital-cameras',
+            id: 'testCatalog/storefront-catalog-m-en/digital-cameras',
+            name: 'Digital Cameras',
+            description: 'Description of Digital Cameras',
+            image: 'http://example.com/digital-cameras.jpg',
+            thumbnail: 'http://example.com/digital-cameras-thumbnail.jpg',
+            url: '/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/digital-cameras',
+            parent_category_id: 'testCatalog/storefront-catalog-m-en/electronics',
+            _tags: ['id:testCatalog/storefront-catalog-m-en/digital-cameras'],
+        }
+        expect(new AlgoliaLocalizedCategory(subcategory, catalogId)).toEqual(expectedSubCategoryModel);
+
+        const expectedSubCategory2Model = {
+            objectID: 'testCatalog/storefront-catalog-m-en/gaming',
+            id: 'testCatalog/storefront-catalog-m-en/gaming',
+            name: 'Gaming',
+            description: 'Description of Gaming',
+            image: 'http://example.com/gaming.jpg',
+            thumbnail: 'http://example.com/gaming-thumbnail.jpg',
+            url: '/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/gaming',
+            parent_category_id: 'testCatalog/storefront-catalog-m-en/electronics',
+            _tags: ['id:testCatalog/storefront-catalog-m-en/gaming'],
+        }
+        expect(new AlgoliaLocalizedCategory(subcategory2, catalogId)).toEqual(expectedSubCategory2Model);
+    });
+
+    test('french locale', function () {
+        const catalogId = 'testCatalog';
+        const category = new CategoryMock({ name: 'Electronics' });
+        const subcategory = new CategoryMock({ name: 'Digital Cameras', parent: category });
+        const subcategory2 = new CategoryMock({ name: 'Gaming', parent: category });
+        category.subcategories = [subcategory, subcategory2];
+
+        const expectedParentCategoryModel = {
+            objectID: 'testCatalog/storefront-catalog-m-en/electronics',
+            id: 'testCatalog/storefront-catalog-m-en/electronics',
+            name: 'Nom français de Electronics',
+            description: 'Description française de Electronics',
+            image: 'http://example.com/electronics.jpg',
+            thumbnail: 'http://example.com/electronics-thumbnail.jpg',
+            url: '/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/electronics',
+            subCategories: [
+                "testCatalog/storefront-catalog-m-en/digital-cameras",
+                "testCatalog/storefront-catalog-m-en/gaming",
+            ],
+            _tags: ['id:testCatalog/storefront-catalog-m-en/electronics'],
+        }
+        expect(new AlgoliaLocalizedCategory(category, catalogId, 'fr')).toEqual(expectedParentCategoryModel);
+
+        const expectedSubCategoryModel = {
+            objectID: 'testCatalog/storefront-catalog-m-en/digital-cameras',
+            id: 'testCatalog/storefront-catalog-m-en/digital-cameras',
+            name: 'Nom français de Digital Cameras',
+            description: 'Description française de Digital Cameras',
+            image: 'http://example.com/digital-cameras.jpg',
+            thumbnail: 'http://example.com/digital-cameras-thumbnail.jpg',
+            url: '/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/digital-cameras',
+            parent_category_id: 'testCatalog/storefront-catalog-m-en/electronics',
+            _tags: ['id:testCatalog/storefront-catalog-m-en/digital-cameras'],
+        }
+        expect(new AlgoliaLocalizedCategory(subcategory, catalogId, 'fr')).toEqual(expectedSubCategoryModel);
+
+        const expectedSubCategory2Model = {
+            objectID: 'testCatalog/storefront-catalog-m-en/gaming',
+            id: 'testCatalog/storefront-catalog-m-en/gaming',
+            name: 'Nom français de Gaming',
+            description: 'Description française de Gaming',
+            image: 'http://example.com/gaming.jpg',
+            thumbnail: 'http://example.com/gaming-thumbnail.jpg',
+            url: '/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/gaming',
+            parent_category_id: 'testCatalog/storefront-catalog-m-en/electronics',
+            _tags: ['id:testCatalog/storefront-catalog-m-en/gaming'],
+        }
+        expect(new AlgoliaLocalizedCategory(subcategory2, catalogId, 'fr')).toEqual(expectedSubCategory2Model);
+    });
+});


### PR DESCRIPTION
This PR introduces a "AlgoliaLocalizedCategory" model, similar to the "AlgoliaLocalizedProduct" model introduced in #62
There was no existing model for the categories, the objects were built directly by the job: https://github.com/algolia/algoliasearch-sfcc-b2c/blob/e2cf1ff8920fd3f92df4a815cbc6781291565a53/cartridges/int_algolia/cartridge/scripts/algolia/job/categoryIndexJob.js#L97

The work was to extract the code from the `categoryIndexJob` in order to create a standalone model, that we can test.

Note: the existing `prepareListOfCategories` method in the `categoryIndexJob` pushes objects in a global `listOfCategories`, containing all the categories objects to send. This will be the role of the new categories job that will be developed next. This PR is only defining the model of a single category.

### Preview

The current `categoryIndexJob` builds the following object, with all locales:
```json
{
    "id": "storefront-catalog-m-en/womens-clothing",
    "url": {
      "en_US": "https://commercecloud.salesforce.com/s/RefArch/womens/clothing/?lang=en_US",
      "fr_FR": "https://commercecloud.salesforce.com/s/RefArch/femme/v%C3%AAtements/?lang=fr_FR",
      "it_IT": "https://commercecloud.salesforce.com/s/RefArch/donna/abbigliamento/?lang=it_IT"
    },
    "name": {
      "en_US": "Clothing",
      "fr_FR": "Vêtements",
      "it_IT": "Abbigliamento"
    },
    "description": {},
    "parent_category_id": "storefront-catalog-m-en/womens",
    "image": "https://commercecloud.salesforce.com/on/demandware.static/-/Sites-storefront-catalog-m-en/default/dwbecc11e6/images/slot/sub_banners/cat-banner-womens-clothing.jpg",
    "subCategories": [
      "storefront-catalog-m-en/womens-outfits",
      "storefront-catalog-m-en/womens-clothing-tops",
      "storefront-catalog-m-en/womens-clothing-dresses"
    ]
}
```

This new model now produces the following object, for a given locale:

```json
{
    "objectID": "storefront-catalog-m-en/womens-clothing",
    "id": "storefront-catalog-m-en/womens-clothing",
    "name": "Clothing",
    "image": "https://commercecloud.salesforce.com/on/demandware.static/-/Sites-storefront-catalog-m-en/default/dwbecc11e6/images/slot/sub_banners/cat-banner-womens-clothing.jpg",
    "parent_category_id": "storefront-catalog-m-en/womens",
    "subCategories": [
      "storefront-catalog-m-en/womens-outfits",
      "storefront-catalog-m-en/womens-clothing-tops",
      "storefront-catalog-m-en/womens-clothing-dresses"
    ],
    "url": "https://commercecloud.salesforce.com/s/RefArch/womens/clothing/?lang=en_US",
    "_tags": [
      "id:storefront-catalog-m-en/womens-clothing"
    ]
}
```

### Tests :test_tube: 

- Added a `Category` mock and a unit test that ensure that for a given `dw.catalog.Category`, the final object contains the expected properties.

---
SFCC-115