### PR TITLE
fix: retry batches without faulty records

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
@@ -106,11 +106,11 @@ function finishAtomicReindex(indexType, locales, lastIndexingTasks) {
  * @return {{failedRecords: number}} returns an object with the last call result and the number of failed records.
  */
 function sendRetryableBatch(batch) {
-    var MAX_ATTEMPT = 50;
+    var MAX_ATTEMPTS = 50;
     var attempts = 0;
     var failedRecords = 0;
     var result = algoliaIndexingAPI.sendMultiIndicesBatch(batch);
-    while (result.error && attempts < MAX_ATTEMPT) {
+    while (result.error && attempts < MAX_ATTEMPTS) {
         ++attempts;
         try {
             var apiResponse = JSON.parse(result.getErrorMessage());

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
@@ -99,9 +99,56 @@ function finishAtomicReindex(indexType, locales, lastIndexingTasks) {
     moveTemporaryIndices(indexType, locales);
 }
 
+/**
+ * Sends an Algolia batch to the multi-indices batch endpoint.
+ * If records fail to be indexed (because e.g. they are too big), they are removed from the batch and the batch is retried.
+ * @param {Object} batch - Algolia multi-indices batch
+ * @return {{failedRecords: number}} returns an object with the last call result and the number of failed records.
+ */
+function sendRetryableBatch(batch) {
+    var MAX_ATTEMPT = 50;
+    var attempts = 0;
+    var failedRecords = 0;
+    var result = algoliaIndexingAPI.sendMultiIndicesBatch(batch);
+    while (result.error && attempts < MAX_ATTEMPT) {
+        ++attempts;
+        try {
+            var apiResponse = JSON.parse(result.getErrorMessage());
+            // When records are failing, Algolia returns the following:
+            // {"message":"Record at the position 6 objectID=008884303996M is too big size=11072/10000 bytes. Please have a look at [...]", "position":6,"objectID":"008884303996M","status":400}
+            if (!apiResponse.objectID || !apiResponse.message || !apiResponse.message.startsWith('Record at the position')) {
+                // No faulty record detected, nothing else to do
+                break;
+            }
+            logger.info('[Retryable batch] Removing records for product ' + apiResponse.objectID);
+            for (var i = batch.length - 1; i >= 0; --i) {
+                if (batch[i].body.objectID === apiResponse.objectID) {
+                    logger.info('[Retryable batch] Removing record for product ' + apiResponse.objectID + ' from the batch (index '+ batch[i].indexName + ')');
+                    batch.splice(i, 1);
+                    failedRecords++;
+                }
+            }
+            logger.info('[Retryable batch] Retrying batch...');
+            result = algoliaIndexingAPI.sendMultiIndicesBatch(batch);
+        } catch(e) {
+            // Error message is not JSON, ignoring
+            logger.error('[Retryable batch] Error while parsing response: ' + e.message);
+            break;
+        }
+    }
+    if (attempts === MAX_ATTEMPT) {
+        logger.error('[Retryable batch] Too many products are in error, aborting the batch...');
+    }
+    return {
+        result: result,
+        failedRecords: failedRecords,
+    }
+}
+
 module.exports.deleteTemporaryIndices = deleteTemporaryIndices;
 module.exports.finishAtomicReindex = finishAtomicReindex;
 module.exports.waitForTasks = waitForTasks;
+module.exports.sendRetryableBatch = sendRetryableBatch;
 
 // For unit testing
 module.exports.copySettingsFromProdIndices = copySettingsFromProdIndices;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
@@ -107,11 +107,11 @@ function finishAtomicReindex(indexType, locales, lastIndexingTasks) {
  */
 function sendRetryableBatch(batch) {
     var MAX_ATTEMPTS = 50;
-    var attempts = 0;
+    var attempt = 0;
     var failedRecords = 0;
     var result = algoliaIndexingAPI.sendMultiIndicesBatch(batch);
-    while (result.error && attempts < MAX_ATTEMPTS) {
-        ++attempts;
+    while (result.error && attempt < MAX_ATTEMPTS) {
+        ++attempt;
         try {
             var apiResponse = JSON.parse(result.getErrorMessage());
             // When records are failing, Algolia returns the following:
@@ -136,7 +136,7 @@ function sendRetryableBatch(batch) {
             break;
         }
     }
-    if (attempts === MAX_ATTEMPTS) {
+    if (attempt === MAX_ATTEMPTS) {
         logger.error('[Retryable batch] Too many products are in error, aborting the batch...');
     }
     return {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
@@ -136,7 +136,7 @@ function sendRetryableBatch(batch) {
             break;
         }
     }
-    if (attempts === MAX_ATTEMPT) {
+    if (attempts === MAX_ATTEMPTS) {
         logger.error('[Retryable batch] Too many products are in error, aborting the batch...');
     }
     return {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategories.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategories.js
@@ -107,7 +107,10 @@ function runCategoryExport(parameters, stepExecution) {
         }
 
         logger.info('Sending a batch of ' + batch.length + ' records for top-level category id: ' + category.getID());
-        status = algoliaIndexingAPI.sendMultiIndicesBatch(batch);
+        var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
+        status = retryableBatchRes.result;
+        categoryLogData.failedRecords += retryableBatchRes.failedRecords;
+
         if (status.error) {
             categoryLogData.failedRecords += batch.length;
             categoryLogData.failedChunks++;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedDeltaProductUpdates.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedDeltaProductUpdates.js
@@ -9,7 +9,7 @@ var logger;
 var paramConsumer, paramDeltaExportJobName, paramFieldListOverride, paramIndexingMethod;
 
 // Algolia requires
-var algoliaData, AlgoliaLocalizedProduct, algoliaProductConfig, jobHelper, fileHelper, algoliaIndexingAPI, sendHelper, productFilter, CPObjectIterator;
+var algoliaData, AlgoliaLocalizedProduct, algoliaProductConfig, jobHelper, fileHelper, reindexHelper, algoliaIndexingAPI, sendHelper, productFilter, CPObjectIterator;
 
 // logging-related variables and constants
 var logData;
@@ -53,6 +53,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     algoliaProductConfig = require('*/cartridge/scripts/algolia/lib/algoliaProductConfig');
     jobHelper = require('*/cartridge/scripts/algolia/helper/jobHelper');
     fileHelper = require('*/cartridge/scripts/algolia/helper/fileHelper');
+    reindexHelper = require('*/cartridge/scripts/algolia/helper/reindexHelper');
     algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
     logger = require('dw/system/Logger').getLogger('algolia', 'Algolia');
     productFilter = require('*/cartridge/scripts/algolia/filters/productFilter');
@@ -296,7 +297,9 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
         batch = batch.concat(algoliaOperationsArray[i].toArray());
     }
 
-    status = algoliaIndexingAPI.sendMultiIndicesBatch(batch);
+    var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
+    status = retryableBatchRes.result;
+    logData.failedRecords += retryableBatchRes.failedRecords;
 
     if (status.error) {
         logData.failedChunks++;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js
@@ -214,7 +214,10 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
         batch = batch.concat(algoliaOperationsArray[i].toArray());
     }
 
-    status = algoliaIndexingAPI.sendMultiIndicesBatch(batch);
+    var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
+    status = retryableBatchRes.result;
+    logData.failedRecords += retryableBatchRes.failedRecords;
+
     if (status.error) {
         logData.failedChunks++;
         logData.failedRecords += batch.length;

--- a/test/unit/int_algolia/scripts/algolia/helper/reindexHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/reindexHelper.test.js
@@ -26,12 +26,14 @@ const mockMoveIndex = jest.fn().mockReturnValue({
     }
 });
 const mockWaitTask = jest.fn();
+const mockSendMultiIndicesBatch = jest.fn();
 jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
     return {
         deleteIndex: mockDeleteIndex,
         copyIndexSettings: mockCopySettingsFromProdIndices,
         moveIndex: mockMoveIndex,
         waitTask: mockWaitTask,
+        sendMultiIndicesBatch: mockSendMultiIndicesBatch,
     }
 }, {virtual: true});
 
@@ -74,4 +76,54 @@ test('waitForTasks', () => {
     expect(mockWaitTask).toHaveBeenCalledTimes(2);
     expect(mockWaitTask).toHaveBeenCalledWith('testIndex', 33);
     expect(mockWaitTask).toHaveBeenCalledWith('testIndex2', 51);
+});
+
+test('sendRetryableBatch', () => {
+    const batch = [
+        {
+            action: 'addObject',
+            indexName: 'test_index_fr_FR',
+            body: { objectID: 'record1', name: 'record1' },
+        },
+        {
+            action: 'addObject',
+            indexName: 'test_index_en_US',
+            body: { objectID: 'record1', name: 'record1' },
+        },
+        {
+            action: 'addObject',
+            indexName: 'test_index_fr_FR',
+            body: { objectID: 'record2', name: 'record2' },
+        },
+        {
+            action: 'addObject',
+            indexName: 'test_index_en_US',
+            body: { objectID: 'record2', name: 'record2' },
+        }
+        ,
+        {
+            action: 'addObject',
+            indexName: 'test_index_fr_FR',
+            body: { objectID: 'record3', name: 'record3' },
+        },
+        {
+            action: 'addObject',
+            indexName: 'test_index_en_US',
+            body: { objectID: 'record3', name: 'record3' },
+        }
+    ];
+    mockSendMultiIndicesBatch.mockReturnValueOnce({
+        error: true,
+        getErrorMessage: () => '{"message":"Record at the position 0 objectID=record1 is too big size=11072/10000 bytes. Please have a look at https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/in-depth/index-and-records-size-and-usage-limitations/#record-size-limits","position":2,"objectID":"record2","status":400}'
+    });
+    mockSendMultiIndicesBatch.mockReturnValue({
+        ok: true,
+    });
+
+    const res = reindexHelper.sendRetryableBatch(batch);
+
+    expect(mockSendMultiIndicesBatch).toHaveBeenCalledTimes(2);
+    expect(res.result.ok).toBe(true);
+    expect(res.failedRecords).toBe(2);
+    expect(batch.length).toBe(4); // 2 records have been removed
 });

--- a/test/unit/int_algolia/scripts/algolia/job/sendCategories.test.js
+++ b/test/unit/int_algolia/scripts/algolia/job/sendCategories.test.js
@@ -68,7 +68,9 @@ jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
 const mockDeleteTemporaryIndices = jest.fn();
 const mockFinishAtomicReindex = jest.fn();
 jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
+    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper');
     return {
+        sendRetryableBatch: originalModule.sendRetryableBatch,
         deleteTemporaryIndices: mockDeleteTemporaryIndices,
         finishAtomicReindex: mockFinishAtomicReindex,
         waitForTasks: jest.fn(),

--- a/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedDeltaProductUpdates.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedDeltaProductUpdates.test.js
@@ -12,6 +12,12 @@ jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
         sendMultiIndicesBatch: mockSendMultiIndicesBatch,
     }
 }, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
+    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper');
+    return {
+        sendRetryableBatch: originalModule.sendRetryableBatch,
+    }
+}, {virtual: true});
 
 const job = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedDeltaProductUpdates');
 const stepExecution = {

--- a/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedProductUpdates.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/sendChunkOrientedProductUpdates.test.js
@@ -11,7 +11,9 @@ const mockCopySettingsFromProdIndices = jest.fn();
 const mockMoveTemporaryIndices = jest.fn();
 const mockFinishAtomicReindex = jest.fn();
 jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
+    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper');
     return {
+        sendRetryableBatch: originalModule.sendRetryableBatch,
         deleteTemporaryIndices: mockDeleteTemporaryIndices,
         copySettingsFromProdIndices: mockCopySettingsFromProdIndices,
         moveTemporaryIndices: mockMoveTemporaryIndices,


### PR DESCRIPTION
In a Algolia batch, if only a few records are in error, the whole batch is rejected.
To avoid rejecting a whole batch for a few faulty records, this PR introduces a helper that removes the records from the batch and retries to send it, when such error is detected.

### How to test

- Put a description in on of your products that exceed the max record size limit
- Run the AlgoliaProductsIndex_v2 job
- In the logs, you will see something similar to:

```
[2023-10-11 09:47:31.346 GMT] ERROR CustomJobThread|522428417|AlgoliaProductsIndex_v2|algoliaProductsIndex {"message":"Record at the position 729 objectID=008884303996M is too big size=12822/10000 bytes. Please have a look at https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/in-depth/index-and-records-size-and-usage-limitations/#record-size-limits","position":729,"objectID":"008884303996M","status":400}
[2023-10-11 09:47:31.348 GMT] INFO CustomJobThread|522428417|AlgoliaProductsIndex_v2|algoliaProductsIndex [Retryable batch] Removing records for product 008884303996M
[2023-10-11 09:47:31.349 GMT] INFO CustomJobThread|522428417|AlgoliaProductsIndex_v2|algoliaProductsIndex [Retryable batch] Removing record for product 008884303996M from the batch (index sfcc_testing__products__it_IT.tmp)
[2023-10-11 09:47:31.349 GMT] INFO CustomJobThread|522428417|AlgoliaProductsIndex_v2|algoliaProductsIndex [Retryable batch] Removing record for product 008884303996M from the batch (index sfcc_testing__products__fr_FR.tmp)
[2023-10-11 09:47:31.349 GMT] INFO CustomJobThread|522428417|AlgoliaProductsIndex_v2|algoliaProductsIndex [Retryable batch] Removing record for product 008884303996M from the batch (index sfcc_testing__products__en_US.tmp)
[2023-10-11 09:47:31.350 GMT] INFO CustomJobThread|522428417|AlgoliaProductsIndex_v2|algoliaProductsIndex [Retryable batch] Retrying batch...
[2023-10-11 09:48:09.801 GMT] INFO CustomJobThread|522428417|AlgoliaProductsIndex_v2|algoliaProductsIndex Chunks sent: 12; Failed chunks: 0
Records sent: 15,093; Failed records: 3
```
And your Algolia indices will miss one record compared to the previous job runs.