### PR TITLE
feat: failureThresholdPercentage parameter

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -156,6 +156,7 @@ exports.beforeStep = function(parameters, stepExecution) {
         logger.info('No delta exports found at ' + l0_deltaExportDir.getFullPath());
         return; // return with an empty changedProducts object
     }
+    logger.info('Delta exports found: ' + deltaExportZips);
 
     // creating empty temporary "_processing" dir
     l1_processingDir = new File(l0_deltaExportDir, '_processing');
@@ -170,6 +171,7 @@ exports.beforeStep = function(parameters, stepExecution) {
 
     // process each export zip one by one
     deltaExportZips.forEach(function(filename) {
+        logger.info('Processing ' + filename + '...');
         var currentZipFile = new File(l0_deltaExportDir, filename); // 000001.zip, 000002.zip, etc.
 
         // this will create a structure like so: "l0_deltaExportDir/_processing/000001.zip/ebff9c4e-ac8c-4954-8303-8e68ec8b190d/catalogs/...
@@ -222,6 +224,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     fileHelper.removeFolderRecursively(l1_processingDir);
 
     changedProductsIterator = new CPObjectIterator(changedProducts);
+    logger.info(jobReport.processedItems + ' updated products found. Starting indexing...');
 }
 
 /**
@@ -377,4 +380,9 @@ exports.afterStep = function(success, parameters, stepExecution) {
         // Showing the job in ERROR in the history
         throw new Error(jobReport.errorMessage);
     }
+}
+
+// For testing
+exports.__getJobReport = function() {
+    return jobReport;
 }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -349,6 +349,7 @@ exports.afterStep = function(success, parameters, stepExecution) {
 
             // cleanup: after the products have successfully been sent, move the delta zips from which the productIDs have successfully been extracted and the corresponding products sent to "_completed"
             if (!empty(deltaExportZips)) {
+                logger.info('Moving the Delta export files to the "_completed" directory...')
                 deltaExportZips.forEach(function (filename) {
                     let currentZipFile = new File(l0_deltaExportDir, filename); // 000001.zip, 000002.zip, etc.
                     let targetZipFile = new File(l1_completedDir, currentZipFile.getName());

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -5,7 +5,7 @@ var ProductMgr = require('dw/catalog/ProductMgr');
 var logger;
 
 // job step parameters
-var paramAttributeListOverride, paramIndexingMethod;
+var paramAttributeListOverride, paramIndexingMethod, paramFailureThresholdPercentage;
 
 // Algolia requires
 var algoliaData, AlgoliaLocalizedProduct, algoliaProductConfig, jobHelper, reindexHelper, algoliaIndexingAPI, sendHelper, productFilter, AlgoliaJobReport;
@@ -63,7 +63,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     /* --- parameters --- */
     paramAttributeListOverride = algoliaData.csvStringToArray(parameters.attributeListOverride); // attributeListOverride - pass it along to sending method
     paramIndexingMethod = parameters.indexingMethod || 'partialRecordUpdate'; // 'partialRecordUpdate' (default), 'fullRecordUpdate' or 'fullCatalogReindex'
-
+    paramFailureThresholdPercentage = parameters.failureThresholdPercentage || 0;
 
     /* --- attributeListOverride parameter --- */
     if (empty(paramAttributeListOverride)) {
@@ -136,6 +136,7 @@ exports.beforeStep = function(parameters, stepExecution) {
 
     /* --- getting all products assigned to the site --- */
     products = ProductMgr.queryAllSiteProducts();
+    logger.info('failureThresholdPercentage parameter: ' + paramFailureThresholdPercentage);
     logger.info('Starting indexing...')
 }
 
@@ -262,14 +263,21 @@ exports.afterStep = function(success, parameters, stepExecution) {
     logger.info('Records sent: {0}; Records failed: {1}', jobReport.recordsSent, jobReport.recordsFailed);
     logger.info('Chunks sent: {0}; Chunks failed: {1}', jobReport.chunksSent, jobReport.chunksFailed);
 
+    const failurePercentage = +((jobReport.recordsFailed / jobReport.recordsToSend * 100).toFixed(2)) || 0;
+
     if (paramIndexingMethod === 'fullCatalogReindex') {
-        if (jobReport.recordsFailed === 0) {
+        if (failurePercentage <= paramFailureThresholdPercentage) {
             reindexHelper.finishAtomicReindex('products', siteLocales.toArray(), lastIndexingTasks);
         } else {
-            // don't proceed with the atomic reindexing if there were errors
+            // don't proceed with the atomic reindexing
             jobReport.error = true;
-            jobReport.errorMessage = 'Some records failed to be indexed (check the logs for details). Not moving temporary indices to production.';
+            jobReport.errorMessage = 'The percentage of records that failed to be indexed (' + failurePercentage + '%) exceeds the failureThresholdPercentage (' +
+                 paramFailureThresholdPercentage + '%). Not moving temporary indices to production. Check the logs for details.';
         }
+    } else if (failurePercentage > paramFailureThresholdPercentage) {
+        jobReport.error = true;
+        jobReport.errorMessage = 'The percentage of records that failed to be indexed (' + failurePercentage + '%) exceeds the failureThresholdPercentage (' +
+            paramFailureThresholdPercentage + '%). Check the logs for details.';
     } else if (jobReport.chunksFailed > 0) {
         jobReport.error = true;
         jobReport.errorMessage = 'Some chunks failed to be sent, check the logs for details.';
@@ -292,4 +300,7 @@ exports.__setLastIndexingTasks = function(indexingTasks) {
 };
 exports.__getAttributesToSend = function() {
     return attributesToSend;
+}
+exports.__getJobReport = function() {
+    return jobReport;
 }

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -46,6 +46,14 @@
                             "@name": "deltaExportJobName",
                             "@type": "string",
                             "@required": "true"
+                        },
+                        {
+                            "@name": "failureThresholdPercentage",
+                            "@type": "long",
+                            "description": "Allowed percentage of records that failed to be indexed before marking the job in error. Default: 0.",
+                            "@required": false,
+                            "min-value":"0",
+                            "max-value":"100"
                         }
                     ]
                 },
@@ -108,6 +116,14 @@
                                 ]
                             },
                             "default-value": "partialRecordUpdate"
+                        },
+                        {
+                            "@name": "failureThresholdPercentage",
+                            "@type": "long",
+                            "description": "Allowed percentage of records that failed to be indexed before marking the job in error. Default: 0. When indexingMethod=fullCatalogReindex, the temporary index is not moved to production if the failure percentage exceeds this threshold.",
+                            "@required": false,
+                            "min-value":"0",
+                            "max-value":"100"
                         }
                     ]
                 },
