### PR TITLE
fix: productModelCustomizer compatibility mode

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js
@@ -99,13 +99,13 @@ function createAlgoliaLocalizedCategoryObject(category) {
  * Customize a Localized Algolia Product.
  * Add extra properties to the product model.
  * @param {Object} productModel - Algolia product model
- * @param {Object} algoliaAttributes - The attributes to index
+ * @param {Array} algoliaAttributes - The attributes to index
  */
 function customizeLocalizedProductModel(productModel, algoliaAttributes) {
     var CATEGORY_ATTRIBUTE = 'CATEGORIES_NEW_ARRIVALS';
     var CATEGORY_ID = 'newarrivals';
 
-    if (algoliaAttributes.includes(CATEGORY_ATTRIBUTE)) {
+    if (algoliaAttributes.indexOf(CATEGORY_ATTRIBUTE) >= 0) {
         productModel[CATEGORY_ATTRIBUTE] = null;
 
         if (!empty(productModel.categories)) {


### PR DESCRIPTION
In older Compatibility Mode versions, the jobs are throwing the following error:
`TypeError: Cannot find function includes in object primary_category_id,in_stock,price. (int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js#108)`

Use `indexOf` instead of `includes` to make it compatible.
Tested on CM 18.10.