### PR TITLE
feat: categories direct indexing

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategories.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategories.js
@@ -62,7 +62,7 @@ function runCategoryExport(parameters) {
     categoryLogData.failedChunks = 0;
     categoryLogData.failedRecords = 0;
 
-    logger.info('Site: ' + Site.getCurrent().getName() +'. Enabled locales: ' + siteLocales.toArray())
+    logger.info('Site: ' + currentSite.getName() +'. Enabled locales: ' + siteLocales.toArray())
     logger.info('CatalogID: ' + siteCatalogId)
 
     var status;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategories.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategories.js
@@ -1,0 +1,111 @@
+var catalogMgr = require('dw/catalog/CatalogMgr');
+var Site = require('dw/system/Site');
+var logger = require('dw/system/Logger').getLogger('algolia', 'Algolia');
+
+var AlgoliaLocalizedCategory = require('*/cartridge/scripts/algolia/model/algoliaLocalizedCategory');
+var utils = require('../lib/utils');
+
+/**
+ * Converts a given dw.catalog.Category and its sub categories to objects ready to be indexed
+ * @param {dw.catalog.Category} category - A category
+ * @param {string} catalogId - ID of the site catalog
+ * @param {string} locale - The locale to use to fetch the categories properties
+ * @returns {Array} the category and all its subcategories converted to objects ready to be indexed
+ */
+function getSubCategoriesModels(category, catalogId, locale) {
+    var res = [];
+    if (!category.custom || !category.custom.showInMenu
+      || (!category.hasOnlineProducts() && !category.hasOnlineSubCategories())) {
+        return res;
+    }
+
+    res.push(new AlgoliaLocalizedCategory(category, catalogId, locale));
+
+    var subCategories = category.getOnlineSubCategories();
+    utils.forEach(subCategories, function (subcategory) {
+        res = res.concat(getSubCategoriesModels(subcategory, catalogId, locale));
+    });
+    return res;
+}
+
+/**
+ * Job that fetch all categories of the site catalog, convert them into AlgoliaOperations
+ * and send them for indexing.
+ * @param {dw.util.HashMap} parameters job step parameters
+ */
+function runCategoryExport(parameters) {
+    var algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
+    var jobHelper = require('*/cartridge/scripts/algolia/helper/jobHelper');
+    var algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
+
+    var currentSite = Site.getCurrent();
+    var siteLocales = currentSite.getAllowedLocales();
+    var siteCatalog = catalogMgr.getSiteCatalog();
+    var siteCatalogId = siteCatalog.getID();
+    var siteRootCategory = siteCatalog.getRoot();
+    var topLevelCategories = siteRootCategory.hasOnlineSubCategories()
+        ? siteRootCategory.getOnlineSubCategories().iterator() : null;
+
+    var updateLogType = 'LastCategorySyncLog';
+
+    var categoryLogData = algoliaData.getLogData(updateLogType);
+    categoryLogData.processedDate = algoliaData.getLocalDateTime(new Date());
+    categoryLogData.processedError = false;
+    categoryLogData.processedErrorMessage = '';
+    categoryLogData.processedRecords = 0;
+    categoryLogData.processedToUpdateRecords = 0;
+
+    categoryLogData.sendError = false;
+    categoryLogData.sendErrorMessage = '';
+    categoryLogData.sentChunks = 0;
+    categoryLogData.sentRecords = 0;
+    categoryLogData.failedChunks = 0;
+    categoryLogData.failedRecords = 0;
+
+    logger.info('Site: ' + Site.getCurrent().getName() +'. Enabled locales: ' + siteLocales.toArray())
+    logger.info('CatalogID: ' + siteCatalogId)
+
+    var status;
+    while (topLevelCategories.hasNext()) {
+        var batch = [];
+        var category = topLevelCategories.next();
+        for (let l = 0; l < siteLocales.size(); ++l) {
+            var locale = siteLocales[l];
+            var indexName = algoliaData.calculateIndexName('categories', locale);
+            var localizedCategories = getSubCategoriesModels(category, siteCatalogId, locale);
+
+            for (let i = 0; i < localizedCategories.length; ++i) {
+                batch.push(new jobHelper.AlgoliaOperation('addObject', localizedCategories[i], indexName));
+            }
+        }
+
+        categoryLogData.processedRecords += batch.length;
+        categoryLogData.processedToUpdateRecords += batch.length;
+
+        if (batch.length === 0) {
+            logger.info('No records generated for category: ' + category.getID() + ', continuing...');
+            continue;
+        }
+
+        logger.info('Sending a batch of ' + batch.length + ' records (top-level category id: ' + category.getID() + ')');
+        status = algoliaIndexingAPI.sendMultiIndicesBatch(batch);
+        if (status.error) {
+            categoryLogData.failedRecords += batch.length;
+            categoryLogData.failedChunks++;
+            categoryLogData.sendError = true;
+        }
+        else {
+            categoryLogData.sentRecords += batch.length;
+            categoryLogData.sentChunks++;
+        }
+    }
+
+    categoryLogData.sendDate = algoliaData.getLocalDateTime(new Date());
+
+    algoliaData.setLogData(updateLogType, categoryLogData);
+}
+
+module.exports.execute = runCategoryExport;
+
+// for testing
+module.exports.getSubCategoriesModels = getSubCategoriesModels;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/utils.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/utils.js
@@ -65,7 +65,7 @@ function forEach(collection, callback, scope) {
         } else {
             callback(item, index, collection);
         }
-        index += 1;
+        ++index;
     }
 }
 

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -39,6 +39,19 @@
 					}
 				]
 			}