@@ -150,6 +166,14 @@
                             "description": "A comma-separated list of attributes to be updated in the index. If not specified, the default list of attributes will be used (defaultAttributes + Algolia_AdditionalAttributes).",
                             "@required": false,
                             "@trim": true
+                        },
+                        {
+                            "@name": "failureThresholdPercentage",
+                            "@type": "long",
+                            "description": "Allowed percentage of records that failed to be indexed before marking the job in error. Default: 0",
+                            "@required": false,
+                            "min-value":"0",
+                            "max-value":"100"
                         }
                     ]
                 },
@@ -217,6 +241,14 @@
                                 ]
                             },
                             "default-value": "fullRecordUpdate"
+                        },
+                        {
+                            "@name": "failureThresholdPercentage",
+                            "@type": "long",
+                            "description": "Allowed percentage of records that failed to be indexed before marking the job in error. Default: 0",
+                            "@required": false,
+                            "min-value":"0",
+                            "max-value":"100"
                         }
                     ]
                 },

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -52,8 +52,8 @@
                             "@type": "long",
                             "description": "Allowed percentage of records that fails to be indexed before marking the job in error. Default: 0.",
                             "@required": false,
-                            "min-value":"0",
-                            "max-value":"100"
+                            "min-value": "0",
+                            "max-value": "100"
                         }
                     ]
                 },

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -50,7 +50,7 @@
                         {
                             "@name": "failureThresholdPercentage",
                             "@type": "long",
-                            "description": "Allowed percentage of records that failed to be indexed before marking the job in error. Default: 0.",
+                            "description": "Allowed percentage of records that fails to be indexed before marking the job in error. Default: 0.",
                             "@required": false,
                             "min-value":"0",
                             "max-value":"100"
@@ -120,7 +120,7 @@
                         {
                             "@name": "failureThresholdPercentage",
                             "@type": "long",
-                            "description": "Allowed percentage of records that failed to be indexed before marking the job in error. Default: 0. When indexingMethod=fullCatalogReindex, the temporary index is not moved to production if the failure percentage exceeds this threshold.",
+                            "description": "Allowed percentage of records that fails to be indexed before marking the job in error. Default: 0. When indexingMethod=fullCatalogReindex, the temporary index is not moved to production if the failure percentage exceeds this threshold.",
                             "@required": false,
                             "min-value":"0",
                             "max-value":"100"
@@ -170,7 +170,7 @@
                         {
                             "@name": "failureThresholdPercentage",
                             "@type": "long",
-                            "description": "Allowed percentage of records that failed to be indexed before marking the job in error. Default: 0",
+                            "description": "Allowed percentage of records that fails to be indexed before marking the job in error. Default: 0",
                             "@required": false,
                             "min-value":"0",
                             "max-value":"100"
@@ -245,7 +245,7 @@
                         {
                             "@name": "failureThresholdPercentage",
                             "@type": "long",
-                            "description": "Allowed percentage of records that failed to be indexed before marking the job in error. Default: 0",
+                            "description": "Allowed percentage of records that fails to be indexed before marking the job in error. Default: 0",
                             "@required": false,
                             "min-value":"0",
                             "max-value":"100"

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -150,19 +150,41 @@ describe('afterStep', () => {
         job.__setLastIndexingTasks({ "test_index_fr": 42, "test_index_en": 51 });
     });
 
-    test('partialRecordUpdate', () => {
-        job.beforeStep({ indexingMethod: 'partialRecordUpdate' }, stepExecution);
-        job.afterStep(true);
-        expect(mockFinishAtomicReindex).not.toHaveBeenCalled();
+    describe('partialRecordUpdate', () => {
+        test('failurePercentage <= failureThresholdPercentage', () => {
+            job.beforeStep({ indexingMethod: 'partialRecordUpdate', failureThresholdPercentage: 5 }, stepExecution);
+            job.__getJobReport().recordsFailed = 5;
+            job.__getJobReport().recordsToSend = 100;
+            job.afterStep(true);
+            expect(mockFinishAtomicReindex).not.toHaveBeenCalled();
+        });
+        test('failurePercentage > failureThresholdPercentage', () => {
+            job.beforeStep({ indexingMethod: 'partialRecordUpdate', failureThresholdPercentage: 5 }, stepExecution);
+            job.__getJobReport().recordsFailed = 6;
+            job.__getJobReport().recordsToSend = 100;
+            expect(() => job.afterStep(true)).toThrow(new Error('The percentage of records that failed to be indexed (6%) exceeds the failureThresholdPercentage (5%). Check the logs for details.'));
+            expect(mockFinishAtomicReindex).not.toHaveBeenCalled();
+        });
     });
-    test('fullCatalogReindex', () => {
-        job.beforeStep({ indexingMethod: 'fullCatalogReindex' }, stepExecution);
-        job.afterStep(true);
-        expect(mockFinishAtomicReindex).toHaveBeenCalledWith(
-            'products',
-            expect.arrayContaining(['default', 'fr', 'en']),
-            { "test_index_fr": 42, "test_index_en": 51 }
-        );
+    describe('fullCatalogReindex', () => {
+        test('failurePercentage <= failureThresholdPercentage', () => {
+            job.beforeStep({ indexingMethod: 'fullCatalogReindex', failureThresholdPercentage: 5 }, stepExecution);
+            job.__getJobReport().recordsFailed = 5;
+            job.__getJobReport().recordsToSend = 100;
+            job.afterStep(true);
+            expect(mockFinishAtomicReindex).toHaveBeenCalledWith(
+                'products',
+                expect.arrayContaining(['default', 'fr', 'en']),
+                {"test_index_fr": 42, "test_index_en": 51}
+            );
+        });
+        test('failurePercentage > failureThresholdPercentage', () => {
+            job.beforeStep({ indexingMethod: 'fullCatalogReindex', failureThresholdPercentage: 5 }, stepExecution);
+            job.__getJobReport().recordsFailed = 6;
+            job.__getJobReport().recordsToSend = 100;
+            expect(() => job.afterStep(true)).toThrow(new Error('The percentage of records that failed to be indexed (6%) exceeds the failureThresholdPercentage (5%). Not moving temporary indices to production. Check the logs for details.'));
+            expect(mockFinishAtomicReindex).not.toHaveBeenCalled();
+        });
     });
     test('job is marked as failed if error in the previous steps', () => {
         job.beforeStep({ indexingMethod: 'partialRecordUpdate' }, stepExecution);


### PR DESCRIPTION
New job step parameter: `failureThresholdPercentage`
When the percentage of records that failed to be indexed exceeds this threshold, the jobs are marked in error.

In case of failure:
- For a `fullCatalogReindex`, the temporary indices are not moved.
- For a delta export job, the delta export zips are not moved.
- For other jobs, the job is only reported in error

### Preview

![image](https://github.com/algolia/algoliasearch-sfcc-b2c/assets/2042109/bff2d21f-6023-41ad-890a-2a92cc3d8670)

---
SFCC-168