### PR TITLE
feat: atomic reindexing

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
@@ -1,0 +1,65 @@
+var logger = require('dw/system/Logger').getLogger('algolia', 'Algolia');
+
+var algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
+var algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
+
+/**
+ * Delete the temporary indices corresponding to the given type and locales
+ * @param {string} indexType - type of the index (products or categories)
+ * @param {string[]} locales - locales for which we want to delete the indices
+ * @return {Object} Algolia taskIDs, in the form: { indexName1: <taskID>, indexName2: <taskID> }
+ */
+function deleteTemporariesIndices(indexType, locales) {
+    var deletionTasks = {};
+    locales.forEach(function(locale) {
+        var tmpIndexName = algoliaData.calculateIndexName(indexType, locale) + '.tmp';
+        var res = algoliaIndexingAPI.deleteIndex(tmpIndexName);
+        if (res.ok) {
+            logger.info(tmpIndexName + ' deleted. ' + JSON.stringify(res.object.body));
+            deletionTasks[tmpIndexName] = res.object.body.taskID;
+        }
+    });
+    return deletionTasks;
+}
+
+/**
+ * Copy the settings of the production indices to the matching temporary index
+ * @param {string} indexType - type of the index (products or categories)
+ * @param {string[]} locales - locales for which we want to copy the index settings
+ * @return {Object} Algolia taskIDs, in the form: { indexName1: <taskID>, indexName2: <taskID> }
+ */
+function copySettingsFromProdIndices(indexType, locales) {
+    var copySettingsTasks = {};
+    locales.forEach(function(locale) {
+        var indexName = algoliaData.calculateIndexName(indexType, locale);
+        var tmpIndexName = indexName + '.tmp';
+        var res = algoliaIndexingAPI.copyIndexSettings(indexName, tmpIndexName);
+        if (res.ok) {
+            logger.info('Settings copied to ' + tmpIndexName);
+            copySettingsTasks[tmpIndexName] = res.object.body.taskID;
+        }
+    });
+    return copySettingsTasks;
+}
+
+/**
+ * Copy the temporary indices to production
+ * @param {string} indexType - type of the index (products or categories)
+ * @param {string[]} locales - locales for which we want to move the indices
+ */
+function moveTemporariesIndices(indexType, locales) {
+    locales.forEach(function(locale) {
+        var indexName = algoliaData.calculateIndexName(indexType, locale);
+        var tmpIndexName = indexName + '.tmp';
+        var res = algoliaIndexingAPI.moveIndex(tmpIndexName, indexName);
+        if (res.ok) {
+            logger.info('Index ' + tmpIndexName + ' moved to ' + indexName);
+        } else {
+            logger.error('Error while moving ' + tmpIndexName + ' to ' + indexName)
+        }
+    });
+}
+
+module.exports.copySettingsFromProdIndices = copySettingsFromProdIndices;
+module.exports.deleteTemporariesIndices = deleteTemporariesIndices;
+module.exports.moveTemporariesIndices = moveTemporariesIndices;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
@@ -9,7 +9,7 @@ var algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
  * @param {string[]} locales - locales for which we want to delete the indices
  * @return {Object} Algolia taskIDs, in the form: { indexName1: <taskID>, indexName2: <taskID> }
  */