+		},
+		{
+			"@type-id": "custom.algoliaSendCategories",
+			"@supports-parallel-execution": "false",
+			"@supports-site-context": "true",
+			"@supports-organization-context": "false",
+			"description": "Index the site's categories into Algolia",
+			"module": "int_algolia/cartridge/scripts/algolia/job/sendCategories.js",
+			"function": "execute",
+			"transactional": "false",
+			"timeout-in-seconds": "600",
+			"parameters": {},
+			"status-codes": {}
 		}],
 		"chunk-script-module-step": [{
 			"@type-id": "custom.sendChunkOrientedProductUpdates",

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -98,6 +98,10 @@ jest.mock('dw/web/Resource', () => {
 }, {virtual: true});
 jest.mock('dw/web/URLUtils', () => {
     return {
+        https: function(endpoint, param, id) {
+            var absURL = 'https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/';
+            return absURL + global.request.getLocale() + '/' + endpoint + '?' + param + '=' + id;
+        },
         url: function(endpoint, param, id) {
             var relURL = '/on/demandware.store/Sites-Algolia_SFRA-Site/';
             return relURL + global.request.getLocale() + '/' + endpoint + '?' + param + '=' + id;
@@ -111,7 +115,10 @@ jest.mock('dw/web/URLUtils', () => {
 // Mocked libraries, to be rewritten with `requireActual()`
 jest.mock('*/cartridge/scripts/algolia/helper/logHelper', () => {
     return {
-        getLogData: function() {}
+        getLogData: function() {
+            return {};
+        },
+        setLogData: function() {}
     }
 }, {virtual: true});
 jest.mock('*/cartridge/scripts/services/algoliaIndexingService', () => {}, {virtual: true});

--- a/test/mocks/dw/catalog/Category.js
+++ b/test/mocks/dw/catalog/Category.js
@@ -1,7 +1,8 @@
-var Category = function ({ name, parent, subcategories}) {
+var Category = function ({ name, parent, subcategories, showInMenu }) {
     this.ID = `storefront-catalog-m-en/${name.split(' ').join('-').toLowerCase()}`;
     this.parent = parent;
     this.subcategories = subcategories;
+    this.showInMenu = showInMenu !== undefined ? showInMenu : true;
 
     this.getID = function() {
         return this.ID;
@@ -40,8 +41,11 @@ var Category = function ({ name, parent, subcategories}) {
     this.getOnlineSubCategories= function() {
         return new Collection(this.subcategories || []);
     }
+    this.hasOnlineSubCategories= function() {
+        return this.subcategories && this.subcategories.length > 0;
+    }
     this.custom = {
-        showInMenu: true,
+        showInMenu: this.showInMenu,
     }
     this.hasOnlineProducts= function() {
         return true;

--- a/test/mocks/dw/catalog/Category.js
+++ b/test/mocks/dw/catalog/Category.js
@@ -1,4 +1,6 @@
-var Category = function ({ name, parent, subcategories, showInMenu }) {
+const Collection = require('../util/Collection');
+
+const Category = function ({ name, parent, subcategories, showInMenu }) {
     this.ID = `storefront-catalog-m-en/${name.split(' ').join('-').toLowerCase()}`;
     this.parent = parent;
     this.subcategories = subcategories;
@@ -51,26 +53,5 @@ var Category = function ({ name, parent, subcategories, showInMenu }) {
         return true;
     }
 };
-
-// Mock of dw.util.Collection
-const Collection = function(values) {
-    this.values = values;
-    const that = this;
-
-    this.iterator = function() {
-        let nextIndex = 0;
-
-        return {
-            hasNext() {
-                return nextIndex < that.values.length;
-            },
-            next() {
-                if (nextIndex < that.values.length) {
-                    return that.values[nextIndex++];
-                }
-            },
-        };
-    }
-}
 
 module.exports = Category;

--- a/test/mocks/dw/util/Collection.js
+++ b/test/mocks/dw/util/Collection.js
@@ -1,0 +1,21 @@
+const Collection = function(values) {
+    this.values = values;
+    const that = this;
+
+    this.iterator = function() {
+        let nextIndex = 0;
+
+        return {
+            hasNext() {
+                return nextIndex < that.values.length;
+            },
+            next() {
+                if (nextIndex < that.values.length) {
+                    return that.values[nextIndex++];
+                }
+            },
+        };
+    }
+}
+
+module.exports = Collection;

--- a/test/unit/int_algolia/scripts/algolia/job/__snapshots__/sendCategories.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/job/__snapshots__/sendCategories.test.js.snap
@@ -16,7 +16,7 @@ exports[`getSubCategoriesModels default locale 1`] = `
       "testCatalog/storefront-catalog-m-en/audio",
     ],
     "thumbnail": "http://example.com/electronics-thumbnail.jpg",
-    "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/electronics",
+    "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/electronics",
   },
   algoliaLocalizedCategory {
     "_tags": [
@@ -29,7 +29,7 @@ exports[`getSubCategoriesModels default locale 1`] = `
     "objectID": "testCatalog/storefront-catalog-m-en/digital-cameras",
     "parent_category_id": "testCatalog/storefront-catalog-m-en/electronics",
     "thumbnail": "http://example.com/digital-cameras-thumbnail.jpg",
-    "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
+    "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
   },
   algoliaLocalizedCategory {
     "_tags": [
@@ -45,7 +45,7 @@ exports[`getSubCategoriesModels default locale 1`] = `
       "testCatalog/storefront-catalog-m-en/headphones",
     ],
     "thumbnail": "http://example.com/audio-thumbnail.jpg",
-    "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/audio",
+    "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/audio",
   },
   algoliaLocalizedCategory {
     "_tags": [
@@ -58,7 +58,7 @@ exports[`getSubCategoriesModels default locale 1`] = `
     "objectID": "testCatalog/storefront-catalog-m-en/headphones",
     "parent_category_id": "testCatalog/storefront-catalog-m-en/audio",
     "thumbnail": "http://example.com/headphones-thumbnail.jpg",
-    "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/headphones",
+    "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/headphones",
   },
 ]
 `;
@@ -79,7 +79,7 @@ exports[`getSubCategoriesModels french locale 1`] = `
       "testCatalog/storefront-catalog-m-en/audio",
     ],
     "thumbnail": "http://example.com/electronics-thumbnail.jpg",
-    "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/electronics",
+    "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/electronics",
   },
   algoliaLocalizedCategory {
     "_tags": [
@@ -92,7 +92,7 @@ exports[`getSubCategoriesModels french locale 1`] = `
     "objectID": "testCatalog/storefront-catalog-m-en/digital-cameras",
     "parent_category_id": "testCatalog/storefront-catalog-m-en/electronics",
     "thumbnail": "http://example.com/digital-cameras-thumbnail.jpg",
-    "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
+    "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
   },
   algoliaLocalizedCategory {
     "_tags": [
@@ -108,7 +108,7 @@ exports[`getSubCategoriesModels french locale 1`] = `
       "testCatalog/storefront-catalog-m-en/headphones",
     ],
     "thumbnail": "http://example.com/audio-thumbnail.jpg",
-    "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/audio",
+    "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/audio",
   },
   algoliaLocalizedCategory {
     "_tags": [
@@ -121,7 +121,7 @@ exports[`getSubCategoriesModels french locale 1`] = `
     "objectID": "testCatalog/storefront-catalog-m-en/headphones",
     "parent_category_id": "testCatalog/storefront-catalog-m-en/audio",
     "thumbnail": "http://example.com/headphones-thumbnail.jpg",
-    "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/headphones",
+    "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/headphones",
   },
 ]
 `;
@@ -147,7 +147,7 @@ exports[`runCategoryExport 1`] = `
               "testCatalog/storefront-catalog-m-en/audio",
             ],
             "thumbnail": "http://example.com/electronics-thumbnail.jpg",
-            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/electronics",
+            "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/electronics",
           },
           "indexName": "test_index___categories__default",
         },
@@ -164,7 +164,7 @@ exports[`runCategoryExport 1`] = `
             "objectID": "testCatalog/storefront-catalog-m-en/digital-cameras",
             "parent_category_id": "testCatalog/storefront-catalog-m-en/electronics",
             "thumbnail": "http://example.com/digital-cameras-thumbnail.jpg",
-            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
+            "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
           },
           "indexName": "test_index___categories__default",
         },
@@ -184,7 +184,7 @@ exports[`runCategoryExport 1`] = `
               "testCatalog/storefront-catalog-m-en/headphones",
             ],
             "thumbnail": "http://example.com/audio-thumbnail.jpg",
-            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/audio",
+            "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/audio",
           },
           "indexName": "test_index___categories__default",
         },
@@ -201,7 +201,7 @@ exports[`runCategoryExport 1`] = `
             "objectID": "testCatalog/storefront-catalog-m-en/headphones",
             "parent_category_id": "testCatalog/storefront-catalog-m-en/audio",
             "thumbnail": "http://example.com/headphones-thumbnail.jpg",
-            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/headphones",
+            "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/headphones",
           },
           "indexName": "test_index___categories__default",
         },
@@ -221,7 +221,7 @@ exports[`runCategoryExport 1`] = `
               "testCatalog/storefront-catalog-m-en/audio",
             ],
             "thumbnail": "http://example.com/electronics-thumbnail.jpg",
-            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/electronics",
+            "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/electronics",
           },
           "indexName": "test_index___categories__fr",
         },
@@ -238,7 +238,7 @@ exports[`runCategoryExport 1`] = `
             "objectID": "testCatalog/storefront-catalog-m-en/digital-cameras",
             "parent_category_id": "testCatalog/storefront-catalog-m-en/electronics",
             "thumbnail": "http://example.com/digital-cameras-thumbnail.jpg",
-            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
+            "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
           },
           "indexName": "test_index___categories__fr",
         },
@@ -258,7 +258,7 @@ exports[`runCategoryExport 1`] = `
               "testCatalog/storefront-catalog-m-en/headphones",
             ],
             "thumbnail": "http://example.com/audio-thumbnail.jpg",
-            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/audio",
+            "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/audio",
           },
           "indexName": "test_index___categories__fr",
         },
@@ -275,7 +275,7 @@ exports[`runCategoryExport 1`] = `
             "objectID": "testCatalog/storefront-catalog-m-en/headphones",
             "parent_category_id": "testCatalog/storefront-catalog-m-en/audio",
             "thumbnail": "http://example.com/headphones-thumbnail.jpg",
-            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/headphones",
+            "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/headphones",
           },
           "indexName": "test_index___categories__fr",
         },
@@ -295,7 +295,7 @@ exports[`runCategoryExport 1`] = `
               "testCatalog/storefront-catalog-m-en/audio",
             ],
             "thumbnail": "http://example.com/electronics-thumbnail.jpg",
-            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/en/Search-Show?cgid=storefront-catalog-m-en/electronics",
+            "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/en/Search-Show?cgid=storefront-catalog-m-en/electronics",
           },
           "indexName": "test_index___categories__en",
         },
@@ -312,7 +312,7 @@ exports[`runCategoryExport 1`] = `
             "objectID": "testCatalog/storefront-catalog-m-en/digital-cameras",
             "parent_category_id": "testCatalog/storefront-catalog-m-en/electronics",
             "thumbnail": "http://example.com/digital-cameras-thumbnail.jpg",
-            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/en/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
+            "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/en/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
           },
           "indexName": "test_index___categories__en",
         },
@@ -332,7 +332,7 @@ exports[`runCategoryExport 1`] = `
               "testCatalog/storefront-catalog-m-en/headphones",
             ],
             "thumbnail": "http://example.com/audio-thumbnail.jpg",
-            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/en/Search-Show?cgid=storefront-catalog-m-en/audio",
+            "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/en/Search-Show?cgid=storefront-catalog-m-en/audio",
           },
           "indexName": "test_index___categories__en",
         },
@@ -349,7 +349,7 @@ exports[`runCategoryExport 1`] = `
             "objectID": "testCatalog/storefront-catalog-m-en/headphones",
             "parent_category_id": "testCatalog/storefront-catalog-m-en/audio",
             "thumbnail": "http://example.com/headphones-thumbnail.jpg",
-            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/en/Search-Show?cgid=storefront-catalog-m-en/headphones",
+            "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/en/Search-Show?cgid=storefront-catalog-m-en/headphones",
           },
           "indexName": "test_index___categories__en",
         },

--- a/test/unit/int_algolia/scripts/algolia/job/__snapshots__/sendCategories.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/job/__snapshots__/sendCategories.test.js.snap
@@ -1,0 +1,127 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getSubCategoriesModels default locale 1`] = `
+[
+  algoliaLocalizedCategory {
+    "_tags": [
+      "id:testCatalog/storefront-catalog-m-en/electronics",
+    ],
+    "description": "Description of Electronics",
+    "id": "testCatalog/storefront-catalog-m-en/electronics",
+    "image": "http://example.com/electronics.jpg",
+    "name": "Electronics",
+    "objectID": "testCatalog/storefront-catalog-m-en/electronics",
+    "subCategories": [
+      "testCatalog/storefront-catalog-m-en/digital-cameras",
+      "testCatalog/storefront-catalog-m-en/audio",
+    ],
+    "thumbnail": "http://example.com/electronics-thumbnail.jpg",
+    "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/electronics",
+  },
+  algoliaLocalizedCategory {
+    "_tags": [
+      "id:testCatalog/storefront-catalog-m-en/digital-cameras",
+    ],
+    "description": "Description of Digital Cameras",
+    "id": "testCatalog/storefront-catalog-m-en/digital-cameras",
+    "image": "http://example.com/digital-cameras.jpg",
+    "name": "Digital Cameras",
+    "objectID": "testCatalog/storefront-catalog-m-en/digital-cameras",
+    "parent_category_id": "testCatalog/storefront-catalog-m-en/electronics",
+    "thumbnail": "http://example.com/digital-cameras-thumbnail.jpg",
+    "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
+  },
+  algoliaLocalizedCategory {
+    "_tags": [
+      "id:testCatalog/storefront-catalog-m-en/audio",
+    ],
+    "description": "Description of Audio",
+    "id": "testCatalog/storefront-catalog-m-en/audio",
+    "image": "http://example.com/audio.jpg",
+    "name": "Audio",
+    "objectID": "testCatalog/storefront-catalog-m-en/audio",
+    "parent_category_id": "testCatalog/storefront-catalog-m-en/electronics",
+    "subCategories": [
+      "testCatalog/storefront-catalog-m-en/headphones",
+    ],
+    "thumbnail": "http://example.com/audio-thumbnail.jpg",
+    "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/audio",
+  },
+  algoliaLocalizedCategory {
+    "_tags": [
+      "id:testCatalog/storefront-catalog-m-en/headphones",
+    ],
+    "description": "Description of Headphones",
+    "id": "testCatalog/storefront-catalog-m-en/headphones",
+    "image": "http://example.com/headphones.jpg",
+    "name": "Headphones",
+    "objectID": "testCatalog/storefront-catalog-m-en/headphones",
+    "parent_category_id": "testCatalog/storefront-catalog-m-en/audio",
+    "thumbnail": "http://example.com/headphones-thumbnail.jpg",
+    "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/headphones",
+  },
+]
+`;
+
+exports[`getSubCategoriesModels french locale 1`] = `
+[
+  algoliaLocalizedCategory {
+    "_tags": [
+      "id:testCatalog/storefront-catalog-m-en/electronics",
+    ],
+    "description": "Description française de Electronics",
+    "id": "testCatalog/storefront-catalog-m-en/electronics",
+    "image": "http://example.com/electronics.jpg",
+    "name": "Nom français de Electronics",
+    "objectID": "testCatalog/storefront-catalog-m-en/electronics",
+    "subCategories": [
+      "testCatalog/storefront-catalog-m-en/digital-cameras",
+      "testCatalog/storefront-catalog-m-en/audio",
+    ],
+    "thumbnail": "http://example.com/electronics-thumbnail.jpg",
+    "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/electronics",
+  },
+  algoliaLocalizedCategory {
+    "_tags": [
+      "id:testCatalog/storefront-catalog-m-en/digital-cameras",
+    ],
+    "description": "Description française de Digital Cameras",
+    "id": "testCatalog/storefront-catalog-m-en/digital-cameras",
+    "image": "http://example.com/digital-cameras.jpg",
+    "name": "Nom français de Digital Cameras",
+    "objectID": "testCatalog/storefront-catalog-m-en/digital-cameras",
+    "parent_category_id": "testCatalog/storefront-catalog-m-en/electronics",
+    "thumbnail": "http://example.com/digital-cameras-thumbnail.jpg",
+    "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
+  },
+  algoliaLocalizedCategory {
+    "_tags": [
+      "id:testCatalog/storefront-catalog-m-en/audio",
+    ],
+    "description": "Description française de Audio",
+    "id": "testCatalog/storefront-catalog-m-en/audio",
+    "image": "http://example.com/audio.jpg",
+    "name": "Nom français de Audio",
+    "objectID": "testCatalog/storefront-catalog-m-en/audio",
+    "parent_category_id": "testCatalog/storefront-catalog-m-en/electronics",
+    "subCategories": [
+      "testCatalog/storefront-catalog-m-en/headphones",
+    ],
+    "thumbnail": "http://example.com/audio-thumbnail.jpg",
+    "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/audio",
+  },
+  algoliaLocalizedCategory {
+    "_tags": [
+      "id:testCatalog/storefront-catalog-m-en/headphones",
+    ],
+    "description": "Description française de Headphones",
+    "id": "testCatalog/storefront-catalog-m-en/headphones",
+    "image": "http://example.com/headphones.jpg",
+    "name": "Nom français de Headphones",
+    "objectID": "testCatalog/storefront-catalog-m-en/headphones",
+    "parent_category_id": "testCatalog/storefront-catalog-m-en/audio",
+    "thumbnail": "http://example.com/headphones-thumbnail.jpg",
+    "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/headphones",
+  },
+]
+`;

--- a/test/unit/int_algolia/scripts/algolia/job/__snapshots__/sendCategories.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/job/__snapshots__/sendCategories.test.js.snap
@@ -125,3 +125,244 @@ exports[`getSubCategoriesModels french locale 1`] = `
   },
 ]
 `;
+
+exports[`runCategoryExport 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      [
+        AlgoliaOperation {
+          "action": "addObject",
+          "body": {
+            "_tags": [
+              "id:testCatalog/storefront-catalog-m-en/electronics",
+            ],
+            "description": "Description of Electronics",
+            "id": "testCatalog/storefront-catalog-m-en/electronics",
+            "image": "http://example.com/electronics.jpg",
+            "name": "Electronics",
+            "objectID": "testCatalog/storefront-catalog-m-en/electronics",
+            "subCategories": [
+              "testCatalog/storefront-catalog-m-en/digital-cameras",
+              "testCatalog/storefront-catalog-m-en/audio",
+            ],
+            "thumbnail": "http://example.com/electronics-thumbnail.jpg",
+            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/electronics",
+          },
+          "indexName": "test_index___categories__default",
+        },
+        AlgoliaOperation {
+          "action": "addObject",
+          "body": {
+            "_tags": [
+              "id:testCatalog/storefront-catalog-m-en/digital-cameras",
+            ],
+            "description": "Description of Digital Cameras",
+            "id": "testCatalog/storefront-catalog-m-en/digital-cameras",
+            "image": "http://example.com/digital-cameras.jpg",
+            "name": "Digital Cameras",
+            "objectID": "testCatalog/storefront-catalog-m-en/digital-cameras",
+            "parent_category_id": "testCatalog/storefront-catalog-m-en/electronics",
+            "thumbnail": "http://example.com/digital-cameras-thumbnail.jpg",
+            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
+          },
+          "indexName": "test_index___categories__default",
+        },
+        AlgoliaOperation {
+          "action": "addObject",
+          "body": {
+            "_tags": [
+              "id:testCatalog/storefront-catalog-m-en/audio",
+            ],
+            "description": "Description of Audio",
+            "id": "testCatalog/storefront-catalog-m-en/audio",
+            "image": "http://example.com/audio.jpg",
+            "name": "Audio",
+            "objectID": "testCatalog/storefront-catalog-m-en/audio",
+            "parent_category_id": "testCatalog/storefront-catalog-m-en/electronics",
+            "subCategories": [
+              "testCatalog/storefront-catalog-m-en/headphones",
+            ],
+            "thumbnail": "http://example.com/audio-thumbnail.jpg",
+            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/audio",
+          },
+          "indexName": "test_index___categories__default",
+        },
+        AlgoliaOperation {
+          "action": "addObject",
+          "body": {
+            "_tags": [
+              "id:testCatalog/storefront-catalog-m-en/headphones",
+            ],
+            "description": "Description of Headphones",
+            "id": "testCatalog/storefront-catalog-m-en/headphones",
+            "image": "http://example.com/headphones.jpg",
+            "name": "Headphones",
+            "objectID": "testCatalog/storefront-catalog-m-en/headphones",
+            "parent_category_id": "testCatalog/storefront-catalog-m-en/audio",
+            "thumbnail": "http://example.com/headphones-thumbnail.jpg",
+            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/headphones",
+          },
+          "indexName": "test_index___categories__default",
+        },
+        AlgoliaOperation {
+          "action": "addObject",
+          "body": {
+            "_tags": [
+              "id:testCatalog/storefront-catalog-m-en/electronics",
+            ],
+            "description": "Description française de Electronics",
+            "id": "testCatalog/storefront-catalog-m-en/electronics",
+            "image": "http://example.com/electronics.jpg",
+            "name": "Nom français de Electronics",
+            "objectID": "testCatalog/storefront-catalog-m-en/electronics",
+            "subCategories": [
+              "testCatalog/storefront-catalog-m-en/digital-cameras",
+              "testCatalog/storefront-catalog-m-en/audio",
+            ],
+            "thumbnail": "http://example.com/electronics-thumbnail.jpg",
+            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/electronics",
+          },
+          "indexName": "test_index___categories__fr",
+        },
+        AlgoliaOperation {
+          "action": "addObject",
+          "body": {
+            "_tags": [
+              "id:testCatalog/storefront-catalog-m-en/digital-cameras",
+            ],
+            "description": "Description française de Digital Cameras",
+            "id": "testCatalog/storefront-catalog-m-en/digital-cameras",
+            "image": "http://example.com/digital-cameras.jpg",
+            "name": "Nom français de Digital Cameras",
+            "objectID": "testCatalog/storefront-catalog-m-en/digital-cameras",
+            "parent_category_id": "testCatalog/storefront-catalog-m-en/electronics",
+            "thumbnail": "http://example.com/digital-cameras-thumbnail.jpg",
+            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
+          },
+          "indexName": "test_index___categories__fr",
+        },
+        AlgoliaOperation {
+          "action": "addObject",
+          "body": {
+            "_tags": [
+              "id:testCatalog/storefront-catalog-m-en/audio",
+            ],
+            "description": "Description française de Audio",
+            "id": "testCatalog/storefront-catalog-m-en/audio",
+            "image": "http://example.com/audio.jpg",
+            "name": "Nom français de Audio",
+            "objectID": "testCatalog/storefront-catalog-m-en/audio",
+            "parent_category_id": "testCatalog/storefront-catalog-m-en/electronics",
+            "subCategories": [
+              "testCatalog/storefront-catalog-m-en/headphones",
+            ],
+            "thumbnail": "http://example.com/audio-thumbnail.jpg",
+            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/audio",
+          },
+          "indexName": "test_index___categories__fr",
+        },
+        AlgoliaOperation {
+          "action": "addObject",
+          "body": {
+            "_tags": [
+              "id:testCatalog/storefront-catalog-m-en/headphones",
+            ],
+            "description": "Description française de Headphones",
+            "id": "testCatalog/storefront-catalog-m-en/headphones",
+            "image": "http://example.com/headphones.jpg",
+            "name": "Nom français de Headphones",
+            "objectID": "testCatalog/storefront-catalog-m-en/headphones",
+            "parent_category_id": "testCatalog/storefront-catalog-m-en/audio",
+            "thumbnail": "http://example.com/headphones-thumbnail.jpg",
+            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/headphones",
+          },
+          "indexName": "test_index___categories__fr",
+        },
+        AlgoliaOperation {
+          "action": "addObject",
+          "body": {
+            "_tags": [
+              "id:testCatalog/storefront-catalog-m-en/electronics",
+            ],
+            "description": "English description of Electronics",
+            "id": "testCatalog/storefront-catalog-m-en/electronics",
+            "image": "http://example.com/electronics.jpg",
+            "name": "English name of Electronics",
+            "objectID": "testCatalog/storefront-catalog-m-en/electronics",
+            "subCategories": [
+              "testCatalog/storefront-catalog-m-en/digital-cameras",
+              "testCatalog/storefront-catalog-m-en/audio",
+            ],
+            "thumbnail": "http://example.com/electronics-thumbnail.jpg",
+            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/en/Search-Show?cgid=storefront-catalog-m-en/electronics",
+          },
+          "indexName": "test_index___categories__en",
+        },
+        AlgoliaOperation {
+          "action": "addObject",
+          "body": {
+            "_tags": [
+              "id:testCatalog/storefront-catalog-m-en/digital-cameras",
+            ],
+            "description": "English description of Digital Cameras",
+            "id": "testCatalog/storefront-catalog-m-en/digital-cameras",
+            "image": "http://example.com/digital-cameras.jpg",
+            "name": "English name of Digital Cameras",
+            "objectID": "testCatalog/storefront-catalog-m-en/digital-cameras",
+            "parent_category_id": "testCatalog/storefront-catalog-m-en/electronics",
+            "thumbnail": "http://example.com/digital-cameras-thumbnail.jpg",
+            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/en/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
+          },
+          "indexName": "test_index___categories__en",
+        },
+        AlgoliaOperation {
+          "action": "addObject",
+          "body": {
+            "_tags": [
+              "id:testCatalog/storefront-catalog-m-en/audio",
+            ],
+            "description": "English description of Audio",
+            "id": "testCatalog/storefront-catalog-m-en/audio",
+            "image": "http://example.com/audio.jpg",
+            "name": "English name of Audio",
+            "objectID": "testCatalog/storefront-catalog-m-en/audio",
+            "parent_category_id": "testCatalog/storefront-catalog-m-en/electronics",
+            "subCategories": [
+              "testCatalog/storefront-catalog-m-en/headphones",
+            ],
+            "thumbnail": "http://example.com/audio-thumbnail.jpg",
+            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/en/Search-Show?cgid=storefront-catalog-m-en/audio",
+          },
+          "indexName": "test_index___categories__en",
+        },
+        AlgoliaOperation {
+          "action": "addObject",
+          "body": {
+            "_tags": [
+              "id:testCatalog/storefront-catalog-m-en/headphones",
+            ],
+            "description": "English description of Headphones",
+            "id": "testCatalog/storefront-catalog-m-en/headphones",
+            "image": "http://example.com/headphones.jpg",
+            "name": "English name of Headphones",
+            "objectID": "testCatalog/storefront-catalog-m-en/headphones",
+            "parent_category_id": "testCatalog/storefront-catalog-m-en/audio",
+            "thumbnail": "http://example.com/headphones-thumbnail.jpg",
+            "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/en/Search-Show?cgid=storefront-catalog-m-en/headphones",
+          },
+          "indexName": "test_index___categories__en",
+        },
+      ],
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": {
+        "ok": true,
+      },
+    },
+  ],
+}
+`;

--- a/test/unit/int_algolia/scripts/algolia/job/sendCategories.test.js
+++ b/test/unit/int_algolia/scripts/algolia/job/sendCategories.test.js
@@ -22,38 +22,6 @@ category.subcategories = [subcategory1, subcategory2, subcategory3];
 const catalogId = 'testCatalog';
 const mockOnlineSubCategories = new Collection([category]);
 
-jest.mock('dw/system/Site', () => {
-    return {
-        getCurrent: function () {
-            return {
-                getID: function() {
-                    return 'Test-Site'
-                },
-                getName: function() {
-                    return 'Name of the Test-Site'
-                },
-                getAllowedLocales: function () {
-                    var arr = ['default', 'fr', 'en'];
-                    arr.size = function () {
-                        return arr.length;
-                    };
-                    arr.toArray = function () {
-                        return arr;
-                    };
-                    return arr;
-                },
-                getCustomPreferenceValue: function(id) {
-                    switch(id) {
-                        case 'Algolia_IndexPrefix':
-                            return 'test_index_';
-                        default:
-                            return null;
-                    }
-                },
-            }
-        },
-    }
-}, {virtual: true});
 jest.mock('dw/catalog/CatalogMgr', () => {
     return {
         getSiteCatalog: function() {
@@ -74,44 +42,8 @@ jest.mock('dw/catalog/CatalogMgr', () => {
     }
 }, {virtual: true});
 
-jest.mock('dw/web/URLUtils', () => {
-    return {
-        https: function(endpoint, param, id) {
-            var relURL = '/on/demandware.store/Sites-Algolia_SFRA-Site/';
-            return relURL + global.request.getLocale() + '/' + endpoint + '?' + param + '=' + id;
-        },
-        staticURL: function(url) {
-            return url;
-        },
-        url: function(endpoint, param, id) {
-            var relURL = '/on/demandware.store/Sites-Algolia_SFRA-Site/';
-            return relURL + global.request.getLocale() + '/' + endpoint + '?' + param + '=' + id;
-        },
-    }
-}, {virtual: true});
-
 jest.mock('*/cartridge/scripts/algolia/model/algoliaLocalizedCategory', () => {
     return jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedCategory');
-}, {virtual: true});
-jest.mock('*/cartridge/scripts/algolia/helper/logHelper', () => {
-    return {
-        getLogData: (id) => {
-            return {};
-        },
-        setLogData: (id, logData) => {}
-    }
-}, {virtual: true});
-jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => {
-    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData');
-    return {
-        ...originalModule,
-        getSetOfArray: function (id) {
-            return id === 'CustomFields'
-                ? ['url', 'UPC', 'searchable', 'variant', 'color', 'refinementColor', 'size', 'refinementSize', 'brand', 'online', 'pageDescription', 'pageKeywords',
-                    'pageTitle', 'short_description', 'name', 'long_description', 'image_groups']
-                : null;
-        },
-    }
 }, {virtual: true});
 
 const mockSendMultiIndicesBatch = jest.fn().mockReturnValue({ ok: true });

--- a/test/unit/int_algolia/scripts/algolia/job/sendCategories.test.js
+++ b/test/unit/int_algolia/scripts/algolia/job/sendCategories.test.js
@@ -1,10 +1,78 @@
+const Collection = require('../../../../../mocks/dw/util/Collection')
+
 const GlobalMock = require('../../../../../mocks/global');
 const CategoryMock = require('../../../../../mocks/dw/catalog/Category');
 
+global.empty = GlobalMock.empty;
 global.request = new GlobalMock.RequestMock();
 
-jest.mock('dw/catalog/CatalogMgr', () => {}, {virtual: true});
-jest.mock('dw/system/Site', () => {}, {virtual: true});
+// We define some categories mocks that represent the following categories hierarchy:
+// Electronics
+// |__Digital Cameras
+// |__Audio
+//    |__Headphones
+const category = new CategoryMock({ name: 'Electronics' });
+const subcategory1 = new CategoryMock({ name: 'Digital Cameras', parent: category });
+const subcategory2 = new CategoryMock({ name: 'Audio', parent: category });
+const subsubcategory2 = new CategoryMock({ name: 'Headphones', parent: subcategory2 });
+subcategory2.subcategories = [subsubcategory2];
+// This category won't be exported because showInMenu is false
+const subcategory3 = new CategoryMock({ name: 'Video', parent: category, showInMenu: false });
+category.subcategories = [subcategory1, subcategory2, subcategory3];
+const catalogId = 'testCatalog';
+const mockOnlineSubCategories = new Collection([category]);
+
+jest.mock('dw/system/Site', () => {
+    return {
+        getCurrent: function () {
+            return {
+                getID: function() {
+                    return 'Test-Site'
+                },
+                getName: function() {
+                    return 'Name of the Test-Site'
+                },
+                getAllowedLocales: function () {
+                    var arr = ['default', 'fr', 'en'];
+                    arr.size = function () {
+                        return arr.length;
+                    };
+                    arr.toArray = function () {
+                        return arr;
+                    };
+                    return arr;
+                },
+                getCustomPreferenceValue: function(id) {
+                    switch(id) {
+                        case 'Algolia_IndexPrefix':
+                            return 'test_index_';
+                        default:
+                            return null;
+                    }
+                },
+            }
+        },
+    }
+}, {virtual: true});
+jest.mock('dw/catalog/CatalogMgr', () => {
+    return {
+        getSiteCatalog: function() {
+            return {
+                getID: function() {
+                    return catalogId;
+                },
+                getRoot: function() {
+                    return {
+                        hasOnlineSubCategories: () => true,
+                        getOnlineSubCategories: () => {
+                            return mockOnlineSubCategories;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}, {virtual: true});
 
 jest.mock('dw/web/URLUtils', () => {
     return {
@@ -12,30 +80,50 @@ jest.mock('dw/web/URLUtils', () => {
             var relURL = '/on/demandware.store/Sites-Algolia_SFRA-Site/';
             return relURL + global.request.getLocale() + '/' + endpoint + '?' + param + '=' + id;
         },
+        staticURL: function(url) {
+            return url;
+        },
+        url: function(endpoint, param, id) {
+            var relURL = '/on/demandware.store/Sites-Algolia_SFRA-Site/';
+            return relURL + global.request.getLocale() + '/' + endpoint + '?' + param + '=' + id;
+        },
     }
 }, {virtual: true});
+
 jest.mock('*/cartridge/scripts/algolia/model/algoliaLocalizedCategory', () => {
     return jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedCategory');
+}, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/helper/logHelper', () => {
+    return {
+        getLogData: (id) => {
+            return {};
+        },
+        setLogData: (id, logData) => {}
+    }
+}, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => {
+    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData');
+    return {
+        ...originalModule,
+        getSetOfArray: function (id) {
+            return id === 'CustomFields'
+                ? ['url', 'UPC', 'searchable', 'variant', 'color', 'refinementColor', 'size', 'refinementSize', 'brand', 'online', 'pageDescription', 'pageKeywords',
+                    'pageTitle', 'short_description', 'name', 'long_description', 'image_groups']
+                : null;
+        },
+    }
+}, {virtual: true});
+
+const mockSendMultiIndicesBatch = jest.fn().mockReturnValue({ ok: true });
+jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
+    return {
+        sendMultiIndicesBatch: mockSendMultiIndicesBatch,
+    }
 }, {virtual: true});
 
 const job = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategories');
 
 describe('getSubCategoriesModels', () => {
-    // We define categories mocks that represent the following categories hierarchy:
-    // Electronics
-    // |__Digital Cameras
-    // |__Audio
-    //    |__Headphones
-    const category = new CategoryMock({ name: 'Electronics' });
-    const subcategory1 = new CategoryMock({ name: 'Digital Cameras', parent: category });
-    const subcategory2 = new CategoryMock({ name: 'Audio', parent: category });
-    const subsubcategory2 = new CategoryMock({ name: 'Headphones', parent: subcategory2 });
-    subcategory2.subcategories = [subsubcategory2];
-    // This category won't be exported as showInMenu is false
-    const subcategory3 = new CategoryMock({ name: 'Video', parent: category, showInMenu: false });
-    category.subcategories = [subcategory1, subcategory2, subcategory3];
-    const catalogId = 'testCatalog';
-
     test('default locale', () => {
         var categoriesModels = job.getSubCategoriesModels(category, catalogId, 'default');
         expect(categoriesModels).toMatchSnapshot();
@@ -44,4 +132,9 @@ describe('getSubCategoriesModels', () => {
         var categoriesModels = job.getSubCategoriesModels(category, catalogId, 'fr');
         expect(categoriesModels).toMatchSnapshot();
     });
+});
+
+test('runCategoryExport', () => {
+    job.execute();
+    expect(mockSendMultiIndicesBatch).toMatchSnapshot();
 });

--- a/test/unit/int_algolia/scripts/algolia/job/sendCategories.test.js
+++ b/test/unit/int_algolia/scripts/algolia/job/sendCategories.test.js
@@ -1,0 +1,47 @@
+const GlobalMock = require('../../../../../mocks/global');
+const CategoryMock = require('../../../../../mocks/dw/catalog/Category');
+
+global.request = new GlobalMock.RequestMock();
+
+jest.mock('dw/catalog/CatalogMgr', () => {}, {virtual: true});
+jest.mock('dw/system/Site', () => {}, {virtual: true});
+
+jest.mock('dw/web/URLUtils', () => {
+    return {
+        https: function(endpoint, param, id) {
+            var relURL = '/on/demandware.store/Sites-Algolia_SFRA-Site/';
+            return relURL + global.request.getLocale() + '/' + endpoint + '?' + param + '=' + id;
+        },
+    }
+}, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/model/algoliaLocalizedCategory', () => {
+    return jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedCategory');
+}, {virtual: true});
+
+const job = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategories');
+
+describe('getSubCategoriesModels', () => {
+    // We define categories mocks that represent the following categories hierarchy:
+    // Electronics
+    // |__Digital Cameras
+    // |__Audio
+    //    |__Headphones
+    const category = new CategoryMock({ name: 'Electronics' });
+    const subcategory1 = new CategoryMock({ name: 'Digital Cameras', parent: category });
+    const subcategory2 = new CategoryMock({ name: 'Audio', parent: category });
+    const subsubcategory2 = new CategoryMock({ name: 'Headphones', parent: subcategory2 });
+    subcategory2.subcategories = [subsubcategory2];
+    // This category won't be exported as showInMenu is false
+    const subcategory3 = new CategoryMock({ name: 'Video', parent: category, showInMenu: false });
+    category.subcategories = [subcategory1, subcategory2, subcategory3];
+    const catalogId = 'testCatalog';
+
+    test('default locale', () => {
+        var categoriesModels = job.getSubCategoriesModels(category, catalogId, 'default');
+        expect(categoriesModels).toMatchSnapshot();
+    });
+    test('french locale', () => {
+        var categoriesModels = job.getSubCategoriesModels(category, catalogId, 'fr');
+        expect(categoriesModels).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
This PR introduce a new job step that exports all categories and send them to Algolia.
This job step follow the same logic than the current `categoryIndexJob` step:
- Iterate over the top categories: https://github.com/algolia/algoliasearch-sfcc-b2c/blob/c41b465530f93337d70986731f265661d1796d44/cartridges/int_algolia/cartridge/scripts/algolia/job/categoryIndexJob.js#L249
- For each, browse the subcategories in order to build objects ready to be indexed: https://github.com/algolia/algoliasearch-sfcc-b2c/blob/c41b465530f93337d70986731f265661d1796d44/cartridges/int_algolia/cartridge/scripts/algolia/job/categoryIndexJob.js#L97


The `prepareListOfCategories` function is now named `getSubCategoriesModels`. The differences are:
- It's pure: it returns an array with the categories object instead of adding it to a global `listOfCategories` object
- It uses the recently added model: https://github.com/algolia/algoliasearch-sfcc-b2c/pull/67

The main method, `runCategoryExport`, calls `getSubCategoriesModels` for each locale, creates `AlgoliaOperations` from the returned array, and sends a batch for each top level category.

### Tests :test_tube: 

Added unit tests for both `getSubCategoriesModels` and `runCategoryExport` methods, with snapshot testing that helps visualizing what the methods produces.

--- 
SFCC-115