### PR TITLE
fix(jobs.xml): replace `fullRecordUpdate` with `indexingMethod`

### DIFF
--- a/metadata/algolia/jobs.xml
+++ b/metadata/algolia/jobs.xml
@@ -80,7 +80,6 @@ Make sure to contact SFCC Support to enable delta exports on your instance.</des
                 <parameters>
                     <parameter name="consumer" job-parameter-ref="consumer"/>
                     <parameter name="deltaExportJobName" job-parameter-ref="deltaExportJobName"/>
-                    <parameter name="indexingMethod">fullRecordUpdate</parameter>
                 </parameters>
             </step>
         </flow>
@@ -131,6 +130,7 @@ Relies on B2C Delta Exports to determine which products have been changed since 
                 <parameters>
                     <parameter name="consumer" job-parameter-ref="consumer"/>
                     <parameter name="deltaExportJobName" job-parameter-ref="deltaExportJobName"/>
+                    <parameter name="indexingMethod">fullRecordUpdate</parameter>
                 </parameters>
             </step>
         </flow>

--- a/metadata/algolia/jobs.xml
+++ b/metadata/algolia/jobs.xml
@@ -80,6 +80,7 @@ Make sure to contact SFCC Support to enable delta exports on your instance.</des
                 <parameters>
                     <parameter name="consumer" job-parameter-ref="consumer"/>
                     <parameter name="deltaExportJobName" job-parameter-ref="deltaExportJobName"/>
+                    <parameter name="indexingMethod">fullRecordUpdate</parameter>
                 </parameters>
             </step>
         </flow>

--- a/metadata/algolia/jobs.xml
+++ b/metadata/algolia/jobs.xml
@@ -130,7 +130,6 @@ Relies on B2C Delta Exports to determine which products have been changed since 
                 <parameters>
                     <parameter name="consumer" job-parameter-ref="consumer"/>
                     <parameter name="deltaExportJobName" job-parameter-ref="deltaExportJobName"/>
-                    <parameter name="fullRecordUpdate">true</parameter>
                 </parameters>
             </step>
         </flow>


### PR DESCRIPTION
`fullRecordUpdate` parameter has been removed from the job step in #70, but not from the `AlgoliaNewProductsDeltaExport` job declaration, resulting in the following error when trying to import the jobs:

```
[2023-10-02 16:58:44.575 GMT] INFO Import:  Start
[2023-10-02 16:58:44.575 GMT] INFO ImportFile:  operations/jobs.xml
[2023-10-02 16:58:44.575 GMT] INFO ImportMode:  REPLACE
[2023-10-02 16:58:44.575 GMT] INFO Starting Import of 'jobs' from: operations/jobs.xml
[2023-10-02 16:58:44.975 GMT] WARN [DATAERROR] [107/62] Job: AlgoliaNewProductsDeltaExport: Invalid job [AlgoliaNewProductsDeltaExport]! Invalid flow! Invalid step [algoliaSendChunkOrientedDeltaProductUpdates]! Invalid parameter [fullRecordUpdate]! Parameter is unknown and the step type [custom.sendChunkOrientedDeltaProductUpdates] does not accept unknown parameters!
[2023-10-02 16:58:45.152 GMT] INFO Processed 6 job elements successfully
[2023-10-02 16:58:45.152 GMT] INFO Processed 6 total elements
[2023-10-02 16:58:45.156 GMT] INFO OK  Details:  DataErrorCount=1; DataWarningCount=0; LogFileName=import-jobs-20231002165844568-0.log; error=OK
[2023-10-02 16:58:45.156 GMT] INFO Import:  End
```