### PR TITLE
fix: revert wrong checks on Status objects

### DIFF
--- a/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
+++ b/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
@@ -55,7 +55,7 @@ function indexing() {
     var responseData = {};
     var status = algoliaExportAPI.makeIndexingRequest(requestType);
 
-    if (!status.ok) {
+    if (status.error) {
         responseData.errorMessage = status.details.errorMessage ? status.details.errorMessage : Resource.msg('algolia.error.service', 'algolia', null);
     } else {
         responseData = status.details.object.body;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/sendHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/sendHelper.js
@@ -40,7 +40,7 @@ function sendFailedChunks(failedChunks, resType, fieldList) {
     for (var startIndex = 0; startIndex < failedChunks.length; startIndex += chunkLength) {
         var elements = failedChunks.slice(startIndex, startIndex + chunkLength);
         status = sendChunk(elements);
-        if (!status.ok) { break; }
+        if (status.error) { break; }
     }
 
     return status;
@@ -94,7 +94,7 @@ function sendDelta(deltaList, logID, parameters) {
         if (entries.length >= maxNumberOfEntries || !deltaList.hasNext()) {
             // send the chunks
             status = sendChunk(entries);
-            if (!status.ok) {
+            if (status.error) {
                 failedChunks = failedChunks.concat(entries);
                 countFailedChunks += 1;
                 sendLogData.failedChunks += 1;
@@ -121,7 +121,7 @@ function sendDelta(deltaList, logID, parameters) {
     // Resending failed chunks
     status = sendFailedChunks(failedChunks);
 
-    if (!status.ok) {
+    if (status.error) {
         sendLogData.sendError = true;
         sendLogData.sendErrorMessage = status.details.errorMessage ? status.details.errorMessage : 'Error sending chunk. See the log file for details.';
     } else {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategoriesDelta.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/job/sendCategoriesDelta.js
@@ -10,7 +10,7 @@ module.exports.execute = function (parameters) {
     var deltaList = deltaIterator.create(algoliaConstants.UPDATE_CATEGORIES_FILE_NAME, 'category');
     var status = sendHelper.sendDelta(deltaList, 'LastCategorySyncLog', parameters);
     var newSnapshotFile = new File(algoliaConstants.TMP_SNAPSHOT_CATEGORIES_FILE_NAME);
-    if (!status.ok) {
+    if (status.error) {
         try {
             if (newSnapshotFile.exists()) {
                 newSnapshotFile.remove();

--- a/cartridges/int_algolia/cartridge/scripts/algolia/job/sendProductsDelta.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/job/sendProductsDelta.js
@@ -12,7 +12,7 @@ module.exports.execute = function (parameters) {
 
     // Remove old Snapshot file and rename a new one
     var newSnapshotFile = new File(algoliaConstants.TMP_SNAPSHOT_PRODUCTS_FILE_NAME);
-    if (!status.ok) {
+    if (status.error) {
         try {
             if (newSnapshotFile.exists()) {
                 newSnapshotFile.remove();

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
@@ -74,7 +74,6 @@ function runCategoryExport(parameters, stepExecution) {
         return new Status(Status.ERROR, '', 'Failed to delete temporary indices: ' + e.message);
     }
 
-    var status;
     var lastIndexingTasks = {};
     while (topLevelCategories.hasNext()) {
         var batch = [];
@@ -101,20 +100,20 @@ function runCategoryExport(parameters, stepExecution) {
         logger.info('Sending a batch of ' + batch.length + ' records for top-level category ID: ' + category.getID());
 
         var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
-        status = retryableBatchRes.result;
+        var result = retryableBatchRes.result;
         jobReport.recordsFailed += retryableBatchRes.failedRecords;
 
-        if (status.ok) {
+        if (result.ok) {
             jobReport.recordsSent += batch.length;
             jobReport.chunksSent++;
 
             // Store Algolia indexing task IDs
-            var taskIDs = status.object.body.taskID;
+            var taskIDs = result.object.body.taskID;
             Object.keys(taskIDs).forEach(function (taskIndexName) {
                 lastIndexingTasks[taskIndexName] = taskIDs[taskIndexName];
             });
         } else {
-            let errorMessage = 'Failed to send categories: ' + status.errorMessage + ', stopping job.';
+            let errorMessage = 'Failed to send categories: ' + result.errorMessage + ', stopping job.';
 
             jobReport.recordsFailed += batch.length;
             jobReport.chunksFailed++;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -299,8 +299,6 @@ exports.process = function(cpObj, parameters, stepExecution) {
  * @param {dw.job.JobStepExecution} stepExecution contains information about the job step
  */
 exports.send = function(algoliaOperations, parameters, stepExecution) {
-    var status;
-
     // algoliaOperations contains all returned Algolia operations from process() as a List of arrays
     var algoliaOperationsArray = algoliaOperations.toArray();
     var productCount = algoliaOperationsArray.length;
@@ -312,10 +310,10 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
     }
 
     var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
-    status = retryableBatchRes.result;
+    var result = retryableBatchRes.result;
     jobReport.recordsFailed += retryableBatchRes.failedRecords;
 
-    if (status.ok) {
+    if (result.ok) {
         jobReport.recordsSent += batch.length;
         jobReport.chunksSent++;
     } else {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -197,8 +197,6 @@ exports.process = function(product, parameters, stepExecution) {
  * @param {dw.job.JobStepExecution} stepExecution contains information about the job step
  */
 exports.send = function(algoliaOperations, parameters, stepExecution) {
-    var status;
-
     // algoliaOperations contains all the returned Algolia operations from process() as a List of arrays
     var algoliaOperationsArray = algoliaOperations.toArray();
     var productCount = algoliaOperationsArray.length;
@@ -210,16 +208,16 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
     }
 
     var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
-    status = retryableBatchRes.result;
+    var result = retryableBatchRes.result;
     jobReport.recordsFailed += retryableBatchRes.failedRecords;
 
-    if (status.ok) {
+    if (result.ok) {
         jobReport.recordsSent += batch.length;
         jobReport.chunksSent++;
 
         // Store Algolia indexing task IDs.
         // When performing a fullCatalogReindex, afterStep will wait for the last indexing tasks to complete.
-        var taskIDs = status.object.body.taskID;
+        var taskIDs = result.object.body.taskID;
         Object.keys(taskIDs).forEach(function (taskIndexName) {
             lastIndexingTasks[taskIndexName] = taskIDs[taskIndexName];
         });

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendDeltaExportProducts.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/sendDeltaExportProducts.js
@@ -323,7 +323,7 @@ function sendDeltaExportProducts(parameters) {
         status = sendHelper.sendDelta(deltaList, updateLogType, parameters); // returns Status.OK if all is well
     }
 
-    if (!status.ok) {
+    if (status.error) {
         let errorMessage = status.details.errorMessage ? status.details.errorMessage : 'Error sending delta. See the logs for details.';
         jobHelper.logError(errorMessage);
         productLogData = algoliaData.getLogData(updateLogType); // need to get it again since sendDelta has updated the file, the in-memory one is out of date


### PR DESCRIPTION
In #85 I fixed some checks involving `dw.svc.Result` objects.
We had named the variables `status`, which made me wrongly update all `status.error` checks to `!status.ok`.

But for the legacy jobs, the `status` variables were actually containing a `dw.system.Status` object, and those don't have a `ok` property.

This PR reverts them, and also rename the variables to `result` when the object is actually a `dw.svc.Result`.