### PR TITLE
Fixed steptypes.json to pass validation

### DIFF
--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -15,15 +15,13 @@
 						"@name": "consumer",
 						"@type": "string",
 						"description": "The name of the consumer to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the deltaExportJobName parameter.",
-						"@required": "true",
-						"@trim": "true"
+						"@required": "true"
 					},
 					{
 						"@name": "deltaExportJobName",
 						"@type": "string",
 						"description": "The name of the delta export job to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the consumer parameter.",
-						"@required": "true",
-						"@trim": "true"
+						"@required": "true"
 					}
 				]
 			},
@@ -55,7 +53,14 @@
 			"timeout-in-seconds": "600",
 			"parameters": {},
 			"status-codes": {
-				"status": []
+				"status": [{
+					"@code": "ERROR",
+					"description": "Used when the step failed with an error."
+				},
+				{
+					"@code": "OK",
+					"description": "Used when the step finished successfully."
+				}]
 			}
 		}],
 		"chunk-script-module-step": [{

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -14,14 +14,14 @@
 				"parameter": [{
 						"@name": "consumer",
 						"@type": "string",
-						"@description": "The name of the consumer to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the deltaExportJobName parameter.",
+						"description": "The name of the consumer to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the deltaExportJobName parameter.",
 						"@required": "true",
 						"@trim": "true"
 					},
 					{
 						"@name": "deltaExportJobName",
 						"@type": "string",
-						"@description": "The name of the delta export job to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the consumer parameter.",
+						"description": "The name of the delta export job to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the consumer parameter.",
 						"@required": "true",
 						"@trim": "true"
 					}
@@ -54,7 +54,9 @@
 			"transactional": "false",
 			"timeout-in-seconds": "600",
 			"parameters": {},
-			"status-codes": {}
+			"status-codes": {
+				"status": []
+			}
 		}],
 		"chunk-script-module-step": [{
 				"@type-id": "custom.sendChunkOrientedProductUpdates",
@@ -78,21 +80,20 @@
 					"parameter": [{
 							"@name": "resourceType",
 							"@type": "string",
-							"@description": "Used for logging purposes only [ price | product | inventory ]",
-							"@required": true,
-							"trim": true
+							"description": "Used for logging purposes only [ price | product | inventory ]",
+							"@required": true
 						},
 						{
 							"@name": "fieldListOverride",
 							"@type": "string",
-							"@description": "A comma-separated list of fields to be updated in the index. If not specified, the default list of fields will be used (defaultAttributes + Algolia_CustomFields).",
+							"description": "A comma-separated list of fields to be updated in the index. If not specified, the default list of fields will be used (defaultAttributes + Algolia_CustomFields).",
 							"@required": false,
 							"@trim": true
 						},
 						{
 							"@name": "fullRecordUpdate",
 							"@type": "boolean",
-							"@description": "Determines whether the step will perform a full record update or a partial record update. A full record update will replace the entire record in the index with the new data. A partial record update will only update the specified fields in the index.",
+							"description": "Determines whether the step will perform a full record update or a partial record update. A full record update will replace the entire record in the index with the new data. A partial record update will only update the specified fields in the index.",
 							"@required": false
 						}
 					]
@@ -132,28 +133,26 @@
 					"parameter": [{
 							"@name": "consumer",
 							"@type": "string",
-							"@description": "The name of the consumer to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the deltaExportJobName parameter.",
-							"@required": true,
-							"@trim": true
+							"description": "The name of the consumer to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the deltaExportJobName parameter.",
+							"@required": true
 						},
 						{
 							"@name": "deltaExportJobName",
 							"@type": "string",
-							"@description": "The name of the delta export job to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the consumer parameter.",
-							"@required": true,
-							"@trim": true
+							"description": "The name of the delta export job to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the consumer parameter.",
+							"@required": true
 						},
 						{
 							"@name": "fieldListOverride",
 							"@type": "string",
-							"@description": "A comma-separated list of fields to be updated in the index. If not specified, the default list of fields will be used (defaultAttributes + Algolia_CustomFields).",
+							"description": "A comma-separated list of fields to be updated in the index. If not specified, the default list of fields will be used (defaultAttributes + Algolia_CustomFields).",
 							"@required": false,
 							"@trim": true
 						},
 						{
 							"@name": "indexingMethod",
 							"@type": "string",
-							"@description": "Determines whether the step will perform a full record update or a partial record update. A full record update will replace the entire record in the index with the new data. A partial record update will only update the specified fields in the index.",
+							"description": "Determines whether the step will perform a full record update or a partial record update. A full record update will replace the entire record in the index with the new data. A partial record update will only update the specified fields in the index.",
 							"@required": "true",
 							"enum-values": {
 								"value": [


### PR DESCRIPTION
Fixed `steptypes.json`, it now passes validation.
- changed `@description` to `description`
- removed `@trim` from the shared parameters
- added status codes for `custom.algoliaSendCategories` step