### PR TITLE
fix: some errors were missing in BM reporting

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -62,18 +62,9 @@ exports.beforeStep = function(parameters, stepExecution) {
     CPObjectIterator = require('*/cartridge/scripts/algolia/helper/CPObjectIterator');
     AlgoliaJobReport = require('*/cartridge/scripts/algolia/helper/AlgoliaJobReport');
 
-    /* --- checking mandatory parameters --- */
-    if (empty(parameters.consumer) || empty(parameters.deltaExportJobName)) {
-        let errorMessage = 'Mandatory job step parameters missing!';
-        jobHelper.logError(errorMessage);
-        return;
-    }
-
-
     /* --- initializing custom object logging --- */
     jobReport = new AlgoliaJobReport(stepExecution.getJobExecution().getJobID(), 'product');
     jobReport.startTime = new Date();
-
 
     /* --- parameters --- */
     paramConsumer = parameters.consumer.trim();
@@ -208,7 +199,7 @@ exports.beforeStep = function(parameters, stepExecution) {
                     jobReport.processedItems += result.nrProductsRead;
                 } else {
                     // abort if error reading from any of the delta export zips
-                    let errorMessage = 'Error reading from file: ' + catalogFile;
+                    let errorMessage = 'Error reading from file: ' + catalogFile.getFullPath();
                     jobHelper.logError(errorMessage);
 
                     jobReport.error = true;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -366,12 +366,14 @@ exports.afterStep = function(success, parameters, stepExecution) {
     jobReport.writeToCustomObject();
 
     if (jobReport.chunksFailed > 0) {
-        throw new Error('Some chunks failed to be sent, check the logs for details.');
+        jobReport.error = true;
+        jobReport.errorMessage = 'Some chunks failed to be sent, check the logs for details.';
     }
 
-    if (success) {
+    if (!jobReport.error) {
         logger.info('Indexing completed successfully.');
     } else {
-        logger.error('Indexing failed.');
+        // Showing the job in ERROR in the history
+        throw new Error(jobReport.errorMessage);
     }
 }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -121,10 +121,18 @@ exports.beforeStep = function(parameters, stepExecution) {
 
     /* --- removing any leftover temporary indices --- */
     if (paramIndexingMethod === 'fullCatalogReindex') {
-        logger.info('Deleting existing temporary indices...');
-        var deletionTasks = reindexHelper.deleteTemporaryIndices('products', siteLocales.toArray());
-        reindexHelper.waitForTasks(deletionTasks);
-        logger.info('Temporary indices deleted.');
+        try {
+            logger.info('Deleting existing temporary indices...');
+            var deletionTasks = reindexHelper.deleteTemporaryIndices('products', siteLocales.toArray());
+            reindexHelper.waitForTasks(deletionTasks);
+            logger.info('Temporary indices deleted.');
+        } catch (e) {
+            jobReport.endTime = new Date();
+            jobReport.error = true;
+            jobReport.errorMessage = 'Failed to delete temporary indices: ' + e.message;
+            jobReport.writeToCustomObject();
+            throw e;
+        }
     }
 
 
@@ -261,20 +269,22 @@ exports.afterStep = function(success, parameters, stepExecution) {
             reindexHelper.finishAtomicReindex('products', siteLocales.toArray(), lastIndexingTasks);
         } else {
             // don't proceed with the atomic reindexing if there were errors
-            throw new Error('Some records failed to be indexed (check the logs for details). Not moving temporary indices to production.');
+            jobReport.error = true;
+            jobReport.errorMessage = 'Some records failed to be indexed (check the logs for details). Not moving temporary indices to production.';
         }
     } else if (jobReport.chunksFailed > 0) {
-        // Showing the job in ERROR in the history
-        throw new Error('Some chunks failed to be sent, check the logs for details.');
+        jobReport.error = true;
+        jobReport.errorMessage = 'Some chunks failed to be sent, check the logs for details.';
     }
 
     jobReport.endTime = new Date();
     jobReport.writeToCustomObject();
 
-    if (success) {
+    if (!jobReport.error) {
         logger.info('Indexing completed successfully.');
     } else {
-        logger.error('Indexing failed.');
+        // Showing the job in ERROR in the history
+        throw new Error(jobReport.errorMessage);
     }
 }
 

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -1,278 +1,288 @@
 {
-	"step-types": {
-		"script-module-step": [{
-			"@type-id": "custom.algoliaCategoryIndex",
-			"@supports-parallel-execution": "false",
-			"@supports-site-context": "true",
-			"@supports-organization-context": "false",
-			"description": "Reindex all categories (incl. categories structures) assigned to the selected site to Algolia.",
-			"module": "int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js",
-			"function": "runCategoryExport",
-			"transactional": "false",
-			"timeout-in-seconds": "600",
-			"parameters": {},
-			"status-codes": {
-				"status": [{
-						"@code": "ERROR",
-						"description": "Used when the step failed with an error."
-					},
-					{
-						"@code": "OK",
-						"description": "Used when the step finished successfully."
-					}
-				]
-			}
-		}, {
-			"@type-id": "custom.algoliaSendDeltaExportProducts",
-			"@supports-parallel-execution": "false",
-			"@supports-site-context": "true",
-			"@supports-organization-context": "false",
-			"description": "DEPRECATED. Use 'custom.algoliaProductDeltaIndex' instead. Takes the product delta export created by SFCC, extracts the PIDs from it, retrieves and enriches the products, then sends them to Algolia. Records in the index are fully replaced.",
-			"module": "int_algolia/cartridge/scripts/algolia/steps/sendDeltaExportProducts.js",
-			"function": "sendDeltaExportProducts",
-			"transactional": "false",
-			"timeout-in-seconds": "7200",
-			"parameters": {
-				"parameter": [{
-					"@name": "consumer",
-					"@type": "string",
-					"@required": "true"
-				},
-					{
-						"@name": "deltaExportJobName",
-						"@type": "string",
-						"@required": "true"
-					}
-
-				]
-			},
-			"status-codes": {
-				"status": [{
-					"@code": "ERROR",
-					"description": "Used when the step failed with an error."
-				},
-					{
-						"@code": "FINISHED",
-						"description": "Used when the step finished successfully."
-					},
-					{
-						"@code": "FINISHED_WITH_WARNINGS",
-						"description": "Used when the step finished with warnings."
-					}
-				]
-			}
-		}],
-		"chunk-script-module-step": [{
-				"@type-id": "custom.algoliaProductIndex",
-				"@supports-parallel-execution": true,
-				"@supports-site-context": true,
-				"@supports-organization-context": false,
-				"description": "Index all products assigned to the selected site. The list of indexed attributes is configurable. Can perform partial records updates, full records updates or a full catalog reindex. See the 'indexingMethod' parameter for details.",
-				"module": "int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js",
-				"read-function": "read",
-				"process-function": "process",
-				"write-function": "send",
-				"total-count-function": "getTotalCount",
-				"before-step-function": "beforeStep",
-				"before-chunk-function": "",
-				"after-chunk-function": "",
-				"after-step-function": "afterStep",
-				"chunk-size": 500,
-				"transactional": false,
-				"timeout-in-seconds": "14400",
-				"parameters": {
-					"parameter": [
-						{
-							"@name": "attributeListOverride",
-							"@type": "string",
-							"description": "A comma-separated list of attributes to be updated in the index. If not specified, the default list of attributes will be used (defaultAttributes + Algolia_CustomFields).",
-							"@required": false,
-							"@trim": true
-						},
-						{
-							"@name": "indexingMethod",
-							"@type": "string",
-							"description": "'partialRecordUpdate': only the specified attributes are updated/added for each record (without affecting other attributes). If the record doesn't exist, a new one will be created. 'fullRecordUpdate': replace the entire record (or create new records) in the index with the specified data (without removing stale/deleted records). 'fullCatalogReindex': reindex all products (incl. removing stale records).",
-							"@required": "true",
-							"enum-values": {
-								"value": [
-									"fullCatalogReindex",
-									"fullRecordUpdate",
-									"partialRecordUpdate"
-								]
-							},
-							"default-value": "partialRecordUpdate"
-						}
-					]
-
-				},
-				"status-codes": {
-					"status": [{
-							"@code": "ERROR",
-							"description": "Used when the step failed with an error."
-						},
-						{
-							"@code": "OK",
-							"description": "Used when the step finished successfully."
-						}
-					]
-				}
-			},
-			{
-				"@type-id": "custom.algoliaProductPartialIndex",
-				"@supports-parallel-execution": true,
-				"@supports-site-context": true,
-				"@supports-organization-context": false,
-				"description": "Update all products assigned to the selected site. The list of indexed attributes is configurable. Performs partial records updates: only the specified attributes are updated/added for each record (without affecting other attributes). If the record doesn't exist, a new one will be created.",
-				"module": "int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js",
-				"read-function": "read",
-				"process-function": "process",
-				"write-function": "send",
-				"total-count-function": "getTotalCount",
-				"before-step-function": "beforeStep",
-				"before-chunk-function": "",
-				"after-chunk-function": "",
-				"after-step-function": "afterStep",
-				"chunk-size": 500,
-				"transactional": false,
-				"timeout-in-seconds": "14400",
-				"parameters": {
-					"parameter": [{
-							"@name": "attributeListOverride",
-							"@type": "string",
-							"description": "A comma-separated list of attributes to be updated in the index. If not specified, the default list of attributes will be used (defaultAttributes + Algolia_CustomFields).",
-							"@required": false,
-							"@trim": true
-						}
-					]
-
-				},
-				"status-codes": {
-					"status": [{
-							"@code": "ERROR",
-							"description": "Used when the step failed with an error."
-						},
-						{
-							"@code": "OK",
-							"description": "Used when the step finished successfully."
-						}
-					]
-				}
-			},
-			{
-				"@type-id": "custom.algoliaProductDeltaIndex",
-				"@supports-parallel-execution": true,
-				"@supports-site-context": true,
-				"@supports-organization-context": false,
-				"description": "Extracts the list of productIDs (of changed products) from a B2C Delta Export, retrieves and enriches the products data, then sends them to Algolia. Can perform full records updates or partial records updates. See the 'indexingMethod' parameter for details.",
-				"module": "int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js",
-				"read-function": "read",
-				"process-function": "process",
-				"write-function": "send",
-				"total-count-function": "getTotalCount",
-				"before-step-function": "beforeStep",
-				"before-chunk-function": "",
-				"after-chunk-function": "",
-				"after-step-function": "afterStep",
-				"chunk-size": 500,
-				"transactional": false,
-				"timeout-in-seconds": "14400",
-				"parameters": {
-					"parameter": [{
-							"@name": "consumer",
-							"@type": "string",
-							"description": "The name of the consumer to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the deltaExportJobName parameter.",
-							"@required": true
-						},
-						{
-							"@name": "deltaExportJobName",
-							"@type": "string",
-							"description": "The name of the delta export job to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the consumer parameter.",
-							"@required": true
-						},
-						{
-							"@name": "attributeListOverride",
-							"@type": "string",
-							"description": "A comma-separated list of attributes to be updated in the index. If not specified, the default list of attributes will be used (defaultAttributes + Algolia_CustomFields).",
-							"@required": false,
-							"@trim": true
-						},
-						{
-							"@name": "indexingMethod",
-							"@type": "string",
-							"description": "'partialRecordUpdate': only the specified attributes are updated/added for each record (without affecting other attributes). If the record doesn't exist, a new one will be created. 'fullRecordUpdate': replace the entire record (or create new records) in the index with the specified data. Deleted products are removed from the index.",
-							"@required": "true",
-							"enum-values": {
-								"value": [
-									"partialRecordUpdate",
-									"fullRecordUpdate"
-								]
-							},
-							"default-value": "fullRecordUpdate"
-						}
-					]
-				},
-				"status-codes": {
-					"status": [{
-							"@code": "ERROR",
-							"description": "Used when the step failed with an error."
-						},
-						{
-							"@code": "OK",
-							"description": "Used when the step finished successfully."
-						}
-					]
-				}
-			},
-			{
-				"@type-id": "custom.sendChunkOrientedProductUpdates",
-				"@supports-parallel-execution": true,
-				"@supports-site-context": true,
-				"@supports-organization-context": false,
-				"description": "DEPRECATED. Use 'custom.algoliaProductIndex' instead. Sends updates of all products assigned to the selected site to Algolia. The list of indexed attributes is configurable. Can perform partial records updates or full records updates.",
-				"module": "int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js",
-				"read-function": "read",
-				"process-function": "process",
-				"write-function": "send",
-				"total-count-function": "getTotalCount",
-				"before-step-function": "beforeStep",
-				"before-chunk-function": "",
-				"after-chunk-function": "",
-				"after-step-function": "afterStep",
-				"chunk-size": 500,
-				"transactional": false,
-				"timeout-in-seconds": "600",
-				"parameters": {
-					"parameter": [{
-						"@name": "resourceType",
-						"@type": "string",
-						"@required": true
-					},
-						{
-							"@name": "fieldListOverride",
-							"@type": "string",
-							"@required": false
-						},
-						{
-							"@name": "fullRecordUpdate",
-							"@type": "boolean",
-							"@required": false
-						}
-					]
-
-				},
-				"status-codes": {
-					"status": [{
-						"@code": "ERROR",
-						"description": "Used when the step failed with an error."
-					},
-						{
-							"@code": "OK",
-							"description": "Used when the step finished successfully."
-						}
-					]
-				}
-			}
-		]
-	}
+    "step-types": {
+        "script-module-step": [
+            {
+                "@type-id": "custom.algoliaCategoryIndex",
+                "@supports-parallel-execution": "false",
+                "@supports-site-context": "true",
+                "@supports-organization-context": "false",
+                "description": "Reindex all categories (incl. categories structures) assigned to the selected site to Algolia.",
+                "module": "int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js",
+                "function": "runCategoryExport",
+                "transactional": "false",
+                "timeout-in-seconds": "600",
+                "parameters": {},
+                "status-codes": {
+                    "status": [
+                        {
+                            "@code": "ERROR",
+                            "description": "Used when the step failed with an error."
+                        },
+                        {
+                            "@code": "OK",
+                            "description": "Used when the step finished successfully."
+                        }
+                    ]
+                }
+            },
+            {
+                "@type-id": "custom.algoliaSendDeltaExportProducts",
+                "@supports-parallel-execution": "false",
+                "@supports-site-context": "true",
+                "@supports-organization-context": "false",
+                "description": "DEPRECATED. Use 'custom.algoliaProductDeltaIndex' instead. Takes the product delta export created by SFCC, extracts the PIDs from it, retrieves and enriches the products, then sends them to Algolia. Records in the index are fully replaced.",
+                "module": "int_algolia/cartridge/scripts/algolia/steps/sendDeltaExportProducts.js",
+                "function": "sendDeltaExportProducts",
+                "transactional": "false",
+                "timeout-in-seconds": "7200",
+                "parameters": {
+                    "parameter": [
+                        {
+                            "@name": "consumer",
+                            "@type": "string",
+                            "@required": "true"
+                        },
+                        {
+                            "@name": "deltaExportJobName",
+                            "@type": "string",
+                            "@required": "true"
+                        }
+                    ]
+                },
+                "status-codes": {
+                    "status": [
+                        {
+                            "@code": "ERROR",
+                            "description": "Used when the step failed with an error."
+                        },
+                        {
+                            "@code": "FINISHED",
+                            "description": "Used when the step finished successfully."
+                        },
+                        {
+                            "@code": "FINISHED_WITH_WARNINGS",
+                            "description": "Used when the step finished with warnings."
+                        }
+                    ]
+                }
+            }
+        ],
+        "chunk-script-module-step": [
+            {
+                "@type-id": "custom.algoliaProductIndex",
+                "@supports-parallel-execution": true,
+                "@supports-site-context": true,
+                "@supports-organization-context": false,
+                "description": "Index all products assigned to the selected site. The list of indexed attributes is configurable. Can perform partial records updates, full records updates or a full catalog reindex. See the 'indexingMethod' parameter for details.",
+                "module": "int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js",
+                "read-function": "read",
+                "process-function": "process",
+                "write-function": "send",
+                "total-count-function": "getTotalCount",
+                "before-step-function": "beforeStep",
+                "before-chunk-function": "",
+                "after-chunk-function": "",
+                "after-step-function": "afterStep",
+                "chunk-size": 500,
+                "transactional": false,
+                "timeout-in-seconds": "14400",
+                "parameters": {
+                    "parameter": [
+                        {
+                            "@name": "attributeListOverride",
+                            "@type": "string",
+                            "description": "A comma-separated list of attributes to be updated in the index. If not specified, the default list of attributes will be used (defaultAttributes + Algolia_CustomFields).",
+                            "@required": false,
+                            "@trim": true
+                        },
+                        {
+                            "@name": "indexingMethod",
+                            "@type": "string",
+                            "description": "'partialRecordUpdate': only the specified attributes are updated/added for each record (without affecting other attributes). If the record doesn't exist, a new one will be created. 'fullRecordUpdate': replace the entire record (or create new records) in the index with the specified data (without removing stale/deleted records). 'fullCatalogReindex': reindex all products (incl. removing stale records).",
+                            "@required": "true",
+                            "enum-values": {
+                                "value": [
+                                    "fullCatalogReindex",
+                                    "fullRecordUpdate",
+                                    "partialRecordUpdate"
+                                ]
+                            },
+                            "default-value": "partialRecordUpdate"
+                        }
+                    ]
+                },
+                "status-codes": {
+                    "status": [
+                        {
+                            "@code": "ERROR",
+                            "description": "Used when the step failed with an error."
+                        },
+                        {
+                            "@code": "OK",
+                            "description": "Used when the step finished successfully."
+                        }
+                    ]
+                }
+            },
+            {
+                "@type-id": "custom.algoliaProductPartialIndex",
+                "@supports-parallel-execution": true,
+                "@supports-site-context": true,
+                "@supports-organization-context": false,
+                "description": "Update all products assigned to the selected site. The list of indexed attributes is configurable. Performs partial records updates: only the specified attributes are updated/added for each record (without affecting other attributes). If the record doesn't exist, a new one will be created.",
+                "module": "int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js",
+                "read-function": "read",
+                "process-function": "process",
+                "write-function": "send",
+                "total-count-function": "getTotalCount",
+                "before-step-function": "beforeStep",
+                "before-chunk-function": "",
+                "after-chunk-function": "",
+                "after-step-function": "afterStep",
+                "chunk-size": 500,
+                "transactional": false,
+                "timeout-in-seconds": "14400",
+                "parameters": {
+                    "parameter": [
+                        {
+                            "@name": "attributeListOverride",
+                            "@type": "string",
+                            "description": "A comma-separated list of attributes to be updated in the index. If not specified, the default list of attributes will be used (defaultAttributes + Algolia_CustomFields).",
+                            "@required": false,
+                            "@trim": true
+                        }
+                    ]
+                },
+                "status-codes": {
+                    "status": [
+                        {
+                            "@code": "ERROR",
+                            "description": "Used when the step failed with an error."
+                        },
+                        {
+                            "@code": "OK",
+                            "description": "Used when the step finished successfully."
+                        }
+                    ]
+                }
+            },
+            {
+                "@type-id": "custom.algoliaProductDeltaIndex",
+                "@supports-parallel-execution": true,
+                "@supports-site-context": true,
+                "@supports-organization-context": false,
+                "description": "Extracts the list of productIDs (of changed products) from a B2C Delta Export, retrieves and enriches the products data, then sends them to Algolia. Can perform full records updates or partial records updates. See the 'indexingMethod' parameter for details.",
+                "module": "int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js",
+                "read-function": "read",
+                "process-function": "process",
+                "write-function": "send",
+                "total-count-function": "getTotalCount",
+                "before-step-function": "beforeStep",
+                "before-chunk-function": "",
+                "after-chunk-function": "",
+                "after-step-function": "afterStep",
+                "chunk-size": 500,
+                "transactional": false,
+                "timeout-in-seconds": "14400",
+                "parameters": {
+                    "parameter": [
+                        {
+                            "@name": "consumer",
+                            "@type": "string",
+                            "description": "The name of the consumer to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the deltaExportJobName parameter.",
+                            "@required": true
+                        },
+                        {
+                            "@name": "deltaExportJobName",
+                            "@type": "string",
+                            "description": "The name of the delta export job to be used for retrieving the delta export file. Also determines the WebDAV folder for the B2C delta export, together with the consumer parameter.",
+                            "@required": true
+                        },
+                        {
+                            "@name": "attributeListOverride",
+                            "@type": "string",
+                            "description": "A comma-separated list of attributes to be updated in the index. If not specified, the default list of attributes will be used (defaultAttributes + Algolia_CustomFields).",
+                            "@required": false,
+                            "@trim": true
+                        },
+                        {
+                            "@name": "indexingMethod",
+                            "@type": "string",
+                            "description": "'partialRecordUpdate': only the specified attributes are updated/added for each record (without affecting other attributes). If the record doesn't exist, a new one will be created. 'fullRecordUpdate': replace the entire record (or create new records) in the index with the specified data. Deleted products are removed from the index.",
+                            "@required": "true",
+                            "enum-values": {
+                                "value": [
+                                    "partialRecordUpdate",
+                                    "fullRecordUpdate"
+                                ]
+                            },
+                            "default-value": "fullRecordUpdate"
+                        }
+                    ]
+                },
+                "status-codes": {
+                    "status": [
+                        {
+                            "@code": "ERROR",
+                            "description": "Used when the step failed with an error."
+                        },
+                        {
+                            "@code": "OK",
+                            "description": "Used when the step finished successfully."
+                        }
+                    ]
+                }
+            },
+            {
+                "@type-id": "custom.sendChunkOrientedProductUpdates",
+                "@supports-parallel-execution": true,
+                "@supports-site-context": true,
+                "@supports-organization-context": false,
+                "description": "DEPRECATED. Use 'custom.algoliaProductIndex' instead. Sends updates of all products assigned to the selected site to Algolia. The list of indexed attributes is configurable. Can perform partial records updates or full records updates.",
+                "module": "int_algolia/cartridge/scripts/algolia/steps/sendChunkOrientedProductUpdates.js",
+                "read-function": "read",
+                "process-function": "process",
+                "write-function": "send",
+                "total-count-function": "getTotalCount",
+                "before-step-function": "beforeStep",
+                "before-chunk-function": "",
+                "after-chunk-function": "",
+                "after-step-function": "afterStep",
+                "chunk-size": 500,
+                "transactional": false,
+                "timeout-in-seconds": "600",
+                "parameters": {
+                    "parameter": [
+                        {
+                            "@name": "resourceType",
+                            "@type": "string",
+                            "@required": true
+                        },
+                        {
+                            "@name": "fieldListOverride",
+                            "@type": "string",
+                            "@required": false
+                        },
+                        {
+                            "@name": "fullRecordUpdate",
+                            "@type": "boolean",
+                            "@required": false
+                        }
+                    ]
+                },
+                "status-codes": {
+                    "status": [
+                        {
+                            "@code": "ERROR",
+                            "description": "Used when the step failed with an error."
+                        },
+                        {
+                            "@code": "OK",
+                            "description": "Used when the step finished successfully."
+                        }
+                    ]
+                }
+            }
+        ]
+    }
 }

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -152,16 +152,21 @@ describe('afterStep', () => {
 
     test('partialRecordUpdate', () => {
         job.beforeStep({ indexingMethod: 'partialRecordUpdate' }, stepExecution);
-        job.afterStep();
+        job.afterStep(true);
         expect(mockFinishAtomicReindex).not.toHaveBeenCalled();
     });
     test('fullCatalogReindex', () => {
         job.beforeStep({ indexingMethod: 'fullCatalogReindex' }, stepExecution);
-        job.afterStep();
+        job.afterStep(true);
         expect(mockFinishAtomicReindex).toHaveBeenCalledWith(
             'products',
             expect.arrayContaining(['default', 'fr', 'en']),
             { "test_index_fr": 42, "test_index_en": 51 }
         );
+    });
+    test('job is marked as failed if error in the previous steps', () => {
+        job.beforeStep({ indexingMethod: 'partialRecordUpdate' }, stepExecution);
+        expect(() => job.afterStep(false)).toThrow();
+        expect(mockFinishAtomicReindex).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
For some errors, we were immediately throwing an error to mark the job as failed, without writing the report object. So they were not logged in the Business Manager.

### Changes

- Set `jobReport.error` and `jobReport.errorMessage` when we encounter some error but don't throw immediately
- Then:
  - If the error happens early: write the report object and throw
  - If the error happens at the end of the job: write the report object and rely on the `jobReport.error` field to mark the job as success or to throw the error

### How to test :test_tube: 

- Set wrong Algolia credentials
- Run the AlgoliaProductIndex_v2 job
- Error should be reported in the BM:
![image](https://github.com/algolia/algoliasearch-sfcc-b2c/assets/2042109/06262286-543c-4cdd-9d29-c05291822b20)

---
SFCC-179