### PR TITLE
fix: network error handling

### DIFF
--- a/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
+++ b/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
@@ -57,7 +57,7 @@ function indexing() {
     var responseData = {};
     var status = algoliaExportAPI.makeIndexingRequest(requestType);
 
-    if (status.error) {
+    if (!status.ok) {
         responseData.errorMessage = status.details.errorMessage ? status.details.errorMessage : Resource.msg('algolia.error.service', 'algolia', null);
     } else {
         responseData = status.details.object.body;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/sendHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/sendHelper.js
@@ -40,7 +40,7 @@ function sendFailedChunks(failedChunks, resType, fieldList) {
     for (var startIndex = 0; startIndex < failedChunks.length; startIndex += chunkLength) {
         var elements = failedChunks.slice(startIndex, startIndex + chunkLength);
         status = sendChunk(elements);
-        if (status.error) { break; }
+        if (!status.ok) { break; }
     }
 
     return status;
@@ -94,7 +94,7 @@ function sendDelta(deltaList, logID, parameters) {
         if (entries.length >= maxNumberOfEntries || !deltaList.hasNext()) {
             // send the chunks
             status = sendChunk(entries);
-            if (status.error) {
+            if (!status.ok) {
                 failedChunks = failedChunks.concat(entries);
                 countFailedChunks += 1;
                 sendLogData.failedChunks += 1;
@@ -121,7 +121,7 @@ function sendDelta(deltaList, logID, parameters) {
     // Resending failed chunks
     status = sendFailedChunks(failedChunks);
 
-    if (status.error) {
+    if (!status.ok) {
         sendLogData.sendError = true;
         sendLogData.sendErrorMessage = status.details.errorMessage ? status.details.errorMessage : 'Error sending chunk. See the log file for details.';
     } else {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategoriesDelta.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategoriesDelta.js
@@ -10,7 +10,7 @@ module.exports.execute = function (parameters) {
     var deltaList = deltaIterator.create(algoliaConstants.UPDATE_CATEGORIES_FILE_NAME, 'category');
     var status = sendHelper.sendDelta(deltaList, 'LastCategorySyncLog', parameters);
     var newSnapshotFile = new File(algoliaConstants.TMP_SNAPSHOT_CATEGORIES_FILE_NAME);
-    if (status.error) {
+    if (!status.ok) {
         try {
             if (newSnapshotFile.exists()) {
                 newSnapshotFile.remove();

--- a/cartridges/int_algolia/cartridge/scripts/algolia/job/sendProductsDelta.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/job/sendProductsDelta.js
@@ -12,7 +12,7 @@ module.exports.execute = function (parameters) {
 
     // Remove old Snapshot file and rename a new one
     var newSnapshotFile = new File(algoliaConstants.TMP_SNAPSHOT_PRODUCTS_FILE_NAME);
-    if (status.error) {
+    if (!status.ok) {
         try {
             if (newSnapshotFile.exists()) {
                 newSnapshotFile.remove();

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
@@ -103,7 +103,7 @@ function runCategoryExport(parameters, stepExecution) {
         status = retryableBatchRes.result;
         jobReport.recordsFailed += retryableBatchRes.failedRecords;
 
-        if (!status.error) {
+        if (status.ok) {
             jobReport.recordsSent += batch.length;
             jobReport.chunksSent++;
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -310,7 +310,7 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
     status = retryableBatchRes.result;
     jobReport.recordsFailed += retryableBatchRes.failedRecords;
 
-    if (!status.error) {
+    if (status.ok) {
         jobReport.recordsSent += batch.length;
         jobReport.chunksSent++;
     } else {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -206,7 +206,7 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
     status = retryableBatchRes.result;
     jobReport.recordsFailed += retryableBatchRes.failedRecords;
 
-    if (!status.error) {
+    if (status.ok) {
         jobReport.recordsSent += batch.length;
         jobReport.chunksSent++;
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendDeltaExportProducts.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendDeltaExportProducts.js
@@ -323,7 +323,7 @@ function sendDeltaExportProducts(parameters) {
         status = sendHelper.sendDelta(deltaList, updateLogType, parameters); // returns Status.OK if all is well
     }
 
-    if (status.error) {
+    if (!status.ok) {
         let errorMessage = status.details.errorMessage ? status.details.errorMessage : 'Error sending delta. See the logs for details.';
         jobHelper.logError(errorMessage);
         productLogData = algoliaData.getLogData(updateLogType); // need to get it again since sendDelta has updated the file, the in-memory one is out of date


### PR DESCRIPTION
Problem:
The `error` field of `dw.svc.Result` contains _"An error-specific code if applicable"_. The "if applicable" is important, as I found out that the error code can indeed be `0`, in case of DNS error for example. Here is the message I saw when putting a wrong App ID and running a job, produced by [this code](https://github.com/algolia/algoliasearch-sfcc-b2c/blob/2ff0b12b3722f54864f56b349b88978d76dee189/cartridges/int_algolia/cartridge/scripts/algolia/helper/retryStrategy.js#L119):
`Request error on TESTAPP.algolia.net: 0 - UnknownHostException:TESTAPP.algolia.net`

This means that all conditions testing `if (status.error)` are not behaving as expected when the error code is `0`.

Here is what happen for the `algoliaIndexProduct` job ran with a wrong app ID (the error happens when trying to read the body):

```
INFO CustomJobThread|1373139411|AlgoliaProductIndex_v2|algoliaProductIndex Starting indexing...
ERROR CustomJobThread|1373139411|AlgoliaProductIndex_v2|algoliaProductIndex Request error on TESTAPP.algolia.net: 0 - UnknownHostException:TESTAPP.algolia.net
ERROR CustomJobThread|1373139411|AlgoliaProductIndex_v2|algoliaProductIndex Request error on TESTAPP.algolia.net: 0 - UnknownHostException:TESTAPP.algolia.net
ERROR CustomJobThread|1373139411|AlgoliaProductIndex_v2|algoliaProductIndex Request error on TESTAPP.algolia.net: 0 - UnknownHostException:TESTAPP.algolia.net
ERROR CustomJobThread|1373139411|AlgoliaProductIndex_v2|algoliaProductIndex Request error on TESTAPP.algolia.net: 0 - UnknownHostException:TESTAPP.algolia.net
ERROR CustomJobThread|1373139411|AlgoliaProductIndex_v2|algoliaProductIndex UnknownHostException:TESTAPP.algolia.net
INFO CustomJobThread|1373139411|AlgoliaProductIndex_v2|algoliaProductIndex Total number of products: 500
INFO CustomJobThread|1373139411|AlgoliaProductIndex_v2|algoliaProductIndex Number of products marked for sending: 276
INFO CustomJobThread|1373139411|AlgoliaProductIndex_v2|algoliaProductIndex Number of locales configured for the site: 3
INFO CustomJobThread|1373139411|AlgoliaProductIndex_v2|algoliaProductIndex Records sent: 828; Records failed: 0
INFO CustomJobThread|1373139411|AlgoliaProductIndex_v2|algoliaProductIndex Chunks sent: 1; Chunks failed: 0
ERROR CustomJobThread|1373139411|AlgoliaProductIndex_v2|algoliaProductIndex Indexing failed.
WARN CustomJobThread|1373139411|AlgoliaProductIndex_v2|algoliaProductIndex Step [algoliaProductIndex@Sites-RefArch-Site] failed with custom status code [FAILED], custom failure status codes are not supported, status code will be replaced with status code [ERROR]!
ERROR CustomJobThread|1373139411|AlgoliaProductIndex_v2|algoliaProductIndex Execution of step [algoliaProductIndex] failed with status [ERROR]! com.demandware.core.script.capi.ScriptingException: TypeError: Cannot read property "body" from null (int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js#215)
	at int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js:215 (anonymous)
Caused by: com.demandware.core.script.capi.ScriptingException: TypeError: Cannot read property "body" from null (int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js#215)
```

### Changes

- Rely on the `ok` field of `dw.svc.Result` instead of the `error` field

### How to test

- Change the app ID to an non-existent one
- Run the `algoliaProductIndex` job
- Logs will look like the following (job tries to process all chunks and fail only at the end):
```
INFO CustomJobThread|374463835|AlgoliaProductIndex_v2|algoliaProductIndex Starting indexing...
ERROR CustomJobThread|374463835|AlgoliaProductIndex_v2|algoliaProductIndex Request error on TESTAPP.algolia.net: 0 - UnknownHostException:TESTAPP.algolia.net
ERROR CustomJobThread|374463835|AlgoliaProductIndex_v2|algoliaProductIndex Request error on TESTAPP.algolia.net: 0 - UnknownHostException:TESTAPP.algolia.net
...
...
...
INFO CustomJobThread|374463835|AlgoliaProductIndex_v2|algoliaProductIndex Total number of products: 5,639
INFO CustomJobThread|374463835|AlgoliaProductIndex_v2|algoliaProductIndex Number of products marked for sending: 5,032
INFO CustomJobThread|374463835|AlgoliaProductIndex_v2|algoliaProductIndex Number of locales configured for the site: 3
INFO CustomJobThread|374463835|AlgoliaProductIndex_v2|algoliaProductIndex Records sent: 0; Records failed: 15,096
INFO CustomJobThread|374463835|AlgoliaProductIndex_v2|algoliaProductIndex Chunks sent: 0; Chunks failed: 12
ERROR CustomJobThread|374463835|AlgoliaProductIndex_v2|algoliaProductIndex Execution of step [algoliaProductIndex] failed with status [ERROR]! com.demandware.core.script.capi.ScriptingException: Error: Some chunks failed to be sent, check the logs for details. (int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js#262)
	at int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js:262 (anonymous)
Caused by: com.demandware.core.script.capi.ScriptingException: Error: Some chunks failed to be sent, check the logs for details. (int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js#262)
```

---
SFCC-179