### PR TITLE
Removing OCAPI-related preferences from the Algolia BM module

### DIFF
--- a/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
+++ b/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
@@ -40,8 +40,6 @@ function handleSettings() {
         algoliaData.setPreference('AdminApiKey', params.AdminApiKey.value);
         algoliaData.setPreference('IndexPrefix', params.IndexPrefix.value);
         algoliaData.setPreference('EnableSSR', params.EnableSSR.submitted);
-        algoliaData.setPreference('OCAPIClientID', params.OCAPIClientID.value);
-        algoliaData.setPreference('OCAPIClientPassword', params.OCAPIClientPassword.value);
     } catch (error) {
         Logger.error(error);
     }

--- a/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
+++ b/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
@@ -127,26 +127,6 @@
                     </td>
                 </tr>
 
-                <iscomment> Algolia_OCAPIClientID </iscomment>
-                <tr>
-                    <td class="table_detail w s" colspan="1">
-                        <isprint value="${Resource.msg('algolia.label.preference.clientid', 'algolia', null)}" encoding="jshtml" />
-                    </td>
-                    <td class="table_detail w e s">
-                        <input type="text" value="${pdict.algoliaData.getPreference('OCAPIClientID') ? pdict.algoliaData.getPreference('OCAPIClientID') : ''}" id="OCAPIClientID" name="OCAPIClientID" />
-                    </td>
-                </tr>
-
-                <iscomment> Algolia_OCAPIClientPassword </iscomment>
-                <tr>
-                    <td class="table_detail w s" colspan="1">
-                        <isprint value="${Resource.msg('algolia.label.preference.clientpassword', 'algolia', null)}" encoding="jshtml" />
-                    </td>
-                    <td class="table_detail w e s">
-                        <input type="text" value="${pdict.algoliaData.getPreference('OCAPIClientPassword') ? pdict.algoliaData.getPreference('OCAPIClientPassword') : ''}" id="OCAPIClientPassword" name="OCAPIClientPassword" />
-                    </td>
-                </tr>
-
                 <iscomment> Apply button </iscomment>
                 <tr>
                     <td class="w e s buttonspacing" align="right" colspan="2">

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData.js
@@ -66,8 +66,6 @@ const clientSideData = {
 //   InStockThreshold       ║ Stock Threshold                                   ║ Double
 //   IndexPrefix            ║ Optional prefix for the index name                ║ String
 //   EnableSSR              ║ Enables server-side rendering of CLP results      ║ Boolean
-//   OCAPIClientID          ║ Authorization OCAPI SFCC Client ID                ║ String
-//   OCAPIClientPassword    ║ Authorization OCAPI SFCC Client passwrd           ║ String
 //  ════════════════════════╩═══════════════════════════════════════════════════╩═══════════════════════════
 //  Preferences stored in the XML file
 //

--- a/metadata/algolia/meta/system-objecttype-extensions.xml
+++ b/metadata/algolia/meta/system-objecttype-extensions.xml
@@ -171,6 +171,7 @@ Setting this preference replaces the first two segments, the final index name be
                 <default-value>false</default-value>
             </attribute-definition>
 
+            <!-- Deprecated, will be removed soon -->
             <attribute-definition attribute-id="Algolia_OCAPIClientID">
                 <display-name xml:lang="x-default">OCAPI client ID</display-name>
                 <description xml:lang="x-default">Authorization OCAPI client ID</description>
@@ -180,6 +181,7 @@ Setting this preference replaces the first two segments, the final index name be
                 <min-length>0</min-length>
             </attribute-definition>
 
+            <!-- Deprecated, will be removed soon -->
             <attribute-definition attribute-id="Algolia_OCAPIClientPassword">
                 <display-name xml:lang="x-default">OCAPI client password</display-name>
                 <description xml:lang="x-default">Authorization OCAPI client password</description>
@@ -201,8 +203,6 @@ Setting this preference replaces the first two segments, the final index name be
                 <attribute attribute-id="Algolia_CustomFields"/>
                 <attribute attribute-id="Algolia_IndexPrefix"/>
                 <attribute attribute-id="Algolia_EnableSSR"/>
-                <attribute attribute-id="Algolia_OCAPIClientID"/>
-                <attribute attribute-id="Algolia_OCAPIClientPassword"/>
 
             </attribute-group>
         </group-definitions>


### PR DESCRIPTION
Removed the OCAPI-related preferences from the BM module.
The preferences themselves can't be removed from the metadata yet as the old jobs try to read them.
Once the old jobs are removed from the cartridge, these preferences can be removed as well.
![Screenshot 2023-10-18 at 19 21 44](https://github.com/algolia/algoliasearch-sfcc-b2c/assets/126484858/eb66b1b5-5818-466d-8ce5-03493148ac46)
