### PR TITLE
chore: minor changes in delta export job

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -140,7 +140,8 @@ exports.beforeStep = function(parameters, stepExecution) {
 
     // return OK if the folder doesn't exist, this means that the CatalogDeltaExport job step finished OK but didn't have any output (there were no changes)
     if (!l0_deltaExportDir.exists()) {
-        logger.info('Export directory does not exist (CatalogDeltaExport didn\'t generate anything here): ' + l0_deltaExportDir.getFullPath());
+        logger.info('Export directory does not exist (' + l0_deltaExportDir.getFullPath() +
+            '). There haven\'t been any changes to the catalog yet or the "consumer" and "deltaExportJobName" parameters do not match for both job steps.')
         return; // return with an empty changedProducts object
     }
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -27,6 +27,9 @@ jest.mock('dw/io/File', () => {
         list() {
             return [];
         }
+        getFullPath() {
+            return '/path/to/mocked/file';
+        }
     }
     return MockedFile;
 }, {virtual: true});


### PR DESCRIPTION
##### 1. Missing export directory

I've tried to change the `consumer` or `deltaExportJobName` parameters at the step level (`algoliaProductDeltaIndex`)
This threw the following error when trying to call `deltaExportZips.forEach`: 
```
com.demandware.core.script.capi.ScriptingException: TypeError: Cannot call method "forEach" of undefined (int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js#333)
	at int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js:333 (anonymous)
Caused by: com.demandware.core.script.capi.ScriptingException: TypeError: Cannot call method "forEach" of undefined (int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js#333)
```

I understand that we don't want to mark the job as error, because it can be normal that the directory doesn't exist. So:
- added logs to make it easier for users (or us) to understand what happened.
- added an `empty` check in `afterStep` to prevent the exception above.


##### 2. Don't override `jobReport.error`

Even if `jobReport.error` has been set to `true` during the job execution, the `afterStep` was setting it back to `false` (when `success = true`).
Now we'll do the files cleanup only if there was no errors and no failed chunks.

---
SFCC-179