### PR TITLE
feat: update default attributes

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var defaultAttributes = ['id', 'primary_category_id', 'in_stock', 'price', 'categories'];
+var defaultAttributes_v2 = ['name', 'primary_category_id', 'categories', 'in_stock', 'price', 'image_groups', 'url'];
 
 var attributeConfig = {
     id: {
@@ -122,5 +123,6 @@ var attributeConfig = {
 
 module.exports = {
     defaultAttributes: defaultAttributes,
+    defaultAttributes_v2: defaultAttributes_v2,
     attributeConfig: attributeConfig
 };

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -322,10 +322,11 @@ var aggregatedValueHandlers = {
  * @param {dw.order.Product} product - Product
  * @param {string} locale - The requested locale
  * @param {Array} [fieldList] list of attributes to be fetched
- * @param {Object} baseModel - A base model object that contains some pre-fetched properties
+ * @param {Object?} baseModel - (optional) A base model object that contains some pre-fetched properties
+ * @param {boolean?} fullRecordUpdate - (optional) Indicate if the model is meant to fully replace the existing record
  * @constructor
  */
-function algoliaLocalizedProduct(product, locale, fieldList, baseModel) {
+function algoliaLocalizedProduct({ product, locale, fieldList, baseModel, fullRecordUpdate}) {
     request.setLocale(locale || 'default');
 
     if (empty(product) || empty(fieldList)) {
@@ -346,7 +347,7 @@ function algoliaLocalizedProduct(product, locale, fieldList, baseModel) {
                 }
             }
         }
-        if (fieldList.indexOf('name') >= 0) {
+        if (fullRecordUpdate) {
             this._tags = ['id:' + product.ID];
         }
         if (this.primary_category_id && this.categories) {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -321,30 +321,19 @@ var aggregatedValueHandlers = {
  * AlgoliaLocalizedProduct class that represents a localized algoliaProduct ready to be indexed
  * @param {dw.order.Product} product - Product
  * @param {string} locale - The requested locale
- * @param {Array} [fieldListOverride] (optional) if supplied, it overrides the regular list of attributes to be sent (default + customFields)
+ * @param {Array} [fieldList] list of attributes to be fetched
  * @param {Object} baseModel - A base model object that contains some pre-fetched properties
  * @constructor
  */
-function algoliaLocalizedProduct(product, locale, fieldListOverride, baseModel) {
+function algoliaLocalizedProduct(product, locale, fieldList, baseModel) {
     request.setLocale(locale || 'default');
 
-    // list of fields to build the object with
-    let algoliaFields;
-    if (!empty(fieldListOverride)) {
-        // use overridden list of fields
-        algoliaFields = fieldListOverride;
-    } else {
-        // use regular list of fields (default behavior)
-        const customFields = algoliaData.getSetOfArray('CustomFields');
-        algoliaFields = algoliaProductConfig.defaultAttributes.concat(customFields);
-    }
-
-    if (empty(product)) {
+    if (empty(product) || empty(fieldList)) {
         this.id = null;
     } else {
         this.objectID = product.ID;
-        for (var i = 0; i < algoliaFields.length; i += 1) {
-            var attributeName = algoliaFields[i];
+        for (var i = 0; i < fieldList.length; i += 1) {
+            var attributeName = fieldList[i];
             var config = algoliaProductConfig.attributeConfig[attributeName];
 
             if (!empty(config)) {
@@ -357,13 +346,13 @@ function algoliaLocalizedProduct(product, locale, fieldListOverride, baseModel) 
                 }
             }
         }
-        if (algoliaFields.indexOf('id') >= 0) {
+        if (fieldList.indexOf('name') >= 0) {
             this._tags = ['id:' + product.ID];
         }
         if (this.primary_category_id && this.categories) {
             this['__primary_category'] = computePrimaryCategoryHierarchicalFacets(this.categories, this.primary_category_id);
         }
-        productModelCustomizer.customizeLocalizedProductModel(this, algoliaFields);
+        productModelCustomizer.customizeLocalizedProductModel(this, fieldList);
     }
 }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -319,15 +319,20 @@ var aggregatedValueHandlers = {
 
 /**
  * AlgoliaLocalizedProduct class that represents a localized algoliaProduct ready to be indexed
- * @param {dw.order.Product} product - Product
- * @param {string} locale - The requested locale
- * @param {Array} [fieldList] list of attributes to be fetched
- * @param {Object?} baseModel - (optional) A base model object that contains some pre-fetched properties
- * @param {boolean?} fullRecordUpdate - (optional) Indicate if the model is meant to fully replace the existing record
+ * @param {Object} parameters - model parameters
+ * @param {dw.order.Product} parameters.product - Product
+ * @param {string} parameters.locale - The requested locale
+ * @param {Array} parameters.fieldList list of attributes to be fetched
+ * @param {Object?} parameters.baseModel - (optional) A base model object that contains some pre-fetched properties
+ * @param {boolean?} parameters.fullRecordUpdate - (optional) Indicate if the model is meant to fully replace the existing record
  * @constructor
  */
-function algoliaLocalizedProduct({ product, locale, fieldList, baseModel, fullRecordUpdate}) {
-    request.setLocale(locale || 'default');
+function algoliaLocalizedProduct(parameters) {
+    const product = parameters.product;
+    const fieldList = parameters.fieldList;
+    const baseModel = parameters.baseModel;
+
+    request.setLocale(parameters.locale || 'default');
 
     if (empty(product) || empty(fieldList)) {
         this.id = null;
@@ -347,7 +352,7 @@ function algoliaLocalizedProduct({ product, locale, fieldList, baseModel, fullRe
                 }
             }
         }
-        if (fullRecordUpdate) {
+        if (parameters.fullRecordUpdate) {
             this._tags = ['id:' + product.ID];
         }
         if (this.primary_category_id && this.categories) {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -20,6 +20,7 @@ var deltaExportZips, siteLocales, nonLocalizedAttributes = [], fieldsToSend;
 
 var baseIndexingOperation; // 'addObject' or 'partialUpdateObject', depending on the step parameter 'indexingMethod'
 const deleteIndexingOperation = 'deleteObject';
+var fullRecordUpdate = false;
 
 /*
  * Rough algorithm of chunk-oriented script module execution:
@@ -110,6 +111,7 @@ exports.beforeStep = function(parameters, stepExecution) {
         case 'fullRecordUpdate':
         default:
             baseIndexingOperation = 'addObject';
+            fullRecordUpdate = true;
             break;
     }
     logger.info('indexingMethod parameter: ' + paramIndexingMethod);
@@ -269,11 +271,11 @@ exports.process = function(cpObj, parameters, stepExecution) {
         if (productFilter.isInclude(product)) {
 
             // Pre-fetch a partial model containing all non-localized attributes, to avoid re-fetching them for each locale
-            let baseModel = new AlgoliaLocalizedProduct(product, 'default', nonLocalizedAttributes);
+            let baseModel = new AlgoliaLocalizedProduct({ product: product, locale: 'default', fieldList: nonLocalizedAttributes, fullRecordUpdate: fullRecordUpdate });
             for (let l = 0; l < siteLocales.size(); l++) {
                 let locale = siteLocales[l];
                 let indexName = algoliaData.calculateIndexName('products', locale);
-                let localizedProduct = new AlgoliaLocalizedProduct(product, locale, fieldsToSend, baseModel);
+                let localizedProduct = new AlgoliaLocalizedProduct({ product: product, locale: locale, fieldList: fieldsToSend, baseModel: baseModel, fullRecordUpdate: fullRecordUpdate });
                 algoliaOperations.push(new jobHelper.AlgoliaOperation(baseIndexingOperation, localizedProduct, indexName));
             }
             jobReport.processedItemsToSend++;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -88,8 +88,13 @@ exports.beforeStep = function(parameters, stepExecution) {
 
     /* --- fieldListOverride parameter --- */
     if (empty(paramFieldListOverride)) {
+        fieldsToSend = algoliaProductConfig.defaultAttributes_v2;
         const customFields = algoliaData.getSetOfArray('CustomFields');
-        fieldsToSend = algoliaProductConfig.defaultAttributes.concat(customFields);
+        customFields.map(function(field) {
+            if (fieldsToSend.indexOf(field) < 0) {
+                fieldsToSend.push(field);
+            }
+        });
     } else {
         fieldsToSend = paramFieldListOverride;
     }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -212,9 +212,7 @@ exports.beforeStep = function(parameters, stepExecution) {
 
                     jobReport.error = true;
                     jobReport.errorMessage = errorMessage;
-                    jogLog.writeToCustomObject();
-
-                    return;
+                    jobReport.writeToCustomObject();
                 }
             });
         }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -10,6 +10,7 @@ var paramFieldListOverride, paramIndexingMethod;
 // Algolia requires
 var algoliaData, AlgoliaLocalizedProduct, algoliaProductConfig, jobHelper, reindexHelper, algoliaIndexingAPI, sendHelper, productFilter, AlgoliaJobReport;
 var indexingOperation;
+var fullRecordUpdate = false;
 
 // logging-related variables
 var jobReport;
@@ -85,6 +86,7 @@ exports.beforeStep = function(parameters, stepExecution) {
         case 'fullRecordUpdate':
         case 'fullCatalogReindex':
             indexingOperation = 'addObject';
+            fullRecordUpdate = true;
             break;
         case 'partialRecordUpdate':
         default:
@@ -169,14 +171,14 @@ exports.process = function(product, parameters, stepExecution) {
         var algoliaOperations = [];
 
         // Pre-fetch a partial model containing all non-localized attributes, to avoid re-fetching them for each locale
-        var baseModel = new AlgoliaLocalizedProduct(product, 'default', nonLocalizedAttributes);
+        var baseModel = new AlgoliaLocalizedProduct({ product: product, locale: 'default', fieldList: nonLocalizedAttributes, fullRecordUpdate: fullRecordUpdate });
         for (let l = 0; l < siteLocales.size(); ++l) {
             var locale = siteLocales[l];
             var indexName = algoliaData.calculateIndexName('products', locale);
 
             if (paramIndexingMethod === 'fullCatalogReindex') indexName += '.tmp';
 
-            let localizedProduct = new AlgoliaLocalizedProduct(product, locale, fieldsToSend, baseModel);
+            let localizedProduct = new AlgoliaLocalizedProduct({ product: product, locale: locale, fieldList: fieldsToSend, baseModel: baseModel, fullRecordUpdate: fullRecordUpdate });
             algoliaOperations.push(new jobHelper.AlgoliaOperation(indexingOperation, localizedProduct, indexName));
         }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -66,8 +66,13 @@ exports.beforeStep = function(parameters, stepExecution) {
 
     /* --- fieldListOverride parameter --- */
     if (empty(paramFieldListOverride)) {
+        fieldsToSend = algoliaProductConfig.defaultAttributes_v2;
         const customFields = algoliaData.getSetOfArray('CustomFields');
-        fieldsToSend = algoliaProductConfig.defaultAttributes.concat(customFields);
+        customFields.map(function(field) {
+            if (fieldsToSend.indexOf(field) < 0) {
+                fieldsToSend.push(field);
+            }
+        });
     } else {
         fieldsToSend = paramFieldListOverride;
     }
@@ -171,7 +176,7 @@ exports.process = function(product, parameters, stepExecution) {
 
             if (paramIndexingMethod === 'fullCatalogReindex') indexName += '.tmp';
 
-            let localizedProduct = new AlgoliaLocalizedProduct(product, locale, paramFieldListOverride, baseModel);
+            let localizedProduct = new AlgoliaLocalizedProduct(product, locale, fieldsToSend, baseModel);
             algoliaOperations.push(new jobHelper.AlgoliaOperation(indexingOperation, localizedProduct, indexName));
         }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -281,3 +281,6 @@ exports.afterStep = function(success, parameters, stepExecution) {
 exports.__setLastIndexingTasks = function(indexingTasks) {
     lastIndexingTasks = indexingTasks;
 };
+exports.__getFieldsToSend = function() {
+    return fieldsToSend;
+}

--- a/metadata/algolia/meta/system-objecttype-extensions.xml
+++ b/metadata/algolia/meta/system-objecttype-extensions.xml
@@ -145,7 +145,7 @@
             </attribute-definition>
 
             <attribute-definition attribute-id="Algolia_CustomFields">
-                <display-name xml:lang="x-default">Additional Product Attributes</display-name>
+                <display-name xml:lang="x-default">Custom Fields</display-name>
                 <description xml:lang="x-default">Any additional attributes of Product Object</description>
                 <type>set-of-string</type>
                 <mandatory-flag>false</mandatory-flag>

--- a/metadata/algolia/meta/system-objecttype-extensions.xml
+++ b/metadata/algolia/meta/system-objecttype-extensions.xml
@@ -145,7 +145,7 @@
             </attribute-definition>
 
             <attribute-definition attribute-id="Algolia_CustomFields">
-                <display-name xml:lang="x-default">Custom Fields</display-name>
+                <display-name xml:lang="x-default">Additional Product Fields</display-name>
                 <description xml:lang="x-default">Any additional attributes of Product Object</description>
                 <type>set-of-string</type>
                 <mandatory-flag>false</mandatory-flag>

--- a/metadata/algolia/meta/system-objecttype-extensions.xml
+++ b/metadata/algolia/meta/system-objecttype-extensions.xml
@@ -145,7 +145,7 @@
             </attribute-definition>
 
             <attribute-definition attribute-id="Algolia_CustomFields">
-                <display-name xml:lang="x-default">Additional Product Fields</display-name>
+                <display-name xml:lang="x-default">Additional Product Attributes</display-name>
                 <description xml:lang="x-default">Any additional attributes of Product Object</description>
                 <type>set-of-string</type>
                 <mandatory-flag>false</mandatory-flag>

--- a/metadata/algolia/sites/RefArch/preferences.xml
+++ b/metadata/algolia/sites/RefArch/preferences.xml
@@ -3,11 +3,8 @@
     <custom-preferences>
         <all-instances>
             <preference preference-id="Algolia_CustomFields">
-                <value>name</value>
                 <value>short_description</value>
                 <value>long_description</value>
-                <value>image_groups</value>
-                <value>url</value>
                 <value>variant</value>
                 <value>master</value>
             </preference>
@@ -17,4 +14,3 @@
         <production/>
     </custom-preferences>
 </preferences>
-

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -169,11 +169,13 @@ describe('algoliaLocalizedProduct', function () {
             refinementColor: 'Pink',
             size: '4',
             refinementSize: '4',
-            _tags: [
-                'id:701644031206M',
-            ],
         };
-        expect(new AlgoliaLocalizedProduct(product, 'default', fields)).toEqual(algoliaProductModel);
+        expect(new AlgoliaLocalizedProduct({ product: product, locale: 'default', fieldList: fields })).toEqual(algoliaProductModel);
+        // Tags are added in case of fullRecordUpdate
+        algoliaProductModel._tags= [
+            'id:701644031206M',
+        ];
+        expect(new AlgoliaLocalizedProduct({ product: product, locale: 'default', fieldList: fields, fullRecordUpdate: true })).toEqual(algoliaProductModel);
     });
 
     test('fr locale', function () {
@@ -267,11 +269,13 @@ describe('algoliaLocalizedProduct', function () {
             refinementColor: 'Rose',
             size: '4',
             refinementSize: '4',
-            _tags: [
-                'id:701644031206M',
-            ],
         };
-        expect(new AlgoliaLocalizedProduct(product, 'fr', fields)).toEqual(algoliaProductModel);
+        expect(new AlgoliaLocalizedProduct({ product: product, locale: 'fr', fieldList: fields })).toEqual(algoliaProductModel);
+        // Tags are added in case of fullRecordUpdate
+        algoliaProductModel._tags= [
+            'id:701644031206M',
+        ];
+        expect(new AlgoliaLocalizedProduct({ product: product, locale: 'fr', fieldList: fields, fullRecordUpdate: true })).toEqual(algoliaProductModel);
     });
 
     test('fieldListOverride', function () {
@@ -283,7 +287,7 @@ describe('algoliaLocalizedProduct', function () {
                 EUR: 92.88
             },
         };
-        expect(new AlgoliaLocalizedProduct(product, undefined, ['price'])).toEqual(algoliaProductModel);
+        expect(new AlgoliaLocalizedProduct({ product: product, locale: undefined, fieldList: ['price'] })).toEqual(algoliaProductModel);
     });
 
     test('baseModel', function () {
@@ -304,8 +308,7 @@ describe('algoliaLocalizedProduct', function () {
                 EUR: 0.93
             },
             name: 'Test name',
-            _tags: ['id:' + product.ID]
         };
-        expect(new AlgoliaLocalizedProduct(product, 'default', ['price', 'UPC', 'name'], baseModel)).toEqual(expectedProductModel);
+        expect(new AlgoliaLocalizedProduct({ product: product, locale: 'default', fieldList: ['price', 'UPC', 'name'], baseModel: baseModel })).toEqual(expectedProductModel);
     });
 });

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -73,13 +73,15 @@ jest.mock('*/cartridge/scripts/algolia/customization/productModelCustomizer', ()
 }, {virtual: true});
 
 const AlgoliaLocalizedProduct = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct');
+const algoliaProductConfig = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig')
+const fields = algoliaProductConfig.defaultAttributes_v2.concat(['url', 'UPC', 'searchable', 'variant', 'color', 'refinementColor', 'size', 'refinementSize', 'brand', 'online', 'pageDescription', 'pageKeywords',
+    'pageTitle', 'short_description', 'name', 'long_description', 'image_groups']);
 
 describe('algoliaLocalizedProduct', function () {
     test('default locale', function () {
         const product = new ProductMock();
         const algoliaProductModel = {
             objectID: '701644031206M',
-            id: '701644031206M',
             in_stock: true,
             primary_category_id: 'womens-clothing-bottoms',
             price: {
@@ -171,14 +173,13 @@ describe('algoliaLocalizedProduct', function () {
                 'id:701644031206M',
             ],
         };
-        expect(new AlgoliaLocalizedProduct(product)).toEqual(algoliaProductModel);
+        expect(new AlgoliaLocalizedProduct(product, 'default', fields)).toEqual(algoliaProductModel);
     });
 
     test('fr locale', function () {
         const product = new ProductMock();
         const algoliaProductModel = {
             objectID: '701644031206M',
-            id: '701644031206M',
             in_stock: true,
             primary_category_id: 'womens-clothing-bottoms',
             price: {
@@ -270,7 +271,7 @@ describe('algoliaLocalizedProduct', function () {
                 'id:701644031206M',
             ],
         };
-        expect(new AlgoliaLocalizedProduct(product, 'fr')).toEqual(algoliaProductModel);
+        expect(new AlgoliaLocalizedProduct(product, 'fr', fields)).toEqual(algoliaProductModel);
     });
 
     test('fieldListOverride', function () {
@@ -303,6 +304,7 @@ describe('algoliaLocalizedProduct', function () {
                 EUR: 0.93
             },
             name: 'Test name',
+            _tags: ['id:' + product.ID]
         };
         expect(new AlgoliaLocalizedProduct(product, 'default', ['price', 'UPC', 'name'], baseModel)).toEqual(expectedProductModel);
     });

--- a/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductDeltaIndex.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductDeltaIndex.test.js.snap
@@ -38,7 +38,6 @@ exports[`process 1`] = `
         ],
       ],
       "color": "Hot Pink Combo",
-      "id": "701644031206M",
       "image_groups": [
         {
           "_type": "image_group",
@@ -136,7 +135,6 @@ exports[`process 1`] = `
         ],
       ],
       "color": "Combo rose vif",
-      "id": "701644031206M",
       "image_groups": [
         {
           "_type": "image_group",
@@ -234,7 +232,6 @@ exports[`process 1`] = `
         ],
       ],
       "color": "Hot Pink Combo",
-      "id": "701644031206M",
       "image_groups": [
         {
           "_type": "image_group",

--- a/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductIndex.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductIndex.test.js.snap
@@ -11,9 +11,6 @@ exports[`process default 1`] = `
         "1": "Womens > Clothing",
         "2": "Womens > Clothing > Bottoms",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
       "brand": null,
       "categories": [
         [
@@ -108,9 +105,6 @@ exports[`process default 1`] = `
         "1": "Femmes > Vêtements",
         "2": "Femmes > Vêtements > Bas",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
       "brand": null,
       "categories": [
         [
@@ -205,9 +199,6 @@ exports[`process default 1`] = `
         "1": "Womens > Clothing",
         "2": "Womens > Clothing > Bottoms",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
       "brand": null,
       "categories": [
         [
@@ -899,9 +890,6 @@ exports[`process partialRecordUpdate 1`] = `
         "1": "Womens > Clothing",
         "2": "Womens > Clothing > Bottoms",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
       "brand": null,
       "categories": [
         [
@@ -996,9 +984,6 @@ exports[`process partialRecordUpdate 1`] = `
         "1": "Femmes > Vêtements",
         "2": "Femmes > Vêtements > Bas",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
       "brand": null,
       "categories": [
         [
@@ -1093,9 +1078,6 @@ exports[`process partialRecordUpdate 1`] = `
         "1": "Womens > Clothing",
         "2": "Womens > Clothing > Bottoms",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
       "brand": null,
       "categories": [
         [

--- a/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductIndex.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductIndex.test.js.snap
@@ -38,7 +38,6 @@ exports[`process default 1`] = `
         ],
       ],
       "color": "Hot Pink Combo",
-      "id": "701644031206M",
       "image_groups": [
         {
           "_type": "image_group",
@@ -136,7 +135,6 @@ exports[`process default 1`] = `
         ],
       ],
       "color": "Combo rose vif",
-      "id": "701644031206M",
       "image_groups": [
         {
           "_type": "image_group",
@@ -234,7 +232,6 @@ exports[`process default 1`] = `
         ],
       ],
       "color": "Hot Pink Combo",
-      "id": "701644031206M",
       "image_groups": [
         {
           "_type": "image_group",
@@ -337,7 +334,6 @@ exports[`process fullCatalogReindex 1`] = `
         ],
       ],
       "color": "Hot Pink Combo",
-      "id": "701644031206M",
       "image_groups": [
         {
           "_type": "image_group",
@@ -435,7 +431,6 @@ exports[`process fullCatalogReindex 1`] = `
         ],
       ],
       "color": "Combo rose vif",
-      "id": "701644031206M",
       "image_groups": [
         {
           "_type": "image_group",
@@ -533,7 +528,6 @@ exports[`process fullCatalogReindex 1`] = `
         ],
       ],
       "color": "Hot Pink Combo",
-      "id": "701644031206M",
       "image_groups": [
         {
           "_type": "image_group",
@@ -636,7 +630,6 @@ exports[`process fullRecordUpdate 1`] = `
         ],
       ],
       "color": "Hot Pink Combo",
-      "id": "701644031206M",
       "image_groups": [
         {
           "_type": "image_group",
@@ -734,7 +727,6 @@ exports[`process fullRecordUpdate 1`] = `
         ],
       ],
       "color": "Combo rose vif",
-      "id": "701644031206M",
       "image_groups": [
         {
           "_type": "image_group",
@@ -832,7 +824,6 @@ exports[`process fullRecordUpdate 1`] = `
         ],
       ],
       "color": "Hot Pink Combo",
-      "id": "701644031206M",
       "image_groups": [
         {
           "_type": "image_group",
@@ -935,7 +926,6 @@ exports[`process partialRecordUpdate 1`] = `
         ],
       ],
       "color": "Hot Pink Combo",
-      "id": "701644031206M",
       "image_groups": [
         {
           "_type": "image_group",
@@ -1033,7 +1023,6 @@ exports[`process partialRecordUpdate 1`] = `
         ],
       ],
       "color": "Combo rose vif",
-      "id": "701644031206M",
       "image_groups": [
         {
           "_type": "image_group",
@@ -1131,7 +1120,6 @@ exports[`process partialRecordUpdate 1`] = `
         ],
       ],
       "color": "Hot Pink Combo",
-      "id": "701644031206M",
       "image_groups": [
         {
           "_type": "image_group",

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -79,6 +79,12 @@ describe('beforeStep', () => {
         expect(job.__getFieldsToSend()).toStrictEqual(['name', 'primary_category_id',
             'categories', 'in_stock', 'price', 'image_groups', 'url']);
     });
+    test('no duplicated attributes', () => {
+        mockCustomFields = ['name'];
+        job.beforeStep({}, stepExecution);
+        expect(job.__getFieldsToSend()).toStrictEqual(['name', 'primary_category_id',
+            'categories', 'in_stock', 'price', 'image_groups', 'url']);
+    });
 });
 
 describe('process', () => {

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -43,6 +43,19 @@ jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
     }
 }, {virtual: true});
 
+let mockCustomFields;
+jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => {
+    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData');
+    return {
+        ...originalModule,
+        getSetOfArray: function (id) {
+            return id === 'CustomFields'
+                ? mockCustomFields
+                : null;
+        },
+    }
+}, {virtual: true});
+
 const stepExecution = {
     getJobExecution: () => {
         return {
@@ -53,6 +66,20 @@ const stepExecution = {
 };
 
 const job = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex');
+
+beforeEach(() => {
+    mockCustomFields = ['url', 'UPC', 'searchable', 'variant', 'color', 'refinementColor', 'size', 'refinementSize', 'brand', 'online', 'pageDescription', 'pageKeywords',
+        'pageTitle', 'short_description', 'name', 'long_description', 'image_groups']
+});
+
+describe('beforeStep', () => {
+    test('defaultAttributes', () => {
+        mockCustomFields = [];
+        job.beforeStep({}, stepExecution);
+        expect(job.__getFieldsToSend()).toStrictEqual(['name', 'primary_category_id',
+            'categories', 'in_stock', 'price', 'image_groups', 'url']);
+    });
+});
 
 describe('process', () => {
     test('default', () => {


### PR DESCRIPTION
- Change the list of default attributes to the following, for v2 jobs:
  `['name', 'primary_category_id', 'categories', 'url', image_groups, 'in_stock', 'price']`

I've also used the occasion to do the following optimizations:
- We were fetching the `CustomFields` property each time that we were instantiating the model. I've removed that from the model, which now requires the `fieldList` to be passed, so the list is built once at the beginning of the jobs (that's what the Delta job was already doing)
  - since `id` is not in the default fields anymore, `_tags` are now added when the record will be fully replaced in the index
- Replaced the simple `concat()` by a loop that checks for duplicates, to avoid fetching a same field multiple times

---
SFCC-78