### PR TITLE
chore: make SSR work with compatibility mode 21.7 and below

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/ssrHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/ssrHelper.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const URLUtils = require('dw/web/URLUtils');
-const URLParameter = require('dw/web/URLParameter');
 const algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData').clientSideData;
 
 /**
@@ -51,8 +49,6 @@ function transformItems(items) {
 
         return item;
     });
-
-    return items;
 }
 
 /**

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/ssrHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/ssrHelper.js
@@ -64,7 +64,7 @@ function transformItems(items) {
  */
 function facetFiltersParamValueFromBreadcrumbs(cgid) {
     var breadcrumbs = require('*/cartridge/scripts/helpers/productHelpers').getAllBreadcrumbs(cgid, null, []);
-    var breadcrumbArray = breadcrumbs.map(({ htmlValue }) => htmlValue); // eslint-disable-line
+    var breadcrumbArray = breadcrumbs.map((breadcrumb) => breadcrumb.htmlValue);
 
     // example: ["__primary_category.2:Mens > Clothing > Suits"]
     var facetFiltersParamValue = '["__primary_category.' + (breadcrumbArray.length - 1) + ':' + breadcrumbArray.reverse().join(' > ') + '"]'

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig.js
@@ -134,10 +134,6 @@ var attributeConfig_v2 = {
         attribute: 'ID',
         localized: false
     },
-    in_stock: {
-        attribute: 'availabilityModel.inStock',
-        localized: false
-    },
     long_description: {
         attribute: 'longDescription.source',
         localized: true
@@ -219,6 +215,9 @@ var attributeConfig_v2 = {
     },
     image_groups: {
         localized: true
+    },
+    in_stock: {
+        localized: false
     },
     price: {
         localized: false


### PR DESCRIPTION
I got the following error when enabling SSR on a sandbox with CM 21.7:
```
SyntaxError: invalid object initializer
in controller Search
```


Small unrelated changed: moved the `in_stock` declaration to the 2nd section and removed the `attribute` field, as it's handled by a custom function