### PR TITLE
feat(insights): send purchasedObjectIDs events

### DIFF
--- a/cartridges/int_algolia/cartridge/templates/default/algolia/headerScripts.isml
+++ b/cartridges/int_algolia/cartridge/templates/default/algolia/headerScripts.isml
@@ -2,6 +2,8 @@
 <isset name="algoliaData" value="${require('*/cartridge/scripts/algolia/lib/algoliaData')}" scope="page" />
 
 <isif condition="${algoliaData.getPreference('Enable')}">
+    <isinclude template="algolia/insights" />
+
     <script>
         var algoliaData = <isprint value="${JSON.stringify(algoliaData.clientSideData)}" encoding="off"/>;
     </script>

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/insights-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/insights-config.js
@@ -92,34 +92,22 @@ function enableInsights(appId, searchApiKey, productsIndex) {
     }
 
     // Purchase events.
-    // SFRA doesn't trigger any 'afterPurchase' event or similar, but triggers a 'checkout:updateCheckoutView' event multiple times
-    // during the checkout process, for example after entering shipping information, or payment details.
-    // E.g.: https://github.com/SalesforceCommerceCloud/storefront-reference-architecture/blob/dec9c7c684275127338ac3197dfaf8fe656bb2b7/cartridges/app_storefront_base/cartridge/client/default/js/checkout/checkout.js#L147
-    // The payload of this event contains the order information. We are storing it locally and use it to send
-    // a 'purchasedObjectIDs' event to Algolia when the user finally clicks on the 'Place Order' button.
+    // The purchase event is sent when the user reaches the Order-Confirm endpoint.
+    // We can detect it because it's the only endpoint that sets a `orderUUID` in `pdict` properties:
+    // https://github.com/SalesforceCommerceCloud/storefront-reference-architecture/blob/dec9c7c684275127338ac3197dfaf8fe656bb2b7/cartridges/app_storefront_base/cartridge/controllers/Order.js#L87
+    // Our 'algolia-insights' tag exposes its "data-order" attribute only in that case. When it is present, we can send the purchase event.
     //
     // TODO: keep track of the queryID in the local storage when users give their consent, and send a 'purchasedObjectIDsAfterSearch' event
 
-    // Store the 'order' property of the last 'checkout:updateCheckoutView' received
-    let lastOrder;
+    const insightsData = document.querySelector('#algolia-insights');
+    const order = insightsData.dataset.order;
+    if (order) {
+        const orderObj = JSON.parse(order);
+        const products = orderObj.items.items.slice(0, 20); // The Insights API accepts up to 20 objectID
 
-    // The data object has a `order` attribute containing a OrderModel object:
-    // https://github.com/SalesforceCommerceCloud/storefront-reference-architecture/blob/dec9c7c684275127338ac3197dfaf8fe656bb2b7/cartridges/app_storefront_base/cartridge/models/order.js#L113
-    $('body').on('checkout:updateCheckoutView', function (event, data) {
-        lastOrder = data.order;
-    });
-
-    // Place Order button: https://github.com/SalesforceCommerceCloud/storefront-reference-architecture/blob/dec9c7c684275127338ac3197dfaf8fe656bb2b7/cartridges/app_storefront_base/cartridge/templates/default/checkout/checkout.isml#L106
-    $('.place-order').on('click', function () {
         const objectIDs = [];
         const objectData = [];
         let currency;
-
-        if (!lastOrder || !lastOrder.items || !lastOrder.items.items) {
-            return;
-        }
-
-        const products = lastOrder.items.items.slice(0, 20); // The Insights API accepts up to 20 objectID
 
         products.forEach((product) => {
             const productInfo = {
@@ -146,7 +134,7 @@ function enableInsights(appId, searchApiKey, productsIndex) {
             currency,
         };
         window.aa('purchasedObjectIDs', algoliaEvent);
-    });
+    }
 
     /**
      * Finds Insights target

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/insights-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/insights-config.js
@@ -100,7 +100,7 @@ function enableInsights(appId, searchApiKey, productsIndex) {
     // TODO: keep track of the queryID in the local storage when users give their consent, and send a 'purchasedObjectIDsAfterSearch' event
 
     const insightsData = document.querySelector('#algolia-insights');
-    const order = insightsData.dataset.order;
+    const order = insightsData && insightsData.dataset.order;
     if (order) {
         const orderObj = JSON.parse(order);
         const products = orderObj.items.items.slice(0, 20); // The Insights API accepts up to 20 objectID

--- a/cartridges/int_algolia_sfra/cartridge/templates/default/algolia/insights.isml
+++ b/cartridges/int_algolia_sfra/cartridge/templates/default/algolia/insights.isml
@@ -1,0 +1,6 @@
+<span id="algolia-insights"
+    <iscomment>orderUUID is only present after a completed purchase (Order-Confirm)</iscomment>
+    <isif condition="${pdict.orderUUID}">
+        data-order="${JSON.stringify(pdict.order)}"
+    </isif>
+></span>


### PR DESCRIPTION
Send [`purchasedObjectIDs` events](https://www.algolia.com/doc/api-reference/api-methods/purchased-object-ids/)

The event is sent when the user reaches the `Order-Confirm` step.
We can detect that because this endpoint is the only place that sets `pdict.orderUUID`: [see Order.js#L87](https://github.com/SalesforceCommerceCloud/storefront-reference-architecture/blob/dec9c7c684275127338ac3197dfaf8fe656bb2b7/cartridges/app_storefront_base/cartridge/controllers/Order.js#L87)

A new `<span>` dedicated to Algolia Insights has been introduced.
When `pdict.orderUUID` is present, the span will keep the `order` in its `data-order` property. The Insights library relies on its presence to send the purchase event.
(The span will also be used to hold the userToken)

### How to test

To test without having to complete the purchase flow:
- Update the `insights.isml` template:
  ```diff
  -    <isif condition="${pdict.orderUUID}">
  +    <isif condition="${pdict.order}">
  ```
- Add product(s) to your cart
- Go to the "Checkout" page. This page exposes `pdict.order`, so the `algolia-insights` span will be filled-up. You should see the `purchasedObjectIDs` being sent in the Network tabs of your browser console

---
SFCC-198