### PR TITLE
fix: productModelCustomizer for localized model

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js
@@ -3,7 +3,17 @@
 var algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
 
 /**
- * Create secondary category Algolia object
+ * Create secondary category Algolia object from a categories flat tree:
+ * For example, the following categories flat tree:
+ *   [
+ *     { id: 'newarrivals-electronics', name: { en: 'Electronics', fr: 'Electronique' } },
+ *     { id: 'newarrivals', name: { en: 'New Arrivals', fr: 'Nouveautés' } },
+ *   ]
+ * Will generate:
+ *   {
+ *      level_0: { en: 'New Arrivals', fr: 'Nouveautés' },
+ *      level_1: { en: 'New Arrivals > Electronics', fr: 'Nouveautés > Electronique' }
+ *   }
  * @param {Array} category - array of categories tree
  * @returns {Object} - secondary category Algolia object
  */
@@ -54,7 +64,39 @@ function customizeProductModel(productModel) {
 }
 
 /**
- * Customize Localized Algolia Product.
+ * Create a hierarchical category Algolia object from a categories flat tree, for a localized model.
+ * For example, the following categories flat tree:
+ *   [
+ *     { id: 'newarrivals-electronics', name: 'Electronics' },
+ *     { id: 'newarrivals', name: 'New Arrivals' }
+ *   ]
+ * Will generate:
+ *   {
+ *      level_0: 'New Arrivals',
+ *      level_1: 'New Arrivals > Electronics'
+ *   }
+ * @param {Array} category - array of categories tree
+ * @returns {Object} - secondary category Algolia object
+ */
+function createAlgoliaLocalizedCategoryObject(category) {
+    var CATEGORIES_LEVEL_PREFIX = 'level_';
+    var result = {};
+
+    category
+        .concat()
+        .reverse()
+        .reduce(function (parentCategory, childCategory, index) {
+            result[CATEGORIES_LEVEL_PREFIX + index] = parentCategory
+                ? parentCategory.name + algoliaData.CATEGORIES_SEPARATOR + childCategory.name
+                : childCategory.name
+            return childCategory;
+        }, null);
+
+    return result;
+}
+
+/**
+ * Customize a Localized Algolia Product.
  * Add extra properties to the product model.
  * @param {Object} productModel - Algolia product model
  * @param {Object} algoliaAttributes - The attributes to index
@@ -70,7 +112,7 @@ function customizeLocalizedProductModel(productModel, algoliaAttributes) {
             for (var i = 0; i < productModel.categories.length; i += 1) {
                 var rootCategoryId = productModel.categories[i][productModel.categories[i].length - 1].id;
                 if (rootCategoryId === CATEGORY_ID) {
-                    productModel[CATEGORY_ATTRIBUTE] = createAlgoliaCategoryObject(productModel.categories[i]);
+                    productModel[CATEGORY_ATTRIBUTE] = createAlgoliaLocalizedCategoryObject(productModel.categories[i]);
                     break;
                 }
             }

--- a/test/unit/int_algolia/scripts/algolia/customization/productModelCustomizer.test.js
+++ b/test/unit/int_algolia/scripts/algolia/customization/productModelCustomizer.test.js
@@ -1,0 +1,78 @@
+const productModelCustomizer = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer');
+
+describe('customizeProductModel (jobs v1)', () => {
+    let product;
+    beforeEach(() => {
+        product = {
+            categories: [
+                [
+                    {
+                        id: 'electronics-televisions',
+                        name: { en: 'Televisions', fr: 'Télévisions' },
+                    },
+                    { id: 'electronics', name: { en: 'Electronics', fr: 'Electronique' } },
+                ],
+                [
+                    {
+                        id: 'newarrivals-electronics',
+                        name: { en: 'Electronics', fr: 'Electronique' },
+                    },
+                    { id: 'newarrivals', name: { en: 'New Arrivals', fr: 'Nouveautés' } },
+                ],
+            ],
+        };
+    });
+
+    test('CATEGORIES_NEW_ARRIVALS in the additional attributes list', () => {
+        productModelCustomizer.customizeProductModel(product, ['CATEGORIES_NEW_ARRIVALS']);
+        expect(product).toHaveProperty('CATEGORIES_NEW_ARRIVALS');
+        expect(product.CATEGORIES_NEW_ARRIVALS).toEqual({
+            level_0: {
+                en: 'New Arrivals',
+                fr: 'Nouveautés',
+            },
+            level_1: {
+                en: 'New Arrivals > Electronics',
+                fr: 'Nouveautés > Electronique',
+            },
+        });
+    });
+
+    test('CATEGORIES_NEW_ARRIVALS not in the additional attributes list', () => {
+        productModelCustomizer.customizeProductModel(product, []);
+        // Property is present, but won't be read by the indexing pipeline
+        expect(product).toHaveProperty('CATEGORIES_NEW_ARRIVALS');
+    });
+});
+
+describe('customizeLocalizedProductModel (jobs v2)', () => {
+    let product;
+    beforeEach(() => {
+        product = {
+            categories: [
+                [
+                    { id: 'electronics-televisions', name: 'Televisions' },
+                    { id: 'electronics', name: 'Electronics' },
+                ],
+                [
+                    { id: 'newarrivals-electronics', name: 'Electronics' },
+                    { id: 'newarrivals', name: 'New Arrivals' },
+                ],
+            ],
+        };
+    });
+
+    test('CATEGORIES_NEW_ARRIVALS in the additional attributes list', () => {
+        productModelCustomizer.customizeLocalizedProductModel(product, ['CATEGORIES_NEW_ARRIVALS']);
+        expect(product).toHaveProperty('CATEGORIES_NEW_ARRIVALS');
+        expect(product.CATEGORIES_NEW_ARRIVALS).toEqual({
+            level_0: 'New Arrivals',
+            level_1: 'New Arrivals > Electronics',
+        });
+    });
+
+    test('CATEGORIES_NEW_ARRIVALS not in the additional attributes list', () => {
+        productModelCustomizer.customizeLocalizedProductModel(product, []);
+        expect(product).not.toHaveProperty('CATEGORIES_NEW_ARRIVALS');
+    });
+});


### PR DESCRIPTION
While testing #108, I found out that the productModelCustomizer isn't working properly for v2 jobs.
Indeed, the `createAlgoliaCategoryObject` function is expecting to have a non-localized model (i.e. have an object for the `name` property, containing all locales). For v2 jobs, as the `name` property is a string and not an object, it generates the following output:

```
{
    level_0: { '0': 'N', '1': 'e', '2': 'w', ...
    level_1: { '0': 'N > E', '1': 'e > l', '2': 'w > e', ...
}
```

### Changes

- Add a `createAlgoliaLocalizedCategoryObject` function that directly reads the `name` properties
- Add tests