### PR TITLE
chore: report indexing method

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -137,7 +137,8 @@ exports.beforeStep = function(parameters, stepExecution) {
 
     algoliaIndexingAPI.setJobInfo({
         jobID: stepExecution.getJobExecution().getJobID(),
-        stepID: stepExecution.getStepID()
+        stepID: stepExecution.getStepID(),
+        indexingMethod: paramIndexingMethod,
     });
 
     // ----------------------------- Extracting productIDs from the output of the Delta Export -----------------------------

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -115,7 +115,8 @@ exports.beforeStep = function(parameters, stepExecution) {
 
     algoliaIndexingAPI.setJobInfo({
         jobID: stepExecution.getJobExecution().getJobID(),
-        stepID: stepExecution.getStepID()
+        stepID: stepExecution.getStepID(),
+        indexingMethod: paramIndexingMethod,
     });
 
     /* --- removing any leftover temporary indices --- */

--- a/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
@@ -11,7 +11,7 @@ var __jobInfo = {};
 
 /**
  * Set information about the job using the API Client
- * @param {Object} jobInfo - object with the following structure: { "jobID": "", "stepID": "" }
+ * @param {Object} jobInfo - object with the following structure: { "jobID": "", "stepID": "", "indexingMethod": "" }
  */
 function setJobInfo(jobInfo) {
     __jobInfo = jobInfo;

--- a/cartridges/int_algolia/cartridge/scripts/services/algoliaIndexingService.js
+++ b/cartridges/int_algolia/cartridge/scripts/services/algoliaIndexingService.js
@@ -45,7 +45,8 @@ function getService(jobInfo) {
         'X-Algolia-Agent', 'Algolia Salesforce B2C v' + version +
         '; CM: ' + System.getCompatibilityMode() +
         '; JobID: ' + (jobInfo ? jobInfo.jobID : 'unknown') +
-        '; StepID: ' + (jobInfo ? jobInfo.stepID : 'unknown')
+        '; StepID: ' + (jobInfo ? jobInfo.stepID : 'unknown') +
+        (jobInfo && jobInfo.indexingMethod ? '; IndexingMethod: ' + jobInfo.indexingMethod : '')
     );
 
     return indexingService;

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
@@ -38,7 +38,7 @@ const job = require('../../../../../../cartridges/int_algolia/cartridge/scripts/
 
 test('process', () => {
     job.beforeStep(parameters, stepExecution);
-    expect(mockSetJobInfo).toHaveBeenCalledWith({ jobID: 'TestJobID', stepID: 'TestStepID' });
+    expect(mockSetJobInfo).toHaveBeenCalledWith({ jobID: 'TestJobID', stepID: 'TestStepID', indexingMethod: 'fullRecordUpdate' });
     var algoliaOperations = job.process({ productID: '701644031206M', available: true });
     expect(algoliaOperations).toMatchSnapshot();
 });

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -90,7 +90,7 @@ describe('beforeStep', () => {
 describe('process', () => {
     test('default', () => {
         job.beforeStep({}, stepExecution);
-        expect(mockSetJobInfo).toHaveBeenCalledWith({ jobID: 'TestJobID', stepID: 'TestStepID' });
+        expect(mockSetJobInfo).toHaveBeenCalledWith({ jobID: 'TestJobID', stepID: 'TestStepID', indexingMethod: 'partialRecordUpdate' });
         expect(mockDeleteTemporaryIndices).not.toHaveBeenCalled();
 
         var algoliaOperations = job.process(new ProductMock());
@@ -98,7 +98,7 @@ describe('process', () => {
     });
     test('partialRecordUpdate', () => {
         job.beforeStep({ indexingMethod: 'partialRecordUpdate' }, stepExecution);
-        expect(mockSetJobInfo).toHaveBeenCalledWith({ jobID: 'TestJobID', stepID: 'TestStepID' });
+        expect(mockSetJobInfo).toHaveBeenCalledWith({ jobID: 'TestJobID', stepID: 'TestStepID', indexingMethod: 'partialRecordUpdate' });
         expect(mockDeleteTemporaryIndices).not.toHaveBeenCalled();
 
         var algoliaOperations = job.process(new ProductMock());
@@ -106,7 +106,7 @@ describe('process', () => {
     });
     test('fullRecordUpdate', () => {
         job.beforeStep({ indexingMethod: 'fullRecordUpdate' }, stepExecution);
-        expect(mockSetJobInfo).toHaveBeenCalledWith({ jobID: 'TestJobID', stepID: 'TestStepID' });
+        expect(mockSetJobInfo).toHaveBeenCalledWith({ jobID: 'TestJobID', stepID: 'TestStepID', indexingMethod: 'fullRecordUpdate' });
         expect(mockDeleteTemporaryIndices).not.toHaveBeenCalled();
 
         var algoliaOperations = job.process(new ProductMock());
@@ -114,7 +114,7 @@ describe('process', () => {
     });
     test('fullCatalogReindex', () => {
         job.beforeStep({ indexingMethod: 'fullCatalogReindex' }, stepExecution);
-        expect(mockSetJobInfo).toHaveBeenCalledWith({ jobID: 'TestJobID', stepID: 'TestStepID' });
+        expect(mockSetJobInfo).toHaveBeenCalledWith({ jobID: 'TestJobID', stepID: 'TestStepID', indexingMethod: 'fullCatalogReindex' });
         expect(mockDeleteTemporaryIndices).toHaveBeenCalledWith('products', expect.arrayContaining(['default', 'fr', 'en']));
 
         var algoliaOperations = job.process(new ProductMock());


### PR DESCRIPTION
Add the `indexingMethod` to the Algolia user-agent, when relevant: I've not added it to the categoryIndex job, which has only a single mode, lmk if you think it can still be useful.

---
SFCC-178