-function deleteTemporariesIndices(indexType, locales) {
+function deleteTemporayIndices(indexType, locales) {
     var deletionTasks = {};
     locales.forEach(function(locale) {
         var tmpIndexName = algoliaData.calculateIndexName(indexType, locale) + '.tmp';
@@ -51,7 +51,7 @@ function copySettingsFromProdIndices(indexType, locales) {
  * @param {string} indexType - type of the index (products or categories)
  * @param {string[]} locales - locales for which we want to move the indices
  */
-function moveTemporariesIndices(indexType, locales) {
+function moveTemporaryIndices(indexType, locales) {
     locales.forEach(function(locale) {
         var indexName = algoliaData.calculateIndexName(indexType, locale);
         var tmpIndexName = indexName + '.tmp';
@@ -96,13 +96,13 @@ function finishAtomicReindex(indexType, locales, lastIndexingTasks) {
     waitForTasks(copySettingsTasks);
 
     logger.info('[FinishReindex] Moving temporary indices to production...');
-    moveTemporariesIndices(indexType, locales);
+    moveTemporaryIndices(indexType, locales);
 }
 
-module.exports.deleteTemporariesIndices = deleteTemporariesIndices;
+module.exports.deleteTemporayIndices = deleteTemporayIndices;
 module.exports.finishAtomicReindex = finishAtomicReindex;
 module.exports.waitForTasks = waitForTasks;
 
 // For unit testing
 module.exports.copySettingsFromProdIndices = copySettingsFromProdIndices;
-module.exports.moveTemporariesIndices = moveTemporariesIndices;
+module.exports.moveTemporaryIndices = moveTemporaryIndices;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
@@ -9,7 +9,7 @@ var algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
  * @param {string[]} locales - locales for which we want to delete the indices
  * @return {Object} Algolia taskIDs, in the form: { indexName1: <taskID>, indexName2: <taskID> }
  */
-function deleteTemporayIndices(indexType, locales) {
+function deleteTemporaryIndices(indexType, locales) {
     var deletionTasks = {};
     locales.forEach(function(locale) {
         var tmpIndexName = algoliaData.calculateIndexName(indexType, locale) + '.tmp';
@@ -99,7 +99,7 @@ function finishAtomicReindex(indexType, locales, lastIndexingTasks) {
     moveTemporaryIndices(indexType, locales);
 }
 
-module.exports.deleteTemporayIndices = deleteTemporayIndices;
+module.exports.deleteTemporaryIndices = deleteTemporaryIndices;
 module.exports.finishAtomicReindex = finishAtomicReindex;
 module.exports.waitForTasks = waitForTasks;
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
@@ -17,6 +17,8 @@ function deleteTemporariesIndices(indexType, locales) {
         if (res.ok) {
             logger.info(tmpIndexName + ' deleted. ' + JSON.stringify(res.object.body));
             deletionTasks[tmpIndexName] = res.object.body.taskID;
+        } else {
+            throw new Error('Error while deleting temporary indices: ' + res.getErrorMessage())
         }
     });
     return deletionTasks;
@@ -35,8 +37,10 @@ function copySettingsFromProdIndices(indexType, locales) {
         var tmpIndexName = indexName + '.tmp';
         var res = algoliaIndexingAPI.copyIndexSettings(indexName, tmpIndexName);
         if (res.ok) {
-            logger.info('Settings copied to ' + tmpIndexName);
+            logger.info('Settings copied to ' + tmpIndexName + '. ' + JSON.stringify(res.object.body));
             copySettingsTasks[tmpIndexName] = res.object.body.taskID;
+        } else {
+            throw new Error('Error while copying index settings: ' + res.getErrorMessage())
         }
     });
     return copySettingsTasks;
@@ -53,9 +57,9 @@ function moveTemporariesIndices(indexType, locales) {
         var tmpIndexName = indexName + '.tmp';
         var res = algoliaIndexingAPI.moveIndex(tmpIndexName, indexName);
         if (res.ok) {
-            logger.info('Index ' + tmpIndexName + ' moved to ' + indexName);
+            logger.info('Index ' + tmpIndexName + ' moved to ' + indexName + '. ' + JSON.stringify(res.object.body));
         } else {
-            logger.error('Error while moving ' + tmpIndexName + ' to ' + indexName)
+            logger.error('Error while moving ' + tmpIndexName + ' to ' + indexName + ': ' + res.getErrorMessage());
         }
     });
 }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategories.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategories.js
@@ -70,7 +70,7 @@ function runCategoryExport(parameters) {
 
     try {
         logger.info('Deleting existing temporary indices...');
-        var deletionTasks = reindexHelper.deleteTemporariesIndices('categories', siteLocales.toArray());
+        var deletionTasks = reindexHelper.deleteTemporayIndices('categories', siteLocales.toArray());
         reindexHelper.waitForTasks(deletionTasks);
         logger.info('Temporary indices deleted. Starting indexing...');
     } catch (e) {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategories.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategories.js
@@ -68,7 +68,7 @@ function runCategoryExport(parameters) {
 
     logger.info('Deleting existing temporary indices...');
     var deletionTasks = reindexHelper.deleteTemporariesIndices('categories', siteLocales.toArray());
-    algoliaIndexingAPI.waitForTasks(deletionTasks);
+    reindexHelper.waitForTasks(deletionTasks);
     logger.info('Temporary indices deleted. Starting indexing...');
 
     var status;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategories.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategories.js
@@ -70,7 +70,7 @@ function runCategoryExport(parameters) {
 
     try {
         logger.info('Deleting existing temporary indices...');
-        var deletionTasks = reindexHelper.deleteTemporayIndices('categories', siteLocales.toArray());
+        var deletionTasks = reindexHelper.deleteTemporaryIndices('categories', siteLocales.toArray());
         reindexHelper.waitForTasks(deletionTasks);
         logger.info('Temporary indices deleted. Starting indexing...');
     } catch (e) {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js
@@ -113,7 +113,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     if (indexingMethod === 'fullCatalogReindex') {
         indexingOperation = 'addObject';
         logger.info('Deleting existing temporary indices...');
-        var deletionTasks = reindexHelper.deleteTemporariesIndices('products', siteLocales.toArray());
+        var deletionTasks = reindexHelper.deleteTemporayIndices('products', siteLocales.toArray());
         reindexHelper.waitForTasks(deletionTasks);
         logger.info('Temporary indices deleted.');
     }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js
@@ -114,7 +114,7 @@ exports.beforeStep = function(parameters, stepExecution) {
         indexingOperation = 'addObject';
         logger.info('Deleting existing temporary indices...');
         var deletionTasks = reindexHelper.deleteTemporariesIndices('products', siteLocales.toArray());
-        algoliaIndexingAPI.waitForTasks(deletionTasks);
+        reindexHelper.waitForTasks(deletionTasks);
         logger.info('Temporary indices deleted.');
     }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js
@@ -113,7 +113,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     if (indexingMethod === 'fullCatalogReindex') {
         indexingOperation = 'addObject';
         logger.info('Deleting existing temporary indices...');
-        var deletionTasks = reindexHelper.deleteTemporayIndices('products', siteLocales.toArray());
+        var deletionTasks = reindexHelper.deleteTemporaryIndices('products', siteLocales.toArray());
         reindexHelper.waitForTasks(deletionTasks);
         logger.info('Temporary indices deleted.');
     }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js
@@ -5,7 +5,7 @@ var ProductMgr = require('dw/catalog/ProductMgr');
 var logger;
 
 // job step parameters
-var resourceType, fieldListOverride, fullRecordUpdate;
+var resourceType, fieldListOverride;
 
 // Algolia requires
 var algoliaData, AlgoliaLocalizedProduct, algoliaProductConfig, jobHelper, reindexHelper, algoliaIndexingAPI, sendHelper, productFilter;
@@ -64,8 +64,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     // parameters
     resourceType = parameters.resourceType; // resouceType ( price | inventory | product ) - pass it along to sendChunk()
     fieldListOverride = algoliaData.csvStringToArray(parameters.fieldListOverride); // fieldListOverride - pass it along to sendChunk()
-    fullRecordUpdate = !!parameters.fullRecordUpdate || false;
-    // indexingMethod = parameters.indexingMethod || 'fullCatalogReindex';
+    indexingMethod = parameters.indexingMethod;
 
     if (empty(fieldListOverride)) {
         const customFields = algoliaData.getSetOfArray('CustomFields');
@@ -84,7 +83,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     });
     logger.info('Non-localized attributes: ' + JSON.stringify(nonLocalizedAttributes));
 
-    indexingOperation = fullRecordUpdate ? 'addObject' : 'partialUpdateObject';
+    indexingOperation = indexingMethod === 'partialRecordUpdate' ? 'partialUpdateObject' : 'addObject';
     siteLocales = Site.getCurrent().getAllowedLocales();
     logger.info('Enabled locales for ' + Site.getCurrent().getName() + ': ' + siteLocales.toArray())
 

--- a/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
@@ -148,7 +148,7 @@ function moveIndex(indexNameSrc, indexNameDest) {
  * @param {string} indexName - index name where the task was executed
  * @param {number} taskID - id of the task
  */
-function waitForTask(indexName, taskID) {
+function waitTask(indexName, taskID) {
     var indexingService = algoliaIndexingService.getService();
     var maxRetries = 1000
 
@@ -165,7 +165,7 @@ function waitForTask(indexName, taskID) {
             logger.error(result.getErrorMessage());
         } else {
             if (result.object.body.status === 'published') {
-                logger.info('Task' + taskID + ' published. (' + i + ' requests sent).');
+                logger.info('Task ' + taskID + ' published. (' + i + ' requests sent).');
                 return;
             }
         }
@@ -173,23 +173,9 @@ function waitForTask(indexName, taskID) {
     logger.info('Max wait time reached, continuing...');
 }
 
-/**
- * Wait for multiple Algolia tasks to complete.
- * This method takes the "taskID" object structure returned by the multi-indices batch write operation and wait for each task to complete.
- * https://www.algolia.com/doc/rest-api/search/#batch-write-operations-multiple-indices
- * @param {Object} taskIDs - object containing a map of { "<indexName>": <taskID> }
- */
-function waitForTasks(taskIDs) {
-    Object.keys(taskIDs).forEach(function (indexName) {
-        logger.info('Waiting for task ' + taskIDs[indexName] + ' on index ' + indexName);
-        waitForTask(indexName, taskIDs[indexName]);
-    });
-}
-
 module.exports.sendBatch = sendBatch;
 module.exports.sendMultiIndicesBatch = sendMultiIndicesBatch;
 module.exports.deleteIndex = deleteIndex;
 module.exports.copyIndexSettings = copyIndexSettings;
 module.exports.moveIndex = moveIndex;
-module.exports.waitForTask = waitForTask;
-module.exports.waitForTasks = waitForTasks;
+module.exports.waitTask = waitTask;

--- a/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
@@ -150,9 +150,12 @@ function moveIndex(indexNameSrc, indexNameDest) {
  */
 function waitTask(indexName, taskID) {
     var indexingService = algoliaIndexingService.getService();
-    var maxRetries = 1000
+    var maxWait = 3 * 60 * 1000;
+    var start = Date.now();
+    var nbRequestsSent = 0;
 
-    for (let i = 0; i < maxRetries; ++i) {
+    while (Date.now() < start + maxWait) {
+        ++nbRequestsSent;
         var result = retryableCall(
             indexingService,
             {
@@ -165,7 +168,7 @@ function waitTask(indexName, taskID) {
             logger.error(result.getErrorMessage());
         } else {
             if (result.object.body.status === 'published') {
-                logger.info('Task ' + taskID + ' published. (' + i + ' requests sent).');
+                logger.info('Task ' + taskID + ' published. (' + nbRequestsSent + ' requests sent).');
                 return;
             }
         }

--- a/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
@@ -150,7 +150,7 @@ function moveIndex(indexNameSrc, indexNameDest) {
  */
 function waitTask(indexName, taskID) {
     var indexingService = algoliaIndexingService.getService();
-    var maxWait = 3 * 60 * 1000;
+    var maxWait = 5 * 60 * 1000;
     var start = Date.now();
     var nbRequestsSent = 0;
 
@@ -173,7 +173,8 @@ function waitTask(indexName, taskID) {
             }
         }
     }
-    logger.info('Max wait time reached, continuing...');
+    logger.error('Max wait time reached... TaskID: ' + taskID + '; index: ' + indexName);
+    throw new Error('Max wait time reached. TaskID: ' + taskID + '; index: ' + indexName);
 }
 
 module.exports.sendBatch = sendBatch;

--- a/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
@@ -11,7 +11,7 @@ const logger = require('dw/system/Logger').getLogger('algolia');
  * Send a batch of objects to Algolia Indexing API: https://www.algolia.com/doc/rest-api/search/#batch-write-operations
  * @param {string} indexName - name of the index to target
  * @param {Array} requestsArray - array of requests to send to Algolia
- * @returns {dw.system.Status} - successful Status to send
+ * @returns {dw.svc.Result} - result of the call
  */
 function sendBatch(indexName, requestsArray) {
     var indexingService = algoliaIndexingService.getService();
@@ -38,7 +38,7 @@ function sendBatch(indexName, requestsArray) {
  * Send a batch of objects to Algolia Indexing API (multiple indices):
  * https://www.algolia.com/doc/rest-api/search/#batch-write-operations-multiple-indices
  * @param {AlgoliaOperation[]} requestsArray - array of requests to send to Algolia. Each operation must contain the `indexName` to target.
- * @returns {dw.system.Status} - successful Status to send
+ * @returns {dw.svc.Result} - result of the call
  */
 function sendMultiIndicesBatch(requestsArray) {
     var indexingService = algoliaIndexingService.getService();
@@ -61,5 +61,135 @@ function sendMultiIndicesBatch(requestsArray) {
     return result;
 }
 
+/**
+ * Delete index
+ * @param {string} indexName - index to delete
+ * @returns {dw.svc.Result} - result of the call
+ */
+function deleteIndex(indexName) {
+    var indexingService = algoliaIndexingService.getService();
+
+    var result = retryableCall(
+        indexingService,
+        {
+            method: 'DELETE',
+            path: '/1/indexes/' + indexName,
+        }
+    );
+
+    if (!result.ok) {
+        logger.error(result.getErrorMessage());
+    }
+
+    return result;
+}
+
+/**
+ * Copy the settings of an index to another. https://www.algolia.com/doc/rest-api/search/#copymove-index
+ * @param {string} indexNameSrc - index to copy
+ * @param {string} indexNameDest - name of the destination index
+ * @returns {dw.svc.Result} - result of the call
+ */
+function copyIndexSettings(indexNameSrc, indexNameDest) {
+    var indexingService = algoliaIndexingService.getService();
+
+    var result = retryableCall(
+        indexingService,
+        {
+            method: 'POST',
+            path: '/1/indexes/' + indexNameSrc + '/operation',
+            body: {
+                operation: 'copy',
+                destination: indexNameDest,
+                scope: ['settings', 'synonyms', 'rules'],
+            }
+        }
+    );
+
+    if (!result.ok) {
+        logger.error(result.getErrorMessage());
+    }
+
+    return result;
+}
+
+/**
+ * Move an index. https://www.algolia.com/doc/rest-api/search/#copymove-index
+ * @param {string} indexNameSrc - index to move
+ * @param {string} indexNameDest - new name of the index
+ * @returns {dw.svc.Result} - result of the call
+ */
+function moveIndex(indexNameSrc, indexNameDest) {
+    var indexingService = algoliaIndexingService.getService();
+
+    var result = retryableCall(
+        indexingService,
+        {
+            method: 'POST',
+            path: '/1/indexes/' + indexNameSrc + '/operation',
+            body: {
+                operation: 'move',
+                destination: indexNameDest,
+            }
+        }
+    );
+
+    if (!result.ok) {
+        logger.error(result.getErrorMessage());
+    }
+
+    return result;
+}
+
+/**
+ * Wait for an Algolia task to complete.
+ * This method will call the /task endpoint until its status become 'published'
+ * https://www.algolia.com/doc/rest-api/search/#get-a-tasks-status
+ * @param {string} indexName - index name where the task was executed
+ * @param {number} taskID - id of the task
+ */
+function waitForTask(indexName, taskID) {
+    var indexingService = algoliaIndexingService.getService();
+    var maxRetries = 1000
+
+    for (let i = 0; i < maxRetries; ++i) {
+        var result = retryableCall(
+            indexingService,
+            {
+                method: 'GET',
+                path: '/1/indexes/' + indexName + '/task/' + taskID,
+            }
+        );
+
+        if (!result.ok) {
+            logger.error(result.getErrorMessage());
+        } else {
+            if (result.object.body.status === 'published') {
+                logger.info('Task' + taskID + ' published. (' + i + ' requests sent).');
+                return;
+            }
+        }
+    }
+    logger.info('Max wait time reached, continuing...');
+}
+
+/**
+ * Wait for multiple Algolia tasks to complete.
+ * This method takes the "taskID" object structure returned by the multi-indices batch write operation and wait for each task to complete.
+ * https://www.algolia.com/doc/rest-api/search/#batch-write-operations-multiple-indices
+ * @param {Object} taskIDs - object containing a map of { "<indexName>": <taskID> }
+ */
+function waitForTasks(taskIDs) {
+    Object.keys(taskIDs).forEach(function (indexName) {
+        logger.info('Waiting for task ' + taskIDs[indexName] + ' on index ' + indexName);
+        waitForTask(indexName, taskIDs[indexName]);
+    });
+}
+
 module.exports.sendBatch = sendBatch;
 module.exports.sendMultiIndicesBatch = sendMultiIndicesBatch;
+module.exports.deleteIndex = deleteIndex;
+module.exports.copyIndexSettings = copyIndexSettings;
+module.exports.moveIndex = moveIndex;
+module.exports.waitForTask = waitForTask;
+module.exports.waitForTasks = waitForTasks;

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -96,10 +96,18 @@
 							"@trim": true
 						},
 						{
-							"@name": "fullRecordUpdate",
-							"@type": "boolean",
-							"description": "Determines whether the step will perform a full record update or a partial record update. A full record update will replace the entire record in the index with the new data. A partial record update will only update the specified fields in the index.",
-							"@required": false
+							"@name": "indexingMethod",
+							"@type": "string",
+							"description": "Determines whether the step will perform partial records updates, full records updates or a full catalog reindex. A partial record update will only update the specified fields in the index. A full record update will replace the entire record in the index with the new data. A full catalog reindex will create a temporary Algolia index, reindex all your catalog in it, and finally replace the production index with the created temporary index.",
+							"@required": "true",
+							"enum-values": {
+								"value": [
+									"fullCatalogReindex",
+									"fullRecordUpdate",
+									"partialRecordUpdate"
+								]
+							},
+							"default-value": "partialRecordUpdate"
 						}
 					]
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,9 +1,15 @@
 // Initialize some default mocks for all tests.
 
+const GlobalMock = require('./test/mocks/global');
+global.empty = GlobalMock.empty;
+global.request = new GlobalMock.RequestMock();
+
 // System classes, alphabetical order
 jest.mock('dw/catalog/ProductMgr', () => {
     return {
-        queryAllSiteProducts: function() {},
+        queryAllSiteProducts: jest.fn().mockReturnValue({
+            close: jest.fn(),
+        }),
         getProduct: jest.fn(() => {
             const ProductMock = require('./test/mocks/dw/catalog/Product');
             return new ProductMock();

--- a/metadata/algolia/jobs.xml
+++ b/metadata/algolia/jobs.xml
@@ -138,6 +138,28 @@ Relies on B2C Delta Exports to determine which products have been changed since 
         <triggers/>
     </job>
 
+    <job job-id="AlgoliaProductExport_v2" priority="0">
+        <description>Exports all catalog products and index them into Algolia.</description>
+        <parameters/>
+        <flow>
+            <context site-id="RefArch"/>
+            <step step-id="algoliaSendProducts" type="custom.sendChunkOrientedProductUpdates" enforce-restart="false">
+                <description>Exports all catalog products and index them into Algolia.</description>
+                <parameters>
+                    <parameter name="resourceType">products</parameter>
+                    <parameter name="fieldListOverride"/>
+                    <parameter name="indexingMethod">fullRecordUpdate</parameter>
+                </parameters>
+            </step>
+        </flow>
+        <rules>
+            <on-running runtime-threshold="60m" enabled="false">
+                <mark-job-as-hanging/>
+            </on-running>
+        </rules>
+        <triggers/>
+    </job>
+
     <job job-id="AlgoliaProductPricesExport" priority="0">
         <description>Exports price data for each product assigned to the current site.
 Performs a partial update on the product objects in the Algolia index.
@@ -150,7 +172,7 @@ Chunk-based script, supports parallel execution.</description>
                 <parameters>
                     <parameter name="resourceType">price</parameter>
                     <parameter name="fieldListOverride">id, price</parameter>
-                    <parameter name="fullRecordUpdate">false</parameter>
+                    <parameter name="indexingMethod">partialRecordUpdate</parameter>
                 </parameters>
             </step>
         </flow>
@@ -187,7 +209,7 @@ Chunk-based script, supports parallel execution.</description>
                 <parameters>
                     <parameter name="resourceType">inventory</parameter>
                     <parameter name="fieldListOverride">id, in_stock</parameter>
-                    <parameter name="fullRecordUpdate">false</parameter>
+                    <parameter name="indexingMethod">partialRecordUpdate</parameter>
                 </parameters>
             </step>
         </flow>

--- a/test/unit/int_algolia/scripts/algolia/algoliaIndexingAPI.test.js
+++ b/test/unit/int_algolia/scripts/algolia/algoliaIndexingAPI.test.js
@@ -119,30 +119,11 @@ test('waitForTask', () => {
             ok: true,
             object: { body: { status: 'notPublished' }}
         });
-    indexingAPI.waitForTask('testIndex', 33);
+    indexingAPI.waitTask('testIndex', 33);
 
     expect(mockRetryableCall).toHaveBeenCalledTimes(3);
     expect(mockRetryableCall).toHaveBeenCalledWith(mockService, {
         method: 'GET',
         path: '/1/indexes/testIndex/task/33',
-    });
-});
-
-test('waitForTasks', () => {
-    mockRetryableCall
-        .mockReturnValue({
-            ok: true,
-            object: { body: { status: 'published' }}
-        });
-    indexingAPI.waitForTasks({ 'testIndex': 33, 'testIndex2': 51 });
-
-    expect(mockRetryableCall).toHaveBeenCalledTimes(2);
-    expect(mockRetryableCall).toHaveBeenCalledWith(mockService, {
-        method: 'GET',
-        path: '/1/indexes/testIndex/task/33',
-    });
-    expect(mockRetryableCall).toHaveBeenCalledWith(mockService, {
-        method: 'GET',
-        path: '/1/indexes/testIndex2/task/51',
     });
 });

--- a/test/unit/int_algolia/scripts/algolia/helper/reindexHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/reindexHelper.test.js
@@ -1,0 +1,62 @@
+const mockDeleteIndex = jest.fn().mockReturnValue({
+    ok: true,
+    object: {
+        body: {
+            taskID: 42,
+            deletedAt: '2023-10-01T12:00:00.000Z'
+        }
+    }
+});
+const mockCopySettingsFromProdIndices = jest.fn().mockReturnValue({
+    ok: true,
+    object: {
+        body: {
+            taskID: 42,
+            updatedAt: '2023-10-01T12:00:00.000Z'
+        }
+    }
+});
+const mockMoveIndex = jest.fn().mockReturnValue({
+    ok: true,
+    object: {
+        body: {
+            taskID: 42,
+            updatedAt: '2023-10-01T12:00:00.000Z'
+        }
+    }
+});
+jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
+    return {
+        deleteIndex: mockDeleteIndex,
+        copyIndexSettings: mockCopySettingsFromProdIndices,
+        moveIndex: mockMoveIndex,
+    }
+}, {virtual: true});
+
+const reindexHelper = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper');
+
+test('deleteTemporariesIndices', () => {
+    const res = reindexHelper.deleteTemporariesIndices('products', ['fr', 'en']);
+    expect(mockDeleteIndex).nthCalledWith(1, 'test_index___products__fr.tmp');
+    expect(mockDeleteIndex).nthCalledWith(2, 'test_index___products__en.tmp');
+    expect(res).toEqual({
+        "test_index___products__en.tmp": 42,
+        "test_index___products__fr.tmp": 42,
+    });
+});
+
+test('copyIndexSettings', () => {
+    var res = reindexHelper.copySettingsFromProdIndices('products', ['fr', 'en']);
+    expect(mockCopySettingsFromProdIndices).nthCalledWith(1, 'test_index___products__fr', 'test_index___products__fr.tmp');
+    expect(mockCopySettingsFromProdIndices).nthCalledWith(2, 'test_index___products__en', 'test_index___products__en.tmp');
+    expect(res).toEqual({
+        "test_index___products__en.tmp": 42,
+        "test_index___products__fr.tmp": 42,
+    });
+});
+
+test('moveTemporariesIndices', () => {
+    reindexHelper.moveTemporariesIndices('products', ['fr', 'en']);
+    expect(mockMoveIndex).nthCalledWith(1, 'test_index___products__fr.tmp', 'test_index___products__fr');
+    expect(mockMoveIndex).nthCalledWith(2, 'test_index___products__en.tmp', 'test_index___products__en');
+});

--- a/test/unit/int_algolia/scripts/algolia/helper/reindexHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/reindexHelper.test.js
@@ -37,8 +37,8 @@ jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
 
 const reindexHelper = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper');
 
-test('deleteTemporayIndices', () => {
-    const res = reindexHelper.deleteTemporayIndices('products', ['fr', 'en']);
+test('deleteTemporaryIndices', () => {
+    const res = reindexHelper.deleteTemporaryIndices('products', ['fr', 'en']);
     expect(mockDeleteIndex).nthCalledWith(1, 'test_index___products__fr.tmp');
     expect(mockDeleteIndex).nthCalledWith(2, 'test_index___products__en.tmp');
     expect(res).toEqual({

--- a/test/unit/int_algolia/scripts/algolia/helper/reindexHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/reindexHelper.test.js
@@ -25,11 +25,13 @@ const mockMoveIndex = jest.fn().mockReturnValue({
         }
     }
 });
+const mockWaitTask = jest.fn();
 jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
     return {
         deleteIndex: mockDeleteIndex,
         copyIndexSettings: mockCopySettingsFromProdIndices,
         moveIndex: mockMoveIndex,
+        waitTask: mockWaitTask,
     }
 }, {virtual: true});
 
@@ -59,4 +61,17 @@ test('moveTemporariesIndices', () => {
     reindexHelper.moveTemporariesIndices('products', ['fr', 'en']);
     expect(mockMoveIndex).nthCalledWith(1, 'test_index___products__fr.tmp', 'test_index___products__fr');
     expect(mockMoveIndex).nthCalledWith(2, 'test_index___products__en.tmp', 'test_index___products__en');
+});
+
+test('waitForTasks', () => {
+    mockWaitTask
+        .mockReturnValue({
+            ok: true,
+            object: { body: { status: 'published' }}
+        });
+    reindexHelper.waitForTasks({ 'testIndex': 33, 'testIndex2': 51 });
+
+    expect(mockWaitTask).toHaveBeenCalledTimes(2);
+    expect(mockWaitTask).toHaveBeenCalledWith('testIndex', 33);
+    expect(mockWaitTask).toHaveBeenCalledWith('testIndex2', 51);
 });

--- a/test/unit/int_algolia/scripts/algolia/helper/reindexHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/reindexHelper.test.js
@@ -37,8 +37,8 @@ jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
 
 const reindexHelper = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper');
 
-test('deleteTemporariesIndices', () => {
-    const res = reindexHelper.deleteTemporariesIndices('products', ['fr', 'en']);
+test('deleteTemporayIndices', () => {
+    const res = reindexHelper.deleteTemporayIndices('products', ['fr', 'en']);
     expect(mockDeleteIndex).nthCalledWith(1, 'test_index___products__fr.tmp');
     expect(mockDeleteIndex).nthCalledWith(2, 'test_index___products__en.tmp');
     expect(res).toEqual({
@@ -57,8 +57,8 @@ test('copyIndexSettings', () => {
     });
 });
 
-test('moveTemporariesIndices', () => {
-    reindexHelper.moveTemporariesIndices('products', ['fr', 'en']);
+test('moveTemporaryIndices', () => {
+    reindexHelper.moveTemporaryIndices('products', ['fr', 'en']);
     expect(mockMoveIndex).nthCalledWith(1, 'test_index___products__fr.tmp', 'test_index___products__fr');
     expect(mockMoveIndex).nthCalledWith(2, 'test_index___products__en.tmp', 'test_index___products__en');
 });

--- a/test/unit/int_algolia/scripts/algolia/job/__snapshots__/sendCategories.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/job/__snapshots__/sendCategories.test.js.snap
@@ -149,7 +149,7 @@ exports[`runCategoryExport 1`] = `
             "thumbnail": "http://example.com/electronics-thumbnail.jpg",
             "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/electronics",
           },
-          "indexName": "test_index___categories__default",
+          "indexName": "test_index___categories__default.tmp",
         },
         AlgoliaOperation {
           "action": "addObject",
@@ -166,7 +166,7 @@ exports[`runCategoryExport 1`] = `
             "thumbnail": "http://example.com/digital-cameras-thumbnail.jpg",
             "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
           },
-          "indexName": "test_index___categories__default",
+          "indexName": "test_index___categories__default.tmp",
         },
         AlgoliaOperation {
           "action": "addObject",
@@ -186,7 +186,7 @@ exports[`runCategoryExport 1`] = `
             "thumbnail": "http://example.com/audio-thumbnail.jpg",
             "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/audio",
           },
-          "indexName": "test_index___categories__default",
+          "indexName": "test_index___categories__default.tmp",
         },
         AlgoliaOperation {
           "action": "addObject",
@@ -203,7 +203,7 @@ exports[`runCategoryExport 1`] = `
             "thumbnail": "http://example.com/headphones-thumbnail.jpg",
             "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/Search-Show?cgid=storefront-catalog-m-en/headphones",
           },
-          "indexName": "test_index___categories__default",
+          "indexName": "test_index___categories__default.tmp",
         },
         AlgoliaOperation {
           "action": "addObject",
@@ -223,7 +223,7 @@ exports[`runCategoryExport 1`] = `
             "thumbnail": "http://example.com/electronics-thumbnail.jpg",
             "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/electronics",
           },
-          "indexName": "test_index___categories__fr",
+          "indexName": "test_index___categories__fr.tmp",
         },
         AlgoliaOperation {
           "action": "addObject",
@@ -240,7 +240,7 @@ exports[`runCategoryExport 1`] = `
             "thumbnail": "http://example.com/digital-cameras-thumbnail.jpg",
             "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
           },
-          "indexName": "test_index___categories__fr",
+          "indexName": "test_index___categories__fr.tmp",
         },
         AlgoliaOperation {
           "action": "addObject",
@@ -260,7 +260,7 @@ exports[`runCategoryExport 1`] = `
             "thumbnail": "http://example.com/audio-thumbnail.jpg",
             "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/audio",
           },
-          "indexName": "test_index___categories__fr",
+          "indexName": "test_index___categories__fr.tmp",
         },
         AlgoliaOperation {
           "action": "addObject",
@@ -277,7 +277,7 @@ exports[`runCategoryExport 1`] = `
             "thumbnail": "http://example.com/headphones-thumbnail.jpg",
             "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Search-Show?cgid=storefront-catalog-m-en/headphones",
           },
-          "indexName": "test_index___categories__fr",
+          "indexName": "test_index___categories__fr.tmp",
         },
         AlgoliaOperation {
           "action": "addObject",
@@ -297,7 +297,7 @@ exports[`runCategoryExport 1`] = `
             "thumbnail": "http://example.com/electronics-thumbnail.jpg",
             "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/en/Search-Show?cgid=storefront-catalog-m-en/electronics",
           },
-          "indexName": "test_index___categories__en",
+          "indexName": "test_index___categories__en.tmp",
         },
         AlgoliaOperation {
           "action": "addObject",
@@ -314,7 +314,7 @@ exports[`runCategoryExport 1`] = `
             "thumbnail": "http://example.com/digital-cameras-thumbnail.jpg",
             "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/en/Search-Show?cgid=storefront-catalog-m-en/digital-cameras",
           },
-          "indexName": "test_index___categories__en",
+          "indexName": "test_index___categories__en.tmp",
         },
         AlgoliaOperation {
           "action": "addObject",
@@ -334,7 +334,7 @@ exports[`runCategoryExport 1`] = `
             "thumbnail": "http://example.com/audio-thumbnail.jpg",
             "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/en/Search-Show?cgid=storefront-catalog-m-en/audio",
           },
-          "indexName": "test_index___categories__en",
+          "indexName": "test_index___categories__en.tmp",
         },
         AlgoliaOperation {
           "action": "addObject",
@@ -351,7 +351,7 @@ exports[`runCategoryExport 1`] = `
             "thumbnail": "http://example.com/headphones-thumbnail.jpg",
             "url": "https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/en/Search-Show?cgid=storefront-catalog-m-en/headphones",
           },
-          "indexName": "test_index___categories__en",
+          "indexName": "test_index___categories__en.tmp",
         },
       ],
     ],
@@ -360,6 +360,14 @@ exports[`runCategoryExport 1`] = `
     {
       "type": "return",
       "value": {
+        "object": {
+          "body": {
+            "taskID": {
+              "test_index_en": 42,
+              "test_index_fr": 33,
+            },
+          },
+        },
         "ok": true,
       },
     },

--- a/test/unit/int_algolia/scripts/algolia/job/sendCategories.test.js
+++ b/test/unit/int_algolia/scripts/algolia/job/sendCategories.test.js
@@ -60,7 +60,6 @@ const mockSendMultiIndicesBatch = jest.fn().mockReturnValue({
 jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
     return {
         sendMultiIndicesBatch: mockSendMultiIndicesBatch,
-        waitForTasks: jest.fn(),
     }
 }, {virtual: true});
 
@@ -70,6 +69,7 @@ jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
     return {
         deleteTemporariesIndices: mockDeleteTemporariesIndices,
         finishAtomicReindex: mockFinishAtomicReindex,
+        waitForTasks: jest.fn(),
     };
 }, {virtual: true});
 

--- a/test/unit/int_algolia/scripts/algolia/job/sendCategories.test.js
+++ b/test/unit/int_algolia/scripts/algolia/job/sendCategories.test.js
@@ -63,11 +63,11 @@ jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
     }
 }, {virtual: true});
 
-const mockDeleteTemporariesIndices = jest.fn();
+const mockDeleteTemporayIndices = jest.fn();
 const mockFinishAtomicReindex = jest.fn();
 jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
     return {
-        deleteTemporariesIndices: mockDeleteTemporariesIndices,
+        deleteTemporayIndices: mockDeleteTemporayIndices,
         finishAtomicReindex: mockFinishAtomicReindex,
         waitForTasks: jest.fn(),
     };

--- a/test/unit/int_algolia/scripts/algolia/job/sendCategories.test.js
+++ b/test/unit/int_algolia/scripts/algolia/job/sendCategories.test.js
@@ -63,11 +63,11 @@ jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
     }
 }, {virtual: true});
 
-const mockDeleteTemporayIndices = jest.fn();
+const mockDeleteTemporaryIndices = jest.fn();
 const mockFinishAtomicReindex = jest.fn();
 jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
     return {
-        deleteTemporayIndices: mockDeleteTemporayIndices,
+        deleteTemporaryIndices: mockDeleteTemporaryIndices,
         finishAtomicReindex: mockFinishAtomicReindex,
         waitForTasks: jest.fn(),
     };

--- a/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/sendChunkOrientedProductUpdates.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/sendChunkOrientedProductUpdates.test.js.snap
@@ -299,6 +299,305 @@ exports[`process fullCatalogReindex 1`] = `
 ]
 `;
 
+exports[`process fullRecordUpdate 1`] = `
+[
+  AlgoliaOperation {
+    "action": "addObject",
+    "body": {
+      "UPC": "701644031206",
+      "__primary_category": {
+        "0": "Womens",
+        "1": "Womens > Clothing",
+        "2": "Womens > Clothing > Bottoms",
+      },
+      "_tags": [
+        "id:701644031206M",
+      ],
+      "brand": null,
+      "categories": [
+        [
+          {
+            "id": "newarrivals-womens",
+            "name": "Womens",
+          },
+        ],
+        [
+          {
+            "id": "womens-clothing-bottoms",
+            "name": "Bottoms",
+          },
+          {
+            "id": "womens-clothing",
+            "name": "Clothing",
+          },
+          {
+            "id": "womens",
+            "name": "Womens",
+          },
+        ],
+      ],
+      "color": "Hot Pink Combo",
+      "id": "701644031206M",
+      "image_groups": [
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "large",
+        },
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "small",
+        },
+      ],
+      "in_stock": true,
+      "long_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "name": "Floral Dress",
+      "objectID": "701644031206M",
+      "online": true,
+      "pageDescription": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "pageKeywords": null,
+      "pageTitle": "Floral Dress",
+      "price": {
+        "EUR": 92.88,
+        "USD": 129,
+      },
+      "primary_category_id": "womens-clothing-bottoms",
+      "refinementColor": "Pink",
+      "refinementSize": "4",
+      "searchable": true,
+      "short_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "size": "4",
+      "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Product-Show?pid=701644031206M",
+      "variant": true,
+    },
+    "indexName": "test_index___products__default",
+  },
+  AlgoliaOperation {
+    "action": "addObject",
+    "body": {
+      "UPC": "701644031206",
+      "__primary_category": {
+        "0": "Femmes",
+        "1": "Femmes > Vêtements",
+        "2": "Femmes > Vêtements > Bas",
+      },
+      "_tags": [
+        "id:701644031206M",
+      ],
+      "brand": null,
+      "categories": [
+        [
+          {
+            "id": "newarrivals-womens",
+            "name": "Femmes",
+          },
+        ],
+        [
+          {
+            "id": "womens-clothing-bottoms",
+            "name": "Bas",
+          },
+          {
+            "id": "womens-clothing",
+            "name": "Vêtements",
+          },
+          {
+            "id": "womens",
+            "name": "Femmes",
+          },
+        ],
+      ],
+      "color": "Combo rose vif",
+      "id": "701644031206M",
+      "image_groups": [
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "large",
+        },
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "small",
+        },
+      ],
+      "in_stock": true,
+      "long_description": "Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.",
+      "name": "Robe florale",
+      "objectID": "701644031206M",
+      "online": true,
+      "pageDescription": "Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.",
+      "pageKeywords": null,
+      "pageTitle": "Robe florale",
+      "price": {
+        "EUR": 92.88,
+        "USD": 129,
+      },
+      "primary_category_id": "womens-clothing-bottoms",
+      "refinementColor": "Rose",
+      "refinementSize": "4",
+      "searchable": true,
+      "short_description": "Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.",
+      "size": "4",
+      "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Product-Show?pid=701644031206M",
+      "variant": true,
+    },
+    "indexName": "test_index___products__fr",
+  },
+  AlgoliaOperation {
+    "action": "addObject",
+    "body": {
+      "UPC": "701644031206",
+      "__primary_category": {
+        "0": "Womens",
+        "1": "Womens > Clothing",
+        "2": "Womens > Clothing > Bottoms",
+      },
+      "_tags": [
+        "id:701644031206M",
+      ],
+      "brand": null,
+      "categories": [
+        [
+          {
+            "id": "newarrivals-womens",
+            "name": "Womens",
+          },
+        ],
+        [
+          {
+            "id": "womens-clothing-bottoms",
+            "name": "Bottoms",
+          },
+          {
+            "id": "womens-clothing",
+            "name": "Clothing",
+          },
+          {
+            "id": "womens",
+            "name": "Womens",
+          },
+        ],
+      ],
+      "color": "Hot Pink Combo",
+      "id": "701644031206M",
+      "image_groups": [
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "large",
+        },
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "small",
+        },
+      ],
+      "in_stock": true,
+      "long_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "name": "Floral Dress",
+      "objectID": "701644031206M",
+      "online": true,
+      "pageDescription": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "pageKeywords": null,
+      "pageTitle": "Floral Dress",
+      "price": {
+        "EUR": 92.88,
+        "USD": 129,
+      },
+      "primary_category_id": "womens-clothing-bottoms",
+      "refinementColor": "Pink",
+      "refinementSize": "4",
+      "searchable": true,
+      "short_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "size": "4",
+      "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/en/Product-Show?pid=701644031206M",
+      "variant": true,
+    },
+    "indexName": "test_index___products__en",
+  },
+]
+`;
+
 exports[`process partialRecordUpdate 1`] = `
 [
   AlgoliaOperation {

--- a/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/sendChunkOrientedProductUpdates.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/sendChunkOrientedProductUpdates.test.js.snap
@@ -1,6 +1,305 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`process 1`] = `
+exports[`process fullCatalogReindex 1`] = `
+[
+  AlgoliaOperation {
+    "action": "addObject",
+    "body": {
+      "UPC": "701644031206",
+      "__primary_category": {
+        "0": "Womens",
+        "1": "Womens > Clothing",
+        "2": "Womens > Clothing > Bottoms",
+      },
+      "_tags": [
+        "id:701644031206M",
+      ],
+      "brand": null,
+      "categories": [
+        [
+          {
+            "id": "newarrivals-womens",
+            "name": "Womens",
+          },
+        ],
+        [
+          {
+            "id": "womens-clothing-bottoms",
+            "name": "Bottoms",
+          },
+          {
+            "id": "womens-clothing",
+            "name": "Clothing",
+          },
+          {
+            "id": "womens",
+            "name": "Womens",
+          },
+        ],
+      ],
+      "color": "Hot Pink Combo",
+      "id": "701644031206M",
+      "image_groups": [
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "large",
+        },
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "small",
+        },
+      ],
+      "in_stock": true,
+      "long_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "name": "Floral Dress",
+      "objectID": "701644031206M",
+      "online": true,
+      "pageDescription": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "pageKeywords": null,
+      "pageTitle": "Floral Dress",
+      "price": {
+        "EUR": 92.88,
+        "USD": 129,
+      },
+      "primary_category_id": "womens-clothing-bottoms",
+      "refinementColor": "Pink",
+      "refinementSize": "4",
+      "searchable": true,
+      "short_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "size": "4",
+      "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Product-Show?pid=701644031206M",
+      "variant": true,
+    },
+    "indexName": "test_index___products__default.tmp",
+  },
+  AlgoliaOperation {
+    "action": "addObject",
+    "body": {
+      "UPC": "701644031206",
+      "__primary_category": {
+        "0": "Femmes",
+        "1": "Femmes > Vêtements",
+        "2": "Femmes > Vêtements > Bas",
+      },
+      "_tags": [
+        "id:701644031206M",
+      ],
+      "brand": null,
+      "categories": [
+        [
+          {
+            "id": "newarrivals-womens",
+            "name": "Femmes",
+          },
+        ],
+        [
+          {
+            "id": "womens-clothing-bottoms",
+            "name": "Bas",
+          },
+          {
+            "id": "womens-clothing",
+            "name": "Vêtements",
+          },
+          {
+            "id": "womens",
+            "name": "Femmes",
+          },
+        ],
+      ],
+      "color": "Combo rose vif",
+      "id": "701644031206M",
+      "image_groups": [
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "large",
+        },
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "small",
+        },
+      ],
+      "in_stock": true,
+      "long_description": "Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.",
+      "name": "Robe florale",
+      "objectID": "701644031206M",
+      "online": true,
+      "pageDescription": "Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.",
+      "pageKeywords": null,
+      "pageTitle": "Robe florale",
+      "price": {
+        "EUR": 92.88,
+        "USD": 129,
+      },
+      "primary_category_id": "womens-clothing-bottoms",
+      "refinementColor": "Rose",
+      "refinementSize": "4",
+      "searchable": true,
+      "short_description": "Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.",
+      "size": "4",
+      "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Product-Show?pid=701644031206M",
+      "variant": true,
+    },
+    "indexName": "test_index___products__fr.tmp",
+  },
+  AlgoliaOperation {
+    "action": "addObject",
+    "body": {
+      "UPC": "701644031206",
+      "__primary_category": {
+        "0": "Womens",
+        "1": "Womens > Clothing",
+        "2": "Womens > Clothing > Bottoms",
+      },
+      "_tags": [
+        "id:701644031206M",
+      ],
+      "brand": null,
+      "categories": [
+        [
+          {
+            "id": "newarrivals-womens",
+            "name": "Womens",
+          },
+        ],
+        [
+          {
+            "id": "womens-clothing-bottoms",
+            "name": "Bottoms",
+          },
+          {
+            "id": "womens-clothing",
+            "name": "Clothing",
+          },
+          {
+            "id": "womens",
+            "name": "Womens",
+          },
+        ],
+      ],
+      "color": "Hot Pink Combo",
+      "id": "701644031206M",
+      "image_groups": [
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "large",
+        },
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "small",
+        },
+      ],
+      "in_stock": true,
+      "long_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "name": "Floral Dress",
+      "objectID": "701644031206M",
+      "online": true,
+      "pageDescription": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "pageKeywords": null,
+      "pageTitle": "Floral Dress",
+      "price": {
+        "EUR": 92.88,
+        "USD": 129,
+      },
+      "primary_category_id": "womens-clothing-bottoms",
+      "refinementColor": "Pink",
+      "refinementSize": "4",
+      "searchable": true,
+      "short_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "size": "4",
+      "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/en/Product-Show?pid=701644031206M",
+      "variant": true,
+    },
+    "indexName": "test_index___products__en.tmp",
+  },
+]
+`;
+
+exports[`process partialRecordUpdate 1`] = `
 [
   AlgoliaOperation {
     "action": "partialUpdateObject",

--- a/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedProductUpdates.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedProductUpdates.test.js
@@ -6,15 +6,15 @@ global.request = new GlobalMock.RequestMock();
 
 jest.mock('*/cartridge/scripts/algolia/helper/logHelper', () => {}, {virtual: true});
 
-const mockDeleteTemporariesIndices = jest.fn();
+const mockDeleteTemporayIndices = jest.fn();
 const mockCopySettingsFromProdIndices = jest.fn();
-const mockMoveTemporariesIndices = jest.fn();
+const mockMoveTemporaryIndices = jest.fn();
 const mockFinishAtomicReindex = jest.fn();
 jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
     return {
-        deleteTemporariesIndices: mockDeleteTemporariesIndices,
+        deleteTemporayIndices: mockDeleteTemporayIndices,
         copySettingsFromProdIndices: mockCopySettingsFromProdIndices,
-        moveTemporariesIndices: mockMoveTemporariesIndices,
+        moveTemporaryIndices: mockMoveTemporaryIndices,
         finishAtomicReindex: mockFinishAtomicReindex,
         waitForTasks: jest.fn(),
     };
@@ -44,21 +44,21 @@ const job = require('../../../../../../cartridges/int_algolia/cartridge/scripts/
 describe('process', () => {
     test('partialRecordUpdate', () => {
         job.beforeStep({ resourceType: 'test', indexingMethod: 'partialRecordUpdate' });
-        expect(mockDeleteTemporariesIndices).not.toHaveBeenCalled();
+        expect(mockDeleteTemporayIndices).not.toHaveBeenCalled();
 
         var algoliaOperations = job.process(new ProductMock());
         expect(algoliaOperations).toMatchSnapshot();
     });
     test('fullRecordUpdate', () => {
         job.beforeStep({ resourceType: 'test', indexingMethod: 'fullRecordUpdate' });
-        expect(mockDeleteTemporariesIndices).not.toHaveBeenCalled();
+        expect(mockDeleteTemporayIndices).not.toHaveBeenCalled();
 
         var algoliaOperations = job.process(new ProductMock());
         expect(algoliaOperations).toMatchSnapshot();
     });
     test('fullCatalogReindex', () => {
         job.beforeStep({ resourceType: 'test', indexingMethod: 'fullCatalogReindex' });
-        expect(mockDeleteTemporariesIndices).toHaveBeenCalledWith('products', expect.arrayContaining(['default', 'fr', 'en']));
+        expect(mockDeleteTemporayIndices).toHaveBeenCalledWith('products', expect.arrayContaining(['default', 'fr', 'en']));
 
         var algoliaOperations = job.process(new ProductMock());
         expect(algoliaOperations).toMatchSnapshot();

--- a/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedProductUpdates.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedProductUpdates.test.js
@@ -49,6 +49,13 @@ describe('process', () => {
         var algoliaOperations = job.process(new ProductMock());
         expect(algoliaOperations).toMatchSnapshot();
     });
+    test('fullRecordUpdate', () => {
+        job.beforeStep({ resourceType: 'test', indexingMethod: 'fullRecordUpdate' });
+        expect(mockDeleteTemporariesIndices).not.toHaveBeenCalled();
+
+        var algoliaOperations = job.process(new ProductMock());
+        expect(algoliaOperations).toMatchSnapshot();
+    });
     test('fullCatalogReindex', () => {
         job.beforeStep({ resourceType: 'test', indexingMethod: 'fullCatalogReindex' });
         expect(mockDeleteTemporariesIndices).toHaveBeenCalledWith('products', expect.arrayContaining(['default', 'fr', 'en']));

--- a/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedProductUpdates.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedProductUpdates.test.js
@@ -6,13 +6,13 @@ global.request = new GlobalMock.RequestMock();
 
 jest.mock('*/cartridge/scripts/algolia/helper/logHelper', () => {}, {virtual: true});
 
-const mockDeleteTemporayIndices = jest.fn();
+const mockDeleteTemporaryIndices = jest.fn();
 const mockCopySettingsFromProdIndices = jest.fn();
 const mockMoveTemporaryIndices = jest.fn();
 const mockFinishAtomicReindex = jest.fn();
 jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
     return {
-        deleteTemporayIndices: mockDeleteTemporayIndices,
+        deleteTemporaryIndices: mockDeleteTemporaryIndices,
         copySettingsFromProdIndices: mockCopySettingsFromProdIndices,
         moveTemporaryIndices: mockMoveTemporaryIndices,
         finishAtomicReindex: mockFinishAtomicReindex,
@@ -44,21 +44,21 @@ const job = require('../../../../../../cartridges/int_algolia/cartridge/scripts/
 describe('process', () => {
     test('partialRecordUpdate', () => {
         job.beforeStep({ resourceType: 'test', indexingMethod: 'partialRecordUpdate' });
-        expect(mockDeleteTemporayIndices).not.toHaveBeenCalled();
+        expect(mockDeleteTemporaryIndices).not.toHaveBeenCalled();
 
         var algoliaOperations = job.process(new ProductMock());
         expect(algoliaOperations).toMatchSnapshot();
     });
     test('fullRecordUpdate', () => {
         job.beforeStep({ resourceType: 'test', indexingMethod: 'fullRecordUpdate' });
-        expect(mockDeleteTemporayIndices).not.toHaveBeenCalled();
+        expect(mockDeleteTemporaryIndices).not.toHaveBeenCalled();
 
         var algoliaOperations = job.process(new ProductMock());
         expect(algoliaOperations).toMatchSnapshot();
     });
     test('fullCatalogReindex', () => {
         job.beforeStep({ resourceType: 'test', indexingMethod: 'fullCatalogReindex' });
-        expect(mockDeleteTemporayIndices).toHaveBeenCalledWith('products', expect.arrayContaining(['default', 'fr', 'en']));
+        expect(mockDeleteTemporaryIndices).toHaveBeenCalledWith('products', expect.arrayContaining(['default', 'fr', 'en']));
 
         var algoliaOperations = job.process(new ProductMock());
         expect(algoliaOperations).toMatchSnapshot();

--- a/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedProductUpdates.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedProductUpdates.test.js
@@ -4,19 +4,58 @@ const ProductMock = require('../../../../../mocks/dw/catalog/Product');
 global.empty = GlobalMock.empty;
 global.request = new GlobalMock.RequestMock();
 
-const mockSendMultiIndicesBatch = jest.fn().mockReturnValue({ ok: true });
+jest.mock('*/cartridge/scripts/algolia/helper/logHelper', () => {}, {virtual: true});
+
+const mockDeleteTemporariesIndices = jest.fn();
+const mockCopySettingsFromProdIndices = jest.fn();
+const mockMoveTemporariesIndices = jest.fn();
+const mockFinishAtomicReindex = jest.fn();
+jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
+    return {
+        deleteTemporariesIndices: mockDeleteTemporariesIndices,
+        copySettingsFromProdIndices: mockCopySettingsFromProdIndices,
+        moveTemporariesIndices: mockMoveTemporariesIndices,
+        finishAtomicReindex: mockFinishAtomicReindex,
+    };
+}, {virtual: true});
+
+jest.mock('*/cartridge/scripts/services/algoliaIndexingService', () => {}, {virtual: true});
+
+const mockSendMultiIndicesBatch = jest.fn().mockReturnValue({
+    ok: true,
+    object: {
+        body: {
+            taskID: {
+                test_index_fr: 42,
+                test_index_en: 51,
+            }
+        }
+    }
+});
 jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
     return {
         sendMultiIndicesBatch: mockSendMultiIndicesBatch,
+        waitForTasks: jest.fn(),
     }
 }, {virtual: true});
 
 const job = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates');
 
-test('process', () => {
-    job.beforeStep({ resourceType: 'test' });
-    var algoliaOperations = job.process(new ProductMock());
-    expect(algoliaOperations).toMatchSnapshot();
+describe('process', () => {
+    test('partialRecordUpdate', () => {
+        job.beforeStep({ resourceType: 'test', indexingMethod: 'partialRecordUpdate' });
+        expect(mockDeleteTemporariesIndices).not.toHaveBeenCalled();
+
+        var algoliaOperations = job.process(new ProductMock());
+        expect(algoliaOperations).toMatchSnapshot();
+    });
+    test('fullCatalogReindex', () => {
+        job.beforeStep({ resourceType: 'test', indexingMethod: 'fullCatalogReindex' });
+        expect(mockDeleteTemporariesIndices).toHaveBeenCalledWith('products', expect.arrayContaining(['default', 'fr', 'en']));
+
+        var algoliaOperations = job.process(new ProductMock());
+        expect(algoliaOperations).toMatchSnapshot();
+    });
 });
 
 test('send', () => {
@@ -40,4 +79,25 @@ test('send', () => {
     job.send(algoliaOperationsChunk);
 
     expect(mockSendMultiIndicesBatch).toHaveBeenCalledWith(algoliaOperationsChunk.flat());
+});
+
+describe('afterStep', () => {
+    beforeAll(() => {
+        job.__setLastIndexingTasks({ "test_index_fr": 42, "test_index_en": 51 });
+    });
+
+    test('partialRecordUpdate', () => {
+        job.beforeStep({ resourceType: 'test', indexingMethod: 'partialRecordUpdate' });
+        job.afterStep();
+        expect(mockFinishAtomicReindex).not.toHaveBeenCalled();
+    });
+    test('fullCatalogReindex', () => {
+        job.beforeStep({ resourceType: 'test', indexingMethod: 'fullCatalogReindex' });
+        job.afterStep();
+        expect(mockFinishAtomicReindex).toHaveBeenCalledWith(
+            'products',
+            expect.arrayContaining(['default', 'fr', 'en']),
+            { "test_index_fr": 42, "test_index_en": 51 }
+        );
+    });
 });

--- a/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedProductUpdates.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedProductUpdates.test.js
@@ -16,6 +16,7 @@ jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
         copySettingsFromProdIndices: mockCopySettingsFromProdIndices,
         moveTemporariesIndices: mockMoveTemporariesIndices,
         finishAtomicReindex: mockFinishAtomicReindex,
+        waitForTasks: jest.fn(),
     };
 }, {virtual: true});
 
@@ -35,7 +36,6 @@ const mockSendMultiIndicesBatch = jest.fn().mockReturnValue({
 jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
     return {
         sendMultiIndicesBatch: mockSendMultiIndicesBatch,
-        waitForTasks: jest.fn(),
     }
 }, {virtual: true});
 


### PR DESCRIPTION
This PR adds the atomic reindexing logic to the `sendCategories` and `sendChunkOrientedProductUpdates` jobs.
An atomic reindex does the following:
- Delete any of the temporaries indices
- Index all products or categories into the temporary indices
- Copy the settings of the production indices on the temporary indices
- Move the temporary indices to production

### Changes

- Added new methods to `algoliaIndexingAPI`:
  - `deleteIndex`
  - `copyIndexSettings`
  - `moveIndex`
  - `waitTask`, that continuously poll the Algolia tasks API until a task is processed, for a maximum of 5 min
- Created a `reindexHelper`, to perform the needed operations to Algolia based on the indexType (products or categories) and the available locales:
  - delete the temporary indices
  - copy the settings
  - move the temporary indices
- Added `indexingMode` parameter to the sendProducts step, and use it to trigger the logic presented above
- Added `AlgoliaProductExport_v2` job definition

Methods of the `reindexHelper` will throw in case of error, so the jobs will be aborted before any data is lost (production indices are only overwritten at the very end).

### How to test :test_tube: 

I've added unit tests and updated the existing ones.

To test manually:
- Import the jobs definition
- Delete your Algolia indices
- Trigger the AlgoliaProductExport_v2 with `indexingMode=fullRecordUpdate`. You will see the indices being created directly (no `.tmp` index
- Trigger the AlgoliaProductExport_v2 again with `indexingMode=fullCatalogReindex`. You will see temporary indices being created during the process, and then moved to the production indices

---
SFCC-116