### PR TITLE
fix: delta job wasn't deleting unassigned products

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -266,7 +266,7 @@ exports.process = function(cpObj, parameters, stepExecution) {
 
     let algoliaOperations = [];
 
-    if (!empty(product) && cpObj.available) {
+    if (!empty(product) && cpObj.available && product.isAssignedToSiteCatalog()) {
         if (productFilter.isInclude(product)) {
 
             // Pre-fetch a partial model containing all non-localized attributes, to avoid re-fetching them for each locale

--- a/test/mocks/dw/catalog/Product.js
+++ b/test/mocks/dw/catalog/Product.js
@@ -107,6 +107,9 @@ Product.prototype = {
         return result;
     }
 };
+Product.prototype.isAssignedToSiteCatalog = function() {
+    return true;
+};
 Product.prototype.getAvailabilityModel = function() {
     return {
         getInventoryRecord: function() {


### PR DESCRIPTION
Our indexing jobs rely on `queryAllSiteProducts()`, which return only the products assigned to the site.
The Delta job wasn't taking that into account, if a product was unassigned from all categories, it was still updated instead of being deleted.

The product object has a `isAssignedToSiteCatalog()` method that permits to fix this behaviour.

---
SFCC-179