### PR TITLE
chore: default jobs names, descriptions and parameters

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js
@@ -64,7 +64,18 @@ exports.beforeStep = function(parameters, stepExecution) {
     // parameters
     resourceType = parameters.resourceType; // resouceType ( price | inventory | product ) - pass it along to sendChunk()
     fieldListOverride = algoliaData.csvStringToArray(parameters.fieldListOverride); // fieldListOverride - pass it along to sendChunk()
-    indexingMethod = parameters.indexingMethod;
+    indexingMethod = parameters.indexingMethod || 'partialRecordUpdate';
+
+    switch (indexingMethod) {
+        case 'fullRecordUpdate':
+        case 'fullCatalogReindexUpdate':
+            indexingOperation = 'addObject';
+            break;
+        case 'partialRecordUpdate':
+        default:
+            indexingOperation = 'partialUpdateObject';
+            break;
+    }
 
     if (empty(fieldListOverride)) {
         const customFields = algoliaData.getSetOfArray('CustomFields');
@@ -83,7 +94,6 @@ exports.beforeStep = function(parameters, stepExecution) {
     });
     logger.info('Non-localized attributes: ' + JSON.stringify(nonLocalizedAttributes));
 
-    indexingOperation = indexingMethod === 'partialRecordUpdate' ? 'partialUpdateObject' : 'addObject';
     siteLocales = Site.getCurrent().getAllowedLocales();
     logger.info('Enabled locales for ' + Site.getCurrent().getName() + ': ' + siteLocales.toArray())
 

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -42,11 +42,11 @@
 			}
 		},
 		{
-			"@type-id": "custom.algoliaSendCategories",
+			"@type-id": "custom.algoliaCategoriesIndex",
 			"@supports-parallel-execution": "false",
 			"@supports-site-context": "true",
 			"@supports-organization-context": "false",
-			"description": "Index the site's categories into Algolia",
+			"description": "Index all categories assigned to the selected site to Algolia.",
 			"module": "int_algolia/cartridge/scripts/algolia/job/sendCategories.js",
 			"function": "execute",
 			"transactional": "false",
@@ -64,11 +64,11 @@
 			}
 		}],
 		"chunk-script-module-step": [{
-				"@type-id": "custom.sendChunkOrientedProductUpdates",
+				"@type-id": "custom.algoliaProductsIndex",
 				"@supports-parallel-execution": true,
 				"@supports-site-context": true,
 				"@supports-organization-context": false,
-				"description": "Sends chunk-oriented updates of all products assigned to the selected site to Algolia. Only the specified fields will be updated in the index. Can be used for partially updating the records with only a few attributes or for full record updates.",
+				"description": "Index all products assigned to the selected site to Algolia. Can perform partial records updates, full records updates or a full catalog reindex. See the 'indexingMethod' field for details.",
 				"module": "int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js",
 				"read-function": "read",
 				"process-function": "process",
@@ -98,7 +98,7 @@
 						{
 							"@name": "indexingMethod",
 							"@type": "string",
-							"description": "Determines whether the step will perform partial records updates, full records updates or a full catalog reindex. A partial record update will only update the specified fields in the index. A full record update will replace the entire record in the index with the new data. A full catalog reindex will create a temporary Algolia index, reindex all your catalog in it, and finally replace the production index with the created temporary index.",
+							"description": "'partialRecordUpdate': only the specified fields are updated in the index. 'fullRecordUpdate': replace the entire records in the index with the new data. 'fullCatalogReindex': reindex all products in a temporary Algolia index, and replace the production index at the end.",
 							"@required": "true",
 							"enum-values": {
 								"value": [
@@ -125,11 +125,11 @@
 				}
 			},
 			{
-				"@type-id": "custom.sendChunkOrientedDeltaProductUpdates",
+				"@type-id": "custom.algoliaIndexDeltaProductUpdates",
 				"@supports-parallel-execution": true,
 				"@supports-site-context": true,
 				"@supports-organization-context": false,
-				"description": "Sends chunk-oriented delta updates of products returned by the B2C delta export.",
+				"description": "Takes the product delta export created by SFCC, extracts the PIDs from it, retrieves and enriches the products, then sends them to Algolia. Can perform full records updates or partial records updates. See the 'indexingMethod' field for details.",
 				"module": "int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedDeltaProductUpdates.js",
 				"read-function": "read",
 				"process-function": "process",
@@ -165,7 +165,7 @@
 						{
 							"@name": "indexingMethod",
 							"@type": "string",
-							"description": "Determines whether the step will perform a full record update or a partial record update. A full record update will replace the entire record in the index with the new data. A partial record update will only update the specified fields in the index.",
+							"description": "'partialRecordUpdate': only the specified fields are updated in the index. 'fullRecordUpdate': replace the entire records in the index with the new data.",
 							"@required": "true",
 							"enum-values": {
 								"value": [

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -1,47 +1,6 @@
 {
 	"step-types": {
 		"script-module-step": [{
-			"@type-id": "custom.algoliaSendDeltaExportProducts",
-			"@supports-parallel-execution": "false",
-			"@supports-site-context": "true",
-			"@supports-organization-context": "false",
-			"description": "Takes the product delta export created by SFCC, extracts the PIDs from it, retrieves and enriches the products, then sends them to Algolia. Performs a full update on product objects; product objects in the index are fully replaced with any new data with the same productID (objectID in the index).",
-			"module": "int_algolia/cartridge/scripts/algolia/steps/sendDeltaExportProducts.js",
-			"function": "sendDeltaExportProducts",
-			"transactional": "false",
-			"timeout-in-seconds": "28800",
-			"parameters": {
-				"parameter": [{
-						"@name": "consumer",
-						"@type": "string",
-						"description": "The name of the consumer to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the deltaExportJobName parameter.",
-						"@required": "true"
-					},
-					{
-						"@name": "deltaExportJobName",
-						"@type": "string",
-						"description": "The name of the delta export job to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the consumer parameter.",
-						"@required": "true"
-					}
-				]
-			},
-			"status-codes": {
-				"status": [{
-						"@code": "ERROR",
-						"description": "Used when the step failed with an error."
-					},
-					{
-						"@code": "FINISHED",
-						"description": "Used when the step finished successfully."
-					},
-					{
-						"@code": "FINISHED_WITH_WARNINGS",
-						"description": "Used when the step finished with warnings."
-					}
-				]
-			}
-		},
-		{
 			"@type-id": "custom.algoliaCategoriesIndex",
 			"@supports-parallel-execution": "false",
 			"@supports-site-context": "true",

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -13,13 +13,14 @@
 			"parameters": {},
 			"status-codes": {
 				"status": [{
-					"@code": "ERROR",
-					"description": "Used when the step failed with an error."
-				},
-				{
-					"@code": "OK",
-					"description": "Used when the step finished successfully."
-				}]
+						"@code": "ERROR",
+						"description": "Used when the step failed with an error."
+					},
+					{
+						"@code": "OK",
+						"description": "Used when the step finished successfully."
+					}
+				]
 			}
 		}],
 		"chunk-script-module-step": [{
@@ -67,6 +68,53 @@
 								]
 							},
 							"default-value": "partialRecordUpdate"
+						}
+					]
+
+				},
+				"status-codes": {
+					"status": [{
+							"@code": "ERROR",
+							"description": "Used when the step failed with an error."
+						},
+						{
+							"@code": "OK",
+							"description": "Used when the step finished successfully."
+						}
+					]
+				}
+			},
+			{
+				"@type-id": "custom.algoliaProductsPartialUpdate",
+				"@supports-parallel-execution": true,
+				"@supports-site-context": true,
+				"@supports-organization-context": false,
+				"description": "Update all products assigned to the selected site. The list of indexed attributes is configurable. Performs partial records updates: only the specified fields are updated/added for each record (without affecting other fields). If the record doesn't exist, a new one will be created.",
+				"module": "int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js",
+				"read-function": "read",
+				"process-function": "process",
+				"write-function": "send",
+				"total-count-function": "getTotalCount",
+				"before-step-function": "beforeStep",
+				"before-chunk-function": "",
+				"after-chunk-function": "",
+				"after-step-function": "afterStep",
+				"chunk-size": 500,
+				"transactional": false,
+				"timeout-in-seconds": "14400",
+				"parameters": {
+					"parameter": [{
+							"@name": "resourceType",
+							"@type": "string",
+							"description": "Used for logging purposes only [ price | product | inventory ]",
+							"@required": true
+						},
+						{
+							"@name": "fieldListOverride",
+							"@type": "string",
+							"description": "A comma-separated list of fields to be updated in the index. If not specified, the default list of fields will be used (defaultAttributes + Algolia_CustomFields).",
+							"@required": false,
+							"@trim": true
 						}
 					]
 

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -5,7 +5,7 @@
 			"@supports-parallel-execution": "false",
 			"@supports-site-context": "true",
 			"@supports-organization-context": "false",
-			"description": "Index all categories assigned to the selected site to Algolia.",
+			"description": "Reindex all categories (incl. categories structures) assigned to the selected site to Algolia.",
 			"module": "int_algolia/cartridge/scripts/algolia/job/sendCategories.js",
 			"function": "execute",
 			"transactional": "false",
@@ -27,7 +27,7 @@
 				"@supports-parallel-execution": true,
 				"@supports-site-context": true,
 				"@supports-organization-context": false,
-				"description": "Index all products assigned to the selected site to Algolia. Can perform partial records updates, full records updates or a full catalog reindex. See the 'indexingMethod' field for details.",
+				"description": "Index all products assigned to the selected site. The list of indexed attributes is configurable. Can perform partial records updates, full records updates or a full catalog reindex. See the 'indexingMethod' field for details.",
 				"module": "int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js",
 				"read-function": "read",
 				"process-function": "process",
@@ -57,7 +57,7 @@
 						{
 							"@name": "indexingMethod",
 							"@type": "string",
-							"description": "'partialRecordUpdate': only the specified fields are updated in the index. 'fullRecordUpdate': replace the entire records in the index with the new data. 'fullCatalogReindex': reindex all products in a temporary Algolia index, and replace the production index at the end.",
+							"description": "'partialRecordUpdate': only the specified fields are updated/added for each record (without affecting other fields). If the record doesn't exist, a new one will be created. 'fullRecordUpdate': replace the entire record (or create new records) in the index with the specified data (without removing stale/deleted records). 'fullCatalogReindex': reindex all products (incl. removing stale records).",
 							"@required": "true",
 							"enum-values": {
 								"value": [
@@ -88,7 +88,7 @@
 				"@supports-parallel-execution": true,
 				"@supports-site-context": true,
 				"@supports-organization-context": false,
-				"description": "Takes the product delta export created by SFCC, extracts the PIDs from it, retrieves and enriches the products, then sends them to Algolia. Can perform full records updates or partial records updates. See the 'indexingMethod' field for details.",
+				"description": "Extracts the list of productIDs (of changed products) from a B2C Delta Export, retrieves and enriches the products data, then sends them to Algolia. Can perform full records updates or partial records updates. See the 'indexingMethod' field for details.",
 				"module": "int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedDeltaProductUpdates.js",
 				"read-function": "read",
 				"process-function": "process",
@@ -124,7 +124,7 @@
 						{
 							"@name": "indexingMethod",
 							"@type": "string",
-							"description": "'partialRecordUpdate': only the specified fields are updated in the index. 'fullRecordUpdate': replace the entire records in the index with the new data.",
+							"description": "'partialRecordUpdate': only the specified fields are updated/added for each record (without affecting other fields). If the record doesn't exist, a new one will be created. 'fullRecordUpdate': replace the entire record (or create new records) in the index with the specified data. Deleted products are removed from the index.",
 							"@required": "true",
 							"enum-values": {
 								"value": [

--- a/metadata/algolia/jobs.xml
+++ b/metadata/algolia/jobs.xml
@@ -2,9 +2,8 @@
 <jobs xmlns="http://www.demandware.com/xml/impex/jobs/2015-07-01">
 
     <job job-id="AlgoliaProductsDeltaIndex_v2" priority="0">
-        <description>Sends product updates to Algolia, only for the products that have changed since the last run of this job.
-This method relies on SFCC's built-in Delta Exports feature to calculate the delta, then enriches and transforms the products before sending them to Algolia for indexing.
-Make sure to contact SFCC Support to enable delta exports on your instance.</description>
+        <description>Send product record index updates to Algolia for B2C Product objects assigned to the site that have changed since the last job run (either via BM or a product feed import, max 7 days).
+The job relies on SFCC's built-in Delta Exports feature (needs to be enabled) to calculate the delta, then enriches and transforms the products before sending them to Algolia for indexing.</description>
         <parameters>
             <parameter name="catalogIDs">apparel-catalog, apparel-m-catalog</parameter>
             <parameter name="consumer">algolia</parameter>
@@ -22,8 +21,9 @@ Make sure to contact SFCC Support to enable delta exports on your instance.</des
                 </parameters>
             </step>
             <step step-id="algoliaIndexDeltaProductUpdates" type="custom.algoliaIndexDeltaProductUpdates" enforce-restart="false">
-                <description>Sends delta product updates to Algolia.
-Relies on B2C Delta Exports to determine which products have been changed since the last export.</description>
+                <description>Performs delta index updates on your Algolia product records using the B2C Delta Export feature (needs to be enabled).
+Extracts the list of productIDs (of changed products) from the B2C Delta Export, retrieves and enriches the products data, then sends them to Algolia.
+Can perform full records updates or partial records updates. See the 'indexingMethod' field for details.</description>
                 <parameters>
                     <parameter name="consumer" job-parameter-ref="consumer"/>
                     <parameter name="deltaExportJobName" job-parameter-ref="deltaExportJobName"/>
@@ -36,13 +36,12 @@ Relies on B2C Delta Exports to determine which products have been changed since 
     </job>
 
     <job job-id="AlgoliaCategoriesIndex_v2" priority="0">
-        <description>Index all categories assigned to the selected site to Algolia.</description>
+        <description>Reindex all categories (incl. categories structures) assigned to the selected site to Algolia.</description>
         <parameters/>
         <flow>
             <context site-id="RefArch"/>
             <step step-id="algoliaCategoriesIndex" type="custom.algoliaCategoriesIndex" enforce-restart="false">
-                <description>Index all categories assigned to the selected site to Algolia.
-It will create a temporary Algolia index, reindex all your categories in it, and replace the production index at the end.</description>
+                <description>Reindex all categories (incl. categories structures) assigned to the selected site to Algolia.</description>
             </step>
         </flow>
         <rules/>
@@ -55,7 +54,7 @@ It will create a temporary Algolia index, reindex all your categories in it, and
         <flow>
             <context site-id="RefArch"/>
             <step step-id="algoliaProductsIndex" type="custom.algoliaProductsIndex" enforce-restart="false">
-                <description>Index all products assigned to the selected site to Algolia. Can perform partial records updates, full records updates or a full catalog reindex, depending on the 'indexingMethod':
+                <description>Index all products assigned to the selected site to Algolia. The list of indexed attributes is configurable, and by default contains related price and inventory data for each product. Can perform partial records updates, full records updates or a full catalog reindex, depending on the 'indexingMethod':
 - 'partialRecordUpdate' will only update the specified fields in the index.
 - 'fullRecordUpdate' will replace the entire record in the index with the new data.
 - 'fullCatalogReindex' will create a temporary Algolia index, reindex all your products catalog in it, and replace the production index at the end.</description>

--- a/metadata/algolia/jobs.xml
+++ b/metadata/algolia/jobs.xml
@@ -61,7 +61,7 @@ Can perform full records updates or partial records updates. See the 'indexingMe
                 <parameters>
                     <parameter name="resourceType">products</parameter>
                     <parameter name="fieldListOverride"/>
-                    <parameter name="indexingMethod">fullRecordUpdate</parameter>
+                    <parameter name="indexingMethod">fullCatalogReindex</parameter>
                 </parameters>
             </step>
         </flow>

--- a/metadata/algolia/jobs.xml
+++ b/metadata/algolia/jobs.xml
@@ -104,8 +104,8 @@ Make sure to contact SFCC Support to enable delta exports on your instance.</des
         </triggers>
     </job>
 
-    <job job-id="AlgoliaNewProductsDeltaExport" priority="0">
-        <description>Sends chunk-oriented product delta updates to Algolia.
+    <job job-id="AlgoliaProductsDeltaIndex_v2" priority="0">
+        <description>Sends product updates to Algolia, only for the products that have changed since the last run of this job.
 This method relies on SFCC's built-in Delta Exports feature to calculate the delta, then enriches and transforms the products before sending them to Algolia for indexing.
 Make sure to contact SFCC Support to enable delta exports on your instance.</description>
         <parameters>
@@ -116,7 +116,7 @@ Make sure to contact SFCC Support to enable delta exports on your instance.</des
         <flow>
             <context site-id="RefArch"/>
             <step step-id="catalogDeltaExport" type="CatalogDeltaExport" enforce-restart="false">
-                <description>Standard B2C catalog delta export. The productIDs are extracted from this export, the products retrieved from the database, enriched and sent to Algolia.</description>
+                <description>Standard B2C catalog delta export. The productIDs will be extracted from this export, the products retrieved from the database, enriched and sent to Algolia.</description>
                 <parameters>
                     <parameter name="CatalogIDs" job-parameter-ref="catalogIDs"/>
                     <parameter name="Consumers" job-parameter-ref="consumer"/>
@@ -124,8 +124,8 @@ Make sure to contact SFCC Support to enable delta exports on your instance.</des
                     <parameter name="MasterProductExport">true</parameter>
                 </parameters>
             </step>
-            <step step-id="algoliaSendChunkOrientedDeltaProductUpdates" type="custom.sendChunkOrientedDeltaProductUpdates" enforce-restart="false">
-                <description>Sends chunk-oritented (parallelized) delta product updates to Algolia.
+            <step step-id="algoliaIndexDeltaProductUpdates" type="custom.algoliaIndexDeltaProductUpdates" enforce-restart="false">
+                <description>Sends delta product updates to Algolia.
 Relies on B2C Delta Exports to determine which products have been changed since the last export.</description>
                 <parameters>
                     <parameter name="consumer" job-parameter-ref="consumer"/>
@@ -138,13 +138,34 @@ Relies on B2C Delta Exports to determine which products have been changed since 
         <triggers/>
     </job>
 
-    <job job-id="AlgoliaProductExport_v2" priority="0">
-        <description>Exports all catalog products and index them into Algolia.</description>
+    <job job-id="AlgoliaCategoriesIndex_v2" priority="0">
+        <description>Index all categories assigned to the selected site to Algolia.</description>
         <parameters/>
         <flow>
             <context site-id="RefArch"/>
-            <step step-id="algoliaSendProducts" type="custom.sendChunkOrientedProductUpdates" enforce-restart="false">
-                <description>Exports all catalog products and index them into Algolia.</description>
+            <step step-id="algoliaCategoriesIndex" type="custom.algoliaCategoriesIndex" enforce-restart="false">
+                <description>Index all categories assigned to the selected site to Algolia.
+It will create a temporary Algolia index, reindex all your categories in it, and replace the production index at the end.</description>
+            </step>
+        </flow>
+        <rules>
+            <on-running runtime-threshold="60m" enabled="false">
+                <mark-job-as-hanging/>
+            </on-running>
+        </rules>
+        <triggers/>
+    </job>
+
+    <job job-id="AlgoliaProductsIndex_v2" priority="0">
+        <description>Index all products assigned to the selected site to Algolia.</description>
+        <parameters/>
+        <flow>
+            <context site-id="RefArch"/>
+            <step step-id="algoliaProductsIndex" type="custom.algoliaProductsIndex" enforce-restart="false">
+                <description>Index all products assigned to the selected site to Algolia. Can perform partial records updates, full records updates or a full catalog reindex, depending on the 'indexingMethod':
+- 'partialRecordUpdate' will only update the specified fields in the index.
+- 'fullRecordUpdate' will replace the entire record in the index with the new data.
+- 'fullCatalogReindex' will create a temporary Algolia index, reindex all your products catalog in it, and replace the production index at the end.</description>
                 <parameters>
                     <parameter name="resourceType">products</parameter>
                     <parameter name="fieldListOverride"/>
@@ -160,18 +181,17 @@ Relies on B2C Delta Exports to determine which products have been changed since 
         <triggers/>
     </job>
 
-    <job job-id="AlgoliaProductPricesExport" priority="0">
-        <description>Exports price data for each product assigned to the current site.
-Performs a partial update on the product objects in the Algolia index.
-Chunk-based script, supports parallel execution.</description>
+    <job job-id="AlgoliaProductsPricesIndex_v2" priority="0">
+        <description>Reindex price data for each product assigned to the current site.
+Performs a partial update on the product objects in the Algolia index.</description>
         <parameters/>
         <flow>
             <context site-id="RefArch"/>
-            <step step-id="algoliaSendPartialPriceUpdates" type="custom.sendChunkOrientedProductUpdates" enforce-restart="false">
+            <step step-id="algoliaPricesIndex" type="custom.algoliaProductsIndex" enforce-restart="false">
                 <description>Retrieves and sends price data for all products assigned to the current site. Sends partial product updates to Algolia, updating only the "price" property of the product objects in the index by default.</description>
                 <parameters>
                     <parameter name="resourceType">price</parameter>
-                    <parameter name="fieldListOverride">id, price</parameter>
+                    <parameter name="fieldListOverride">price</parameter>
                     <parameter name="indexingMethod">partialRecordUpdate</parameter>
                 </parameters>
             </step>
@@ -197,18 +217,17 @@ Chunk-based script, supports parallel execution.</description>
         </triggers>
     </job>
 
-    <job job-id="AlgoliaProductInventoryExport" priority="0">
-        <description>Exports inventory data for each product assigned to the current site.
-Performs a partial update on the product objects in the Algolia index.
-Chunk-based script, supports parallel execution.</description>
+    <job job-id="AlgoliaProductsInventoryIndex_v2" priority="0">
+        <description>Reindex inventory data for each product assigned to the current site.
+Performs a partial update on the product objects in the Algolia index.</description>
         <parameters/>
         <flow>
             <context site-id="RefArch"/>
-            <step step-id="algoliaSendPartialInventoryUpdates" type="custom.sendChunkOrientedProductUpdates" enforce-restart="false">
+            <step step-id="algoliaInventoryIndex" type="custom.algoliaProductsIndex" enforce-restart="false">
                 <description>Retrieves and sends inventory data for all products assigned to the current site. Sends partial product updates to Algolia, updating only the "in_stock" property of the product objects in the index by default.</description>
                 <parameters>
                     <parameter name="resourceType">inventory</parameter>
-                    <parameter name="fieldListOverride">id, in_stock</parameter>
+                    <parameter name="fieldListOverride">in_stock</parameter>
                     <parameter name="indexingMethod">partialRecordUpdate</parameter>
                 </parameters>
             </step>

--- a/metadata/algolia/jobs.xml
+++ b/metadata/algolia/jobs.xml
@@ -73,7 +73,7 @@ Can perform full records updates or partial records updates. See the 'indexingMe
         <triggers/>
     </job>
 
-    <job job-id="AlgoliaProductsPricesIndex_v2" priority="0">
+    <job job-id="AlgoliaProductPricesIndex_v2" priority="0">
         <description>Reindex price data for each product assigned to the current site.
 Performs a partial update on the product objects in the Algolia index.</description>
         <parameters/>
@@ -95,7 +95,7 @@ Performs a partial update on the product objects in the Algolia index.</descript
         <triggers/>
     </job>
 
-    <job job-id="AlgoliaProductsInventoryIndex_v2" priority="0">
+    <job job-id="AlgoliaProductInventoryIndex_v2" priority="0">
         <description>Reindex inventory data for each product assigned to the current site.
 Performs a partial update on the product objects in the Algolia index.</description>
         <parameters/>

--- a/metadata/algolia/jobs.xml
+++ b/metadata/algolia/jobs.xml
@@ -55,9 +55,9 @@ Can perform full records updates or partial records updates. See the 'indexingMe
             <context site-id="RefArch"/>
             <step step-id="algoliaProductsIndex" type="custom.algoliaProductsIndex" enforce-restart="false">
                 <description>Index all products assigned to the selected site to Algolia. The list of indexed attributes is configurable, and by default contains related price and inventory data for each product. Can perform partial records updates, full records updates or a full catalog reindex, depending on the 'indexingMethod':
-- 'partialRecordUpdate' will only update the specified fields in the index.
-- 'fullRecordUpdate' will replace the entire record in the index with the new data.
-- 'fullCatalogReindex' will create a temporary Algolia index, reindex all your products catalog in it, and replace the production index at the end.</description>
+- 'partialRecordUpdate': only the specified fields are updated/added for each record (without affecting other fields). If the record doesn't exist, a new one will be created.
+- 'fullRecordUpdate': replace the entire record (or create new records) in the index with the specified data (without removing stale/deleted records).
+- 'fullCatalogReindex': reindex all products (incl. removing stale records).</description>
                 <parameters>
                     <parameter name="resourceType">products</parameter>
                     <parameter name="fieldListOverride"/>

--- a/metadata/algolia/jobs.xml
+++ b/metadata/algolia/jobs.xml
@@ -94,20 +94,7 @@ Performs a partial update on the product objects in the Algolia index.</descript
                 <mark-job-as-hanging/>
             </on-running>
         </rules>
-        <triggers>
-            <run-once enabled="false">
-                <date>2023-07-26Z</date>
-                <time>15:33:00.000Z</time>
-                <rules>
-                    <on-exit status="ERROR">
-                        <retry>
-                            <interval>1m</interval>
-                            <max-retries>3</max-retries>
-                        </retry>
-                    </on-exit>
-                </rules>
-            </run-once>
-        </triggers>
+        <triggers/>
     </job>
 
     <job job-id="AlgoliaProductsInventoryIndex_v2" priority="0">
@@ -130,20 +117,7 @@ Performs a partial update on the product objects in the Algolia index.</descript
                 <mark-job-as-hanging/>
             </on-running>
         </rules>
-        <triggers>
-            <run-once enabled="false">
-                <date>2023-08-01Z</date>
-                <time>16:05:00.000Z</time>
-                <rules>
-                    <on-exit status="ERROR">
-                        <retry>
-                            <interval>1m</interval>
-                            <max-retries>3</max-retries>
-                        </retry>
-                    </on-exit>
-                </rules>
-            </run-once>
-        </triggers>
+        <triggers/>
     </job>
 
 </jobs>

--- a/metadata/algolia/jobs.xml
+++ b/metadata/algolia/jobs.xml
@@ -79,12 +79,11 @@ Performs a partial update on the product objects in the Algolia index.</descript
         <parameters/>
         <flow>
             <context site-id="RefArch"/>
-            <step step-id="algoliaPricesIndex" type="custom.algoliaProductsIndex" enforce-restart="false">
+            <step step-id="algoliaPricesIndex" type="custom.algoliaProductsPartialUpdate" enforce-restart="false">
                 <description>Retrieves and sends price data for all products assigned to the current site. Sends partial product updates to Algolia, updating only the "price" property of the product objects in the index by default.</description>
                 <parameters>
                     <parameter name="resourceType">price</parameter>
                     <parameter name="fieldListOverride">price</parameter>
-                    <parameter name="indexingMethod">partialRecordUpdate</parameter>
                 </parameters>
             </step>
         </flow>
@@ -102,12 +101,11 @@ Performs a partial update on the product objects in the Algolia index.</descript
         <parameters/>
         <flow>
             <context site-id="RefArch"/>
-            <step step-id="algoliaInventoryIndex" type="custom.algoliaProductsIndex" enforce-restart="false">
+            <step step-id="algoliaInventoryIndex" type="custom.algoliaProductsPartialUpdate" enforce-restart="false">
                 <description>Retrieves and sends inventory data for all products assigned to the current site. Sends partial product updates to Algolia, updating only the "in_stock" property of the product objects in the index by default.</description>
                 <parameters>
                     <parameter name="resourceType">inventory</parameter>
                     <parameter name="fieldListOverride">in_stock</parameter>
-                    <parameter name="indexingMethod">partialRecordUpdate</parameter>
                 </parameters>
             </step>
         </flow>

--- a/metadata/algolia/jobs.xml
+++ b/metadata/algolia/jobs.xml
@@ -1,109 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jobs xmlns="http://www.demandware.com/xml/impex/jobs/2015-07-01">
 
-    <job job-id="AlgoliaProductsIndex" priority="0">
-        <description>Export products to Algolia service for update search index files</description>
-        <parameters/>
-        <flow>
-            <context site-id="RefArch"/>
-            <step step-id="calculateProductsDelta" type="ExecuteScriptModule" enforce-restart="false">
-                <description/>
-                <parameters>
-                    <parameter name="ExecuteScriptModule.Module">int_algolia/cartridge/scripts/algolia/job/productsIndexJob.js</parameter>
-                    <parameter name="ExecuteScriptModule.FunctionName">execute</parameter>
-                    <parameter name="ExecuteScriptModule.Transactional">false</parameter>
-                    <parameter name="clearAndRebuild">false</parameter>
-                </parameters>
-            </step>
-            <step step-id="sendProductsDelta" type="ExecuteScriptModule" enforce-restart="false">
-                <description/>
-                <parameters>
-                    <parameter name="ExecuteScriptModule.Module">int_algolia/cartridge/scripts/algolia/job/sendProductsDelta.js</parameter>
-                    <parameter name="ExecuteScriptModule.FunctionName">execute</parameter>
-                    <parameter name="ExecuteScriptModule.Transactional">false</parameter>
-                </parameters>
-            </step>
-        </flow>
-        <rules/>
-        <triggers/>
-    </job>
-
-    <job job-id="AlgoliaCategoriesIndex" priority="0">
-        <description>Export categories to Algolia service for update search index files</description>
-        <parameters/>
-        <flow>
-            <context site-id="RefArch"/>
-            <step step-id="calculateСategoriesDelta" type="ExecuteScriptModule" enforce-restart="false">
-                <description/>
-                <parameters>
-                    <parameter name="ExecuteScriptModule.Module">int_algolia/cartridge/scripts/algolia/job/categoryIndexJob.js</parameter>
-                    <parameter name="ExecuteScriptModule.FunctionName">execute</parameter>
-                    <parameter name="ExecuteScriptModule.Transactional">false</parameter>
-                    <parameter name="clearAndRebuild">false</parameter>
-                </parameters>
-            </step>
-            <step step-id="sendCategoriesDelta" type="ExecuteScriptModule" enforce-restart="false">
-                <description/>
-                <parameters>
-                    <parameter name="ExecuteScriptModule.Module">int_algolia/cartridge/scripts/algolia/job/sendCategoriesDelta.js</parameter>
-                    <parameter name="ExecuteScriptModule.FunctionName">execute</parameter>
-                    <parameter name="ExecuteScriptModule.Transactional">false</parameter>
-                </parameters>
-            </step>
-        </flow>
-        <rules/>
-        <triggers/>
-    </job>
-
-    <job job-id="AlgoliaProductsDeltaExport" priority="0">
-        <description>This is an alternative to the previous delta calculation and sending method which calculates the delta export file by comparing the last full export to the current one, comparing two large XML files.
-This method relies on SFCC's built-in Delta Exports feature to calculate the delta (omitting the delta calculation phase completely and speeding up the process considerably), then enriches and transforms the products before sending them to Algolia for indexing.
-Make sure to contact SFCC Support to enable delta exports on your instance.</description>
-        <parameters>
-            <parameter name="catalogIDs">apparel-catalog, apparel-m-catalog</parameter>
-            <parameter name="consumer">algolia</parameter>
-            <parameter name="deltaExportJobName">productDeltaExport</parameter>
-        </parameters>
-        <flow>
-            <context site-id="RefArch"/>
-            <step step-id="catalogDeltaExport" type="CatalogDeltaExport" enforce-restart="false">
-                <description>Standard B2C catalog delta export. The productIDs are extracted from this export, the products retrieved from the database, enriched and sent to Algolia.</description>
-                <parameters>
-                    <parameter name="CatalogIDs" job-parameter-ref="catalogIDs"/>
-                    <parameter name="Consumers" job-parameter-ref="consumer"/>
-                    <parameter name="ExportFile" job-parameter-ref="deltaExportJobName"/>
-                    <parameter name="MasterProductExport">true</parameter>
-                </parameters>
-            </step>
-            <step step-id="sendDeltaExportProducts" type="custom.algoliaSendDeltaExportProducts" enforce-restart="false">
-                <description>Takes the productIDs from the standard B2C product delta export, retrieves the products from the database, enriches them and then sends them to Algolia.</description>
-                <parameters>
-                    <parameter name="consumer" job-parameter-ref="consumer"/>
-                    <parameter name="deltaExportJobName" job-parameter-ref="deltaExportJobName"/>
-                </parameters>
-            </step>
-        </flow>
-        <rules>
-            <on-running runtime-threshold="60m" enabled="false">
-                <mark-job-as-hanging/>
-            </on-running>
-        </rules>
-        <triggers>
-            <run-once enabled="false">
-                <date>2023-06-13Z</date>
-                <time>21:00:00.000Z</time>
-                <rules>
-                    <on-exit status="ERROR">
-                        <retry>
-                            <interval>30m</interval>
-                            <max-retries>2</max-retries>
-                        </retry>
-                    </on-exit>
-                </rules>
-            </run-once>
-        </triggers>
-    </job>
-
     <job job-id="AlgoliaProductsDeltaIndex_v2" priority="0">
         <description>Sends product updates to Algolia, only for the products that have changed since the last run of this job.
 This method relies on SFCC's built-in Delta Exports feature to calculate the delta, then enriches and transforms the products before sending them to Algolia for indexing.
@@ -148,11 +45,7 @@ Relies on B2C Delta Exports to determine which products have been changed since 
 It will create a temporary Algolia index, reindex all your categories in it, and replace the production index at the end.</description>
             </step>
         </flow>
-        <rules>
-            <on-running runtime-threshold="60m" enabled="false">
-                <mark-job-as-hanging/>
-            </on-running>
-        </rules>
+        <rules/>
         <triggers/>
     </job>
 

--- a/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/sendChunkOrientedProductUpdates.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/sendChunkOrientedProductUpdates.test.js.snap
@@ -1,5 +1,304 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`process default 1`] = `
+[
+  AlgoliaOperation {
+    "action": "partialUpdateObject",
+    "body": {
+      "UPC": "701644031206",
+      "__primary_category": {
+        "0": "Womens",
+        "1": "Womens > Clothing",
+        "2": "Womens > Clothing > Bottoms",
+      },
+      "_tags": [
+        "id:701644031206M",
+      ],
+      "brand": null,
+      "categories": [
+        [
+          {
+            "id": "newarrivals-womens",
+            "name": "Womens",
+          },
+        ],
+        [
+          {
+            "id": "womens-clothing-bottoms",
+            "name": "Bottoms",
+          },
+          {
+            "id": "womens-clothing",
+            "name": "Clothing",
+          },
+          {
+            "id": "womens",
+            "name": "Womens",
+          },
+        ],
+      ],
+      "color": "Hot Pink Combo",
+      "id": "701644031206M",
+      "image_groups": [
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "large",
+        },
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "small",
+        },
+      ],
+      "in_stock": true,
+      "long_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "name": "Floral Dress",
+      "objectID": "701644031206M",
+      "online": true,
+      "pageDescription": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "pageKeywords": null,
+      "pageTitle": "Floral Dress",
+      "price": {
+        "EUR": 92.88,
+        "USD": 129,
+      },
+      "primary_category_id": "womens-clothing-bottoms",
+      "refinementColor": "Pink",
+      "refinementSize": "4",
+      "searchable": true,
+      "short_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "size": "4",
+      "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Product-Show?pid=701644031206M",
+      "variant": true,
+    },
+    "indexName": "test_index___products__default",
+  },
+  AlgoliaOperation {
+    "action": "partialUpdateObject",
+    "body": {
+      "UPC": "701644031206",
+      "__primary_category": {
+        "0": "Femmes",
+        "1": "Femmes > Vêtements",
+        "2": "Femmes > Vêtements > Bas",
+      },
+      "_tags": [
+        "id:701644031206M",
+      ],
+      "brand": null,
+      "categories": [
+        [
+          {
+            "id": "newarrivals-womens",
+            "name": "Femmes",
+          },
+        ],
+        [
+          {
+            "id": "womens-clothing-bottoms",
+            "name": "Bas",
+          },
+          {
+            "id": "womens-clothing",
+            "name": "Vêtements",
+          },
+          {
+            "id": "womens",
+            "name": "Femmes",
+          },
+        ],
+      ],
+      "color": "Combo rose vif",
+      "id": "701644031206M",
+      "image_groups": [
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "large",
+        },
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "small",
+        },
+      ],
+      "in_stock": true,
+      "long_description": "Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.",
+      "name": "Robe florale",
+      "objectID": "701644031206M",
+      "online": true,
+      "pageDescription": "Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.",
+      "pageKeywords": null,
+      "pageTitle": "Robe florale",
+      "price": {
+        "EUR": 92.88,
+        "USD": 129,
+      },
+      "primary_category_id": "womens-clothing-bottoms",
+      "refinementColor": "Rose",
+      "refinementSize": "4",
+      "searchable": true,
+      "short_description": "Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.",
+      "size": "4",
+      "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Product-Show?pid=701644031206M",
+      "variant": true,
+    },
+    "indexName": "test_index___products__fr",
+  },
+  AlgoliaOperation {
+    "action": "partialUpdateObject",
+    "body": {
+      "UPC": "701644031206",
+      "__primary_category": {
+        "0": "Womens",
+        "1": "Womens > Clothing",
+        "2": "Womens > Clothing > Bottoms",
+      },
+      "_tags": [
+        "id:701644031206M",
+      ],
+      "brand": null,
+      "categories": [
+        [
+          {
+            "id": "newarrivals-womens",
+            "name": "Womens",
+          },
+        ],
+        [
+          {
+            "id": "womens-clothing-bottoms",
+            "name": "Bottoms",
+          },
+          {
+            "id": "womens-clothing",
+            "name": "Clothing",
+          },
+          {
+            "id": "womens",
+            "name": "Womens",
+          },
+        ],
+      ],
+      "color": "Hot Pink Combo",
+      "id": "701644031206M",
+      "image_groups": [
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, large",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "large",
+        },
+        {
+          "_type": "image_group",
+          "images": [
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+            {
+              "_type": "image",
+              "alt": "Floral Dress, Hot Pink Combo, small",
+              "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
+              "title": "Floral Dress, Hot Pink Combo",
+            },
+          ],
+          "view_type": "small",
+        },
+      ],
+      "in_stock": true,
+      "long_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "name": "Floral Dress",
+      "objectID": "701644031206M",
+      "online": true,
+      "pageDescription": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "pageKeywords": null,
+      "pageTitle": "Floral Dress",
+      "price": {
+        "EUR": 92.88,
+        "USD": 129,
+      },
+      "primary_category_id": "womens-clothing-bottoms",
+      "refinementColor": "Pink",
+      "refinementSize": "4",
+      "searchable": true,
+      "short_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
+      "size": "4",
+      "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/en/Product-Show?pid=701644031206M",
+      "variant": true,
+    },
+    "indexName": "test_index___products__en",
+  },
+]
+`;
+
 exports[`process fullCatalogReindex 1`] = `
 [
   AlgoliaOperation {

--- a/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedProductUpdates.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedProductUpdates.test.js
@@ -42,6 +42,13 @@ jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
 const job = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates');
 
 describe('process', () => {
+    test('default', () => {
+        job.beforeStep({ resourceType: 'test' });
+        expect(mockDeleteTemporaryIndices).not.toHaveBeenCalled();
+
+        var algoliaOperations = job.process(new ProductMock());
+        expect(algoliaOperations).toMatchSnapshot(); //  "action" should be "partialUpdateObject" when no indexingMethod is specified
+    });
     test('partialRecordUpdate', () => {
         job.beforeStep({ resourceType: 'test', indexingMethod: 'partialRecordUpdate' });
         expect(mockDeleteTemporaryIndices).not.toHaveBeenCalled();


### PR DESCRIPTION
This PR cleans our jobs and steps definitions:
- remove legacy jobs to keep only the new jobs by default
- standardize the names and descriptions

## Names

Step names updated to:
- `custom.algoliaCategoriesIndex`
- `custom.algoliaProductsIndex`
- `custom.algoliaIndexDeltaProductUpdates`

Jobs name have now a `*Index_v2` suffix so they are clearly identified after importing the jobs, and don't overwrite legacy jobs.

## Descriptions

- Some steps descriptions have been shortened, as the tooltip is hidden otherwise:
![image](https://github.com/algolia/algoliasearch-sfcc-b2c/assets/2042109/e414c93b-6135-46bb-8db1-50e29d3ef74a)

- The details of how each indexing mode works is moved to the `indexingMethod` parameter description, slightly shortened too:
![image](https://github.com/algolia/algoliasearch-sfcc-b2c/assets/2042109/84b58ed7-ddf8-44aa-b7c6-ee8faedc8203)

- Removed some details about the implementation (chunk-based)

## Cleanup

- Removed all legacy jobs and steps from the definitions
- Removed the `triggers`

---
SFCC-155