### PR TITLE
fix: retry strategy wasn't looping on all hosts

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/retryStrategy.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/retryStrategy.js
@@ -103,10 +103,10 @@ function isRetryable(result) {
  * @return {dw.svc.Result} The first non-retryable result
  */
 function retryableCall(service, requestParams) {
-    var result;
-    var hosts = getAvailableHosts();
+    let result;
+    let hosts = getAvailableHosts();
     for (let i = 0; i < hosts.length; ++i) {
-        var statefulhost = hosts[i];
+        let statefulhost = hosts[i];
         result = service.call({
             method: requestParams.method,
             url: 'https://' + statefulhost.hostname + requestParams.path,

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
@@ -70,6 +70,7 @@ function runCategoryExport(parameters, stepExecution) {
         reindexHelper.waitForTasks(deletionTasks);
         logger.info('Temporary indices deleted. Starting indexing...');
     } catch (e) {
+        logger.error('Failed to delete temporary indices. Stopping job... Error: ' + e.message)
         return new Status(Status.ERROR, '', 'Failed to delete temporary indices: ' + e.message);
     }
 


### PR DESCRIPTION
Our tests didn't detect it because they are run in a standard JS environment, but in an SFCC environment, `const` shouldn't be used inside `for` loops, because they have the following behaviour:
```
for (let i = 0; i < 3; ++i) {
    const number = i;
    Logger.info(number); // prints 0 three times
}
```

The result is that the retry strategy was calling 4 times the same host on the first request, then 4 times the same host one the second request, etc...

### Changes

- Fixed the retry strategy loop
- Added more logs

### How to test

- Change your Algolia app ID to an app ID that doesn't exist
- Trigger a v2 job
- Look at the logs, you will see all hosts being tried:
```
Request error on TESTAPP.algolia.net: ...
Marking host TESTAPP.algolia.net down.
Request error on TESTAPP-1.algolianet.com: ...
Marking host TESTAPP-1.algolianet.com down.
Request error on TESTAPP-2.algolianet.com: ...
...
```

---
SFCC-179