### PR TITLE
fix: localized image_groups

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig.js
@@ -121,8 +121,128 @@ var attributeConfig = {
     }
 };
 
+var attributeConfig_v2 = {
+    brand: {
+        attribute: 'brand',
+        localized: true
+    },
+    EAN: {
+        attribute: 'EAN',
+        localized: false
+    },
+    id: {
+        attribute: 'ID',
+        localized: false
+    },
+    in_stock: {
+        attribute: 'availabilityModel.inStock',
+        localized: false
+    },
+    long_description: {
+        attribute: 'longDescription.source',
+        localized: true
+    },
+    manufacturerName: {
+        attribute: 'manufacturerName',
+        localized: false
+    },
+    manufacturerSKU: {
+        attribute: 'manufacturerSKU',
+        localized: false
+    },
+    master: {
+        attribute: 'master',
+        localized: false
+    },
+    name: {
+        attribute: 'name',
+        localized: true
+    },
+    online: {
+        attribute: 'online',
+        localized: false
+    },
+    optionProduct: {
+        attribute: 'optionProduct',
+        localized: false
+    },
+    pageDescription: {
+        attribute: 'pageDescription',
+        localized: true
+    },
+    pageKeywords: {
+        attribute: 'pageKeywords',
+        localized: true
+    },
+    pageTitle: {
+        attribute: 'pageTitle',
+        localized: true
+    },
+    primary_category_id: {
+        attribute: 'primaryCategory.ID',
+        localized: false
+    },
+    productSet: {
+        attribute: 'productSet',
+        localized: false
+    },
+    productSetProduct: {
+        attribute: 'productSetProduct',
+        localized: false
+    },
+    searchable: {
+        attribute: 'searchable',
+        localized: false
+    },
+    short_description: {
+        attribute: 'shortDescription.source',
+        localized: true
+    },
+    unit: {
+        attribute: 'unit',
+        localized: false
+    },
+    UPC: {
+        attribute: 'UPC',
+        localized: false
+    },
+    variant: {
+        attribute: 'variant',
+        localized: false
+    },
+    // The following have no 'attribute' declared because the model has special values handlers
+    categories: {
+        localized: true
+    },
+    color: {
+        localized: true
+    },
+    image_groups: {
+        localized: true
+    },
+    price: {
+        localized: false
+    },
+    promotionalPrice: {
+        localized: false
+    },
+    refinementColor: {
+        localized: true
+    },
+    refinementSize: {
+        localized: true
+    },
+    size: {
+        localized: true
+    },
+    url: {
+        localized: true
+    },
+};
+
 module.exports = {
     defaultAttributes: defaultAttributes,
     defaultAttributes_v2: defaultAttributes_v2,
-    attributeConfig: attributeConfig
+    attributeConfig: attributeConfig,
+    attributeConfig_v2: attributeConfig_v2
 };

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -340,7 +340,7 @@ function algoliaLocalizedProduct(parameters) {
         this.objectID = product.ID;
         for (var i = 0; i < attributeList.length; i += 1) {
             var attributeName = attributeList[i];
-            var config = algoliaProductConfig.attributeConfig[attributeName];
+            var config = algoliaProductConfig.attributeConfig_v2[attributeName];
 
             if (!empty(config)) {
                 if (baseModel && baseModel[attributeName]) {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -118,12 +118,10 @@ exports.beforeStep = function(parameters, stepExecution) {
 
 
     /* --- non-localized attributes --- */
-    Object.keys(algoliaProductConfig.attributeConfig).forEach(function(attributeName) {
-        if (!algoliaProductConfig.attributeConfig[attributeName].localized &&
+    Object.keys(algoliaProductConfig.attributeConfig_v2).forEach(function(attributeName) {
+        if (!algoliaProductConfig.attributeConfig_v2[attributeName].localized &&
             attributesToSend.indexOf(attributeName) >= 0) {
-            if (attributeName !== 'categories') {
-                nonLocalizedAttributes.push(attributeName);
-            }
+            nonLocalizedAttributes.push(attributeName);
         }
     });
     logger.info('Non-localized attributes: ' + JSON.stringify(nonLocalizedAttributes));

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -97,12 +97,10 @@ exports.beforeStep = function(parameters, stepExecution) {
 
 
     /* --- non-localized attributes --- */
-    Object.keys(algoliaProductConfig.attributeConfig).forEach(function(attributeName) {
-        if (!algoliaProductConfig.attributeConfig[attributeName].localized &&
+    Object.keys(algoliaProductConfig.attributeConfig_v2).forEach(function(attributeName) {
+        if (!algoliaProductConfig.attributeConfig_v2[attributeName].localized &&
           attributesToSend.indexOf(attributeName) >= 0) {
-            if (attributeName !== 'categories') {
-                nonLocalizedAttributes.push(attributeName);
-            }
+            nonLocalizedAttributes.push(attributeName);
         }
     });
     logger.info('Non-localized attributes: ' + JSON.stringify(nonLocalizedAttributes));

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -123,7 +123,7 @@
 				"@supports-parallel-execution": true,
 				"@supports-site-context": true,
 				"@supports-organization-context": false,
-				"description": "Update all products assigned to the selected site. The list of indexed attributes is configurable. Performs partial records updates: only the specified attributes are updated/added for each record (without affecting other attributes). If the record doesn't exist, a new one will be created.",
+				"description": "Update all products assigned to the selected site. The list of indexed attributes is configurable. Performs partial records updates: only the specified attributes are updated/added for each record. If the record doesn't exist, a new one will be created.",
 				"module": "int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js",
 				"read-function": "read",
 				"process-function": "process",

--- a/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductDeltaIndex.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductDeltaIndex.test.js.snap
@@ -141,15 +141,15 @@ exports[`process 1`] = `
           "images": [
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, large",
+              "alt": "Robe florale, Combo rose vif, large",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, large",
+              "alt": "Robe florale, Combo rose vif, large",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
           ],
           "view_type": "large",
@@ -159,15 +159,15 @@ exports[`process 1`] = `
           "images": [
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, small",
+              "alt": "Robe florale, Combo rose vif, small",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, small",
+              "alt": "Robe florale, Combo rose vif, small",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
           ],
           "view_type": "small",

--- a/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductIndex.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductIndex.test.js.snap
@@ -135,15 +135,15 @@ exports[`process default 1`] = `
           "images": [
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, large",
+              "alt": "Robe florale, Combo rose vif, large",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, large",
+              "alt": "Robe florale, Combo rose vif, large",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
           ],
           "view_type": "large",
@@ -153,15 +153,15 @@ exports[`process default 1`] = `
           "images": [
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, small",
+              "alt": "Robe florale, Combo rose vif, small",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, small",
+              "alt": "Robe florale, Combo rose vif, small",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
           ],
           "view_type": "small",
@@ -428,15 +428,15 @@ exports[`process fullCatalogReindex 1`] = `
           "images": [
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, large",
+              "alt": "Robe florale, Combo rose vif, large",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, large",
+              "alt": "Robe florale, Combo rose vif, large",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
           ],
           "view_type": "large",
@@ -446,15 +446,15 @@ exports[`process fullCatalogReindex 1`] = `
           "images": [
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, small",
+              "alt": "Robe florale, Combo rose vif, small",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, small",
+              "alt": "Robe florale, Combo rose vif, small",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
           ],
           "view_type": "small",
@@ -724,15 +724,15 @@ exports[`process fullRecordUpdate 1`] = `
           "images": [
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, large",
+              "alt": "Robe florale, Combo rose vif, large",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, large",
+              "alt": "Robe florale, Combo rose vif, large",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
           ],
           "view_type": "large",
@@ -742,15 +742,15 @@ exports[`process fullRecordUpdate 1`] = `
           "images": [
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, small",
+              "alt": "Robe florale, Combo rose vif, small",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, small",
+              "alt": "Robe florale, Combo rose vif, small",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
           ],
           "view_type": "small",
@@ -1014,15 +1014,15 @@ exports[`process partialRecordUpdate 1`] = `
           "images": [
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, large",
+              "alt": "Robe florale, Combo rose vif, large",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwcc434d54/images/large/PG.10237222.JJB52A0.PZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, large",
+              "alt": "Robe florale, Combo rose vif, large",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw58a034a4/images/large/PG.10237222.JJB52A0.BZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
           ],
           "view_type": "large",
@@ -1032,15 +1032,15 @@ exports[`process partialRecordUpdate 1`] = `
           "images": [
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, small",
+              "alt": "Robe florale, Combo rose vif, small",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4e4ce4f6/images/small/PG.10237222.JJB52A0.PZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
             {
               "_type": "image",
-              "alt": "Floral Dress, Hot Pink Combo, small",
+              "alt": "Robe florale, Combo rose vif, small",
               "dis_base_link": "https://zzrk-018.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2612fb5e/images/small/PG.10237222.JJB52A0.BZ.jpg",
-              "title": "Floral Dress, Hot Pink Combo",
+              "title": "Robe florale, Combo rose vif",
             },
           ],
           "view_type": "small",


### PR DESCRIPTION
The `image_groups` attribute was marked as non-localized in the `attributeConfig`.

To avoid adding yet another exception in the jobs code (it's also the case for `categories`), I've created a new `attributeConfig_v2`, which is a copy of the `attributeConfig` with the following modifications:
- `categories` and `image_groups` are set to `localized: true`
- properties are ordered alphabetically (first the ones with an `attribute` declared, then the others)

---

Unrelated small change: one of the job steps description was too large for the BM tooltip, I've shortened it.

---
SFCC-179