### PR TITLE
fix: ocapi default pwd

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algoliaExportAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaExportAPI.js
@@ -61,7 +61,7 @@ function createHandshakeRequest() {
 
     var ocapiEncrypted = encryptHelper.encryptOcapiCredentials(
         algoliaData.getPreference('OCAPIClientID') || 'aaaaaaaaaaaaaaaaaaaaaaa',
-        algoliaData.getPreference('OCAPIClientPassword' || 'aaaaaaaaaaaaaaaaaaaaaaa'),
+        algoliaData.getPreference('OCAPIClientPassword') || 'aaaaaaaaaaaaaaaaaaaaaaa',
         algoliaData.getPreference('AdminApiKey'),
         algoliaData.getPreference('SearchApiKey')
     );


### PR DESCRIPTION
There was a syntax error which resulted in OCAPI password being `null` when `Algolia_OCAPIClientPassword` wasn't defined, instead of taking the default `'aaaaaaaaaaaaaaaaaaaaaaa'` value.