### PR TITLE
fix: steptypes

### DIFF
--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -144,15 +144,13 @@
 							"@name": "consumer",
 							"@type": "string",
 							"description": "The name of the consumer to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the deltaExportJobName parameter.",
-							"@required": true,
-							"@trim": true
+							"@required": true
 						},
 						{
 							"@name": "deltaExportJobName",
 							"@type": "string",
 							"description": "The name of the delta export job to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the consumer parameter.",
-							"@required": true,
-							"@trim": true
+							"@required": true
 						},
 						{
 							"@name": "fieldListOverride",

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -14,12 +14,14 @@
 				"parameter": [{
 						"@name": "consumer",
 						"@type": "string",
+						"description": "The name of the consumer to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the deltaExportJobName parameter.",
 						"@required": "true",
 						"@trim": "true"
 					},
 					{
 						"@name": "deltaExportJobName",
 						"@type": "string",
+						"description": "The name of the delta export job to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the consumer parameter.",
 						"@required": "true",
 						"@trim": "true"
 					}
@@ -53,7 +55,16 @@
 			"timeout-in-seconds": "600",
 			"parameters": {},
 			"status-codes": {
-				"status": []
+				"status": [
+					{
+						"@code": "ERROR",
+						"description": "Used when the step failed with an error."
+					},
+					{
+						"@code": "OK",
+						"description": "Used when the step finished successfully."
+					}
+				]
 			}
 		}],
 		"chunk-script-module-step": [{
@@ -78,18 +89,21 @@
 					"parameter": [{
 							"@name": "resourceType",
 							"@type": "string",
+							"description": "Used for logging purposes only [ price | product | inventory ]",
 							"@required": true,
 							"@trim": true
 						},
 						{
 							"@name": "fieldListOverride",
 							"@type": "string",
+							"description": "A comma-separated list of fields to be updated in the index. If not specified, the default list of fields will be used (defaultAttributes + Algolia_CustomFields).",
 							"@required": false,
 							"@trim": true
 						},
 						{
 							"@name": "fullRecordUpdate",
 							"@type": "boolean",
+							"description": "Determines whether the step will perform a full record update or a partial record update. A full record update will replace the entire record in the index with the new data. A partial record update will only update the specified fields in the index.",
 							"@required": false
 						}
 					]
@@ -129,24 +143,28 @@
 					"parameter": [{
 							"@name": "consumer",
 							"@type": "string",
+							"description": "The name of the consumer to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the deltaExportJobName parameter.",
 							"@required": true,
 							"@trim": true
 						},
 						{
 							"@name": "deltaExportJobName",
 							"@type": "string",
+							"description": "The name of the delta export job to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the consumer parameter.",
 							"@required": true,
 							"@trim": true
 						},
 						{
 							"@name": "fieldListOverride",
 							"@type": "string",
+							"description": "A comma-separated list of fields to be updated in the index. If not specified, the default list of fields will be used (defaultAttributes + Algolia_CustomFields).",
 							"@required": false,
 							"@trim": true
 						},
 						{
 							"@name": "indexingMethod",
 							"@type": "string",
+							"description": "Determines whether the step will perform a full record update or a partial record update. A full record update will replace the entire record in the index with the new data. A partial record update will only update the specified fields in the index.",
 							"@required": "true",
 							"enum-values": {
 								"value": [

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -14,14 +14,12 @@
 				"parameter": [{
 						"@name": "consumer",
 						"@type": "string",
-						"@description": "The name of the consumer to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the deltaExportJobName parameter.",
 						"@required": "true",
 						"@trim": "true"
 					},
 					{
 						"@name": "deltaExportJobName",
 						"@type": "string",
-						"@description": "The name of the delta export job to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the consumer parameter.",
 						"@required": "true",
 						"@trim": "true"
 					}
@@ -54,7 +52,9 @@
 			"transactional": "false",
 			"timeout-in-seconds": "600",
 			"parameters": {},
-			"status-codes": {}
+			"status-codes": {
+				"status": []
+			}
 		}],
 		"chunk-script-module-step": [{
 				"@type-id": "custom.sendChunkOrientedProductUpdates",
@@ -78,21 +78,17 @@
 					"parameter": [{
 							"@name": "resourceType",
 							"@type": "string",
-							"@description": "Used for logging purposes only [ price | product | inventory ]",
-							"@required": true,
-							"trim": true
+							"@required": true
 						},
 						{
 							"@name": "fieldListOverride",
 							"@type": "string",
-							"@description": "A comma-separated list of fields to be updated in the index. If not specified, the default list of fields will be used (defaultAttributes + Algolia_CustomFields).",
 							"@required": false,
 							"@trim": true
 						},
 						{
 							"@name": "fullRecordUpdate",
 							"@type": "boolean",
-							"@description": "Determines whether the step will perform a full record update or a partial record update. A full record update will replace the entire record in the index with the new data. A partial record update will only update the specified fields in the index.",
 							"@required": false
 						}
 					]
@@ -132,28 +128,24 @@
 					"parameter": [{
 							"@name": "consumer",
 							"@type": "string",
-							"@description": "The name of the consumer to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the deltaExportJobName parameter.",
 							"@required": true,
 							"@trim": true
 						},
 						{
 							"@name": "deltaExportJobName",
 							"@type": "string",
-							"@description": "The name of the delta export job to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the consumer parameter.",
 							"@required": true,
 							"@trim": true
 						},
 						{
 							"@name": "fieldListOverride",
 							"@type": "string",
-							"@description": "A comma-separated list of fields to be updated in the index. If not specified, the default list of fields will be used (defaultAttributes + Algolia_CustomFields).",
 							"@required": false,
 							"@trim": true
 						},
 						{
 							"@name": "indexingMethod",
 							"@type": "string",
-							"@description": "Determines whether the step will perform a full record update or a partial record update. A full record update will replace the entire record in the index with the new data. A partial record update will only update the specified fields in the index.",
 							"@required": "true",
 							"enum-values": {
 								"value": [

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -78,7 +78,8 @@
 					"parameter": [{
 							"@name": "resourceType",
 							"@type": "string",
-							"@required": true
+							"@required": true,
+							"@trim": true
 						},
 						{
 							"@name": "fieldListOverride",


### PR DESCRIPTION
Our steptypes file is not valid anymore due to:
- [This commit](https://github.com/algolia/algoliasearch-sfcc-b2c/pull/70/commits/30ab81de0721afc6953e9de500af6c1822aaa1dd) that added some `@description` fields instead of `description`, and a `trim` parameter instead of `@trim`
- The validator that seems to be a bit stricter, and the `algoliaSendCategories`, which wasn't finished yet, was missing a complete `status-code`

Also, it seems that constraints on shared job parameters must match, so we have to remove `@trim` from them.