### PR TITLE
Changed Algolia_CustomFields to Algolia_AdditionalAttributes

### DIFF
--- a/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
+++ b/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
@@ -34,7 +34,7 @@ function handleSettings() {
         var algoliaEnable = ('Enable' in params) && (params.Enable.submitted === true);
         algoliaData.setPreference('Enable', algoliaEnable);
         algoliaData.setPreference('ApplicationID', params.ApplicationID.value);
-        algoliaData.setSetOfStrings('CustomFields', params.CustomFields.value);
+        algoliaData.setSetOfStrings('AdditionalAttributes', params.AdditionalAttributes.value);
         algoliaData.setPreference('InStockThreshold', params.InStockThreshold.value * 1);
         algoliaData.setPreference('SearchApiKey', params.SearchApiKey.value);
         algoliaData.setPreference('AdminApiKey', params.AdminApiKey.value);

--- a/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
+++ b/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
@@ -92,13 +92,13 @@
                     </td>
                 </tr>
 
-                <iscomment> Algolia_CustomFields </iscomment>
+                <iscomment> Algolia_AdditionalAttributes </iscomment>
                 <tr>
                     <td class="table_detail w s" colspan="1">
                         <isprint value="${Resource.msg('algolia.label.preference.custom', 'algolia', null)}" encoding="jshtml" />
                     </td>
                     <td class="table_detail w e s">
-                        <input type="text" value="${pdict.algoliaData.getSetOfStrings('CustomFields') ? pdict.algoliaData.getSetOfStrings('CustomFields') : ''}" id="CustomFields" name="CustomFields" />
+                        <input type="text" value="${pdict.algoliaData.getSetOfStrings('AdditionalAttributes') ? pdict.algoliaData.getSetOfStrings('AdditionalAttributes') : ''}" id="AdditionalAttributes" name="AdditionalAttributes" />
                     </td>
                 </tr>
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData.js
@@ -94,7 +94,8 @@ const clientSideData = {
  * @returns {*} value of preference
  */
 function getPreference(id) {
-    return currentSite.getCustomPreferenceValue('Algolia_' + id);
+    let value = currentSite.getCustomPreferenceValue('Algolia_' + id);
+    return value === null ? '' : value;
 }
 
 /**
@@ -115,8 +116,8 @@ function setPreference(id, value) {
  * @returns {array} value of preference
  */
 function getSetOfArray(id) {
-    var values = currentSite.getCustomPreferenceValue('Algolia_' + id);
-    return values.length ? values.map(function (element) { return element; }) : [];
+    let values = currentSite.getCustomPreferenceValue('Algolia_' + id);
+    return values && values.length ? values.map(function (element) { return element; }) : [];
 }
 
 /**
@@ -125,8 +126,8 @@ function getSetOfArray(id) {
  * @returns {string} value of preference
  */
 function getSetOfStrings(id) {
-    var values = currentSite.getCustomPreferenceValue('Algolia_' + id);
-    return values.length ? values.join() : ', ';
+    let values = currentSite.getCustomPreferenceValue('Algolia_' + id);
+    return values && values.length ? values.join(', ') : '';
 }
 
 /**

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData.js
@@ -62,7 +62,7 @@ const clientSideData = {
 //   ApplicationID          ║ Identifies the application for this site          ║ String
 //   SearchApiKey           ║ Authorization key for Algolia                     ║ String
 //   AdminApiKey            ║ Authorization Admin key for Algolia               ║ String
-//   CustomFields           ║ Any additional attributes of Product Object       ║ Set-of-string
+//   AdditionalAttributes   ║ Any additional Product attributes                 ║ Set-of-string
 //   InStockThreshold       ║ Stock Threshold                                   ║ Double
 //   IndexPrefix            ║ Optional prefix for the index name                ║ String
 //   EnableSSR              ║ Enables server-side rendering of CLP results      ║ Boolean

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -81,7 +81,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     /* --- attributeListOverride parameter --- */
     if (empty(paramAttributeListOverride)) {
         attributesToSend = algoliaProductConfig.defaultAttributes_v2;
-        const additionalAttributes = algoliaData.getSetOfArray('CustomFields');
+        const additionalAttributes = algoliaData.getSetOfArray('AdditionalAttributes');
         additionalAttributes.map(function(attribute) {
             if (attributesToSend.indexOf(attribute) < 0) {
                 attributesToSend.push(attribute);

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -68,7 +68,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     /* --- attributeListOverride parameter --- */
     if (empty(paramAttributeListOverride)) {
         attributesToSend = algoliaProductConfig.defaultAttributes_v2;
-        const additionalAttributes = algoliaData.getSetOfArray('CustomFields');
+        const additionalAttributes = algoliaData.getSetOfArray('AdditionalAttributes');
         additionalAttributes.map(function(attribute) {
             if (attributesToSend.indexOf(attribute) < 0) {
                 attributesToSend.push(attribute);

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -91,7 +91,7 @@
                         {
                             "@name": "attributeListOverride",
                             "@type": "string",
-                            "description": "A comma-separated list of attributes to be updated in the index. If not specified, the default list of attributes will be used (defaultAttributes + Algolia_CustomFields).",
+                            "description": "A comma-separated list of attributes to be updated in the index. If not specified, the default list of attributes will be used (defaultAttributes + Algolia_AdditionalAttributes).",
                             "@required": false,
                             "@trim": true
                         },
@@ -147,7 +147,7 @@
                         {
                             "@name": "attributeListOverride",
                             "@type": "string",
-                            "description": "A comma-separated list of attributes to be updated in the index. If not specified, the default list of attributes will be used (defaultAttributes + Algolia_CustomFields).",
+                            "description": "A comma-separated list of attributes to be updated in the index. If not specified, the default list of attributes will be used (defaultAttributes + Algolia_AdditionalAttributes).",
                             "@required": false,
                             "@trim": true
                         }
@@ -201,7 +201,7 @@
                         {
                             "@name": "attributeListOverride",
                             "@type": "string",
-                            "description": "A comma-separated list of attributes to be updated in the index. If not specified, the default list of attributes will be used (defaultAttributes + Algolia_CustomFields).",
+                            "description": "A comma-separated list of attributes to be updated in the index. If not specified, the default list of attributes will be used (defaultAttributes + Algolia_AdditionalAttributes).",
                             "@required": false,
                             "@trim": true
                         },

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -228,7 +228,7 @@ jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => {
     return {
         ...originalModule,
         getSetOfArray: function (id) {
-            return id === 'CustomFields'
+            return id === 'AdditionalAttributes'
                 ? ['url', 'UPC', 'searchable', 'variant', 'color', 'refinementColor', 'size', 'refinementSize', 'brand', 'online', 'pageDescription', 'pageKeywords',
                     'pageTitle', 'short_description', 'name', 'long_description', 'image_groups']
                 : null;

--- a/metadata/algolia/jobs.xml
+++ b/metadata/algolia/jobs.xml
@@ -21,7 +21,7 @@
             <context site-id="RefArch"/>
             <step step-id="algoliaProductIndex" type="custom.algoliaProductIndex" enforce-restart="false">
                 <description>Index all products assigned to the selected site to Algolia. The list of indexed attributes is configurable, and by default contains related price and inventory data for each product. Can perform partial records updates, full records updates or a full catalog reindex, depending on the 'indexingMethod':
-- 'partialRecordUpdate': only the specified fields are updated/added for each record (without affecting other fields). If the record doesn't exist, a new one will be created.
+- 'partialRecordUpdate': only the specified attributes are updated/added for each record (without affecting other attributes). If the record doesn't exist, a new one will be created.
 - 'fullRecordUpdate': replace the entire record (or create new records) in the index with the specified data (without removing stale/deleted records).
 - 'fullCatalogReindex': reindex all products (incl. removing stale records).</description>
                 <parameters>

--- a/metadata/algolia/meta/system-objecttype-extensions.xml
+++ b/metadata/algolia/meta/system-objecttype-extensions.xml
@@ -144,9 +144,9 @@
                 <externally-managed-flag>false</externally-managed-flag>
             </attribute-definition>
 
-            <attribute-definition attribute-id="Algolia_CustomFields">
+            <attribute-definition attribute-id="Algolia_AdditionalAttributes">
                 <display-name xml:lang="x-default">Additional Product Attributes</display-name>
-                <description xml:lang="x-default">Any additional attributes of Product Object</description>
+                <description xml:lang="x-default">Any additional Product attributes</description>
                 <type>set-of-string</type>
                 <mandatory-flag>false</mandatory-flag>
                 <externally-managed-flag>false</externally-managed-flag>
@@ -200,7 +200,7 @@ Setting this preference replaces the first two segments, the final index name be
                 <attribute attribute-id="Algolia_SearchApiKey"/>
                 <attribute attribute-id="Algolia_AdminApiKey"/>
                 <attribute attribute-id="Algolia_InStockThreshold"/>
-                <attribute attribute-id="Algolia_CustomFields"/>
+                <attribute attribute-id="Algolia_AdditionalAttributes"/>
                 <attribute attribute-id="Algolia_IndexPrefix"/>
                 <attribute attribute-id="Algolia_EnableSSR"/>
 

--- a/metadata/algolia/sites/RefArch/preferences.xml
+++ b/metadata/algolia/sites/RefArch/preferences.xml
@@ -2,11 +2,9 @@
 <preferences xmlns="http://www.demandware.com/xml/impex/preferences/2007-03-31">
     <custom-preferences>
         <all-instances>
-            <preference preference-id="Algolia_CustomFields">
+            <preference preference-id="Algolia_AdditionalAttributes">
                 <value>short_description</value>
                 <value>long_description</value>
-                <value>variant</value>
-                <value>master</value>
             </preference>
         </all-instances>
         <development/>

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -52,7 +52,7 @@ jest.mock('dw/web/URLUtils', () => {
 jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => {
     return {
         getSetOfArray: function (id) {
-            return id === 'CustomFields'
+            return id === 'AdditionalAttributes'
                 ? ['url', 'UPC', 'searchable', 'variant', 'color', 'refinementColor', 'size', 'refinementSize', 'brand', 'online', 'pageDescription', 'pageKeywords',
                     'pageTitle', 'short_description', 'name', 'long_description', 'image_groups']
                 : null;

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -43,14 +43,14 @@ jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
     }
 }, {virtual: true});
 
-let mockCustomFields;
+let mockAdditionalAttributes;
 jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => {
     const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData');
     return {
         ...originalModule,
         getSetOfArray: function (id) {
-            return id === 'CustomFields'
-                ? mockCustomFields
+            return id === 'AdditionalAttributes'
+                ? mockAdditionalAttributes
                 : null;
         },
     }
@@ -68,19 +68,19 @@ const stepExecution = {
 const job = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex');
 
 beforeEach(() => {
-    mockCustomFields = ['url', 'UPC', 'searchable', 'variant', 'color', 'refinementColor', 'size', 'refinementSize', 'brand', 'online', 'pageDescription', 'pageKeywords',
+    mockAdditionalAttributes = ['url', 'UPC', 'searchable', 'variant', 'color', 'refinementColor', 'size', 'refinementSize', 'brand', 'online', 'pageDescription', 'pageKeywords',
         'pageTitle', 'short_description', 'name', 'long_description', 'image_groups']
 });
 
 describe('beforeStep', () => {
     test('defaultAttributes', () => {
-        mockCustomFields = [];
+        mockAdditionalAttributes = [];
         job.beforeStep({}, stepExecution);
         expect(job.__getAttributesToSend()).toStrictEqual(['name', 'primary_category_id',
             'categories', 'in_stock', 'price', 'image_groups', 'url']);
     });
     test('no duplicated attributes', () => {
-        mockCustomFields = ['name'];
+        mockAdditionalAttributes = ['name'];
         job.beforeStep({}, stepExecution);
         expect(job.__getAttributesToSend()).toStrictEqual(['name', 'primary_category_id',
             'categories', 'in_stock', 'price', 'image_groups', 'url']);


### PR DESCRIPTION
The ID of the `CustomFields` site preference needs to be changed in order to minimize the possibility for errors upon upgrading, since the list of default + recommended additional attributes has changed.
Renamed site preference `CustomFields` to `AdditionalAttributes`.
Old jobs and scripts still use `CustomFields` as it won't be removed forcibly from the cartridge with `mode="delete"`, but I'll mention it in the release notes so that clients who want to fully transition to the new jobs can remove it.

Getter methods in `algoliaData` will no longer throw an error when trying to get preferences which have not been defined in BM (`Cannot read property "length" from null` error).