### PR TITLE
fix: copy index settings

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
@@ -68,7 +68,8 @@ function runCategoryExport(parameters, stepExecution) {
         logger.info('Deleting existing temporary indices...');
         var deletionTasks = reindexHelper.deleteTemporaryIndices('categories', siteLocales.toArray());
         reindexHelper.waitForTasks(deletionTasks);
-        logger.info('Temporary indices deleted. Starting indexing...');
+        logger.info('Temporary indices deleted. Copying index settings from production and starting indexing...');
+        reindexHelper.copySettingsFromProdIndices('categories', siteLocales.toArray());
     } catch (e) {
         jobReport.endTime = new Date();
         jobReport.error = true;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -123,7 +123,8 @@ exports.beforeStep = function(parameters, stepExecution) {
             logger.info('Deleting existing temporary indices...');
             var deletionTasks = reindexHelper.deleteTemporaryIndices('products', siteLocales.toArray());
             reindexHelper.waitForTasks(deletionTasks);
-            logger.info('Temporary indices deleted.');
+            logger.info('Temporary indices deleted. Copying index settings from production and starting indexing...');
+            reindexHelper.copySettingsFromProdIndices('products', siteLocales.toArray());
         } catch (e) {
             jobReport.endTime = new Date();
             jobReport.error = true;

--- a/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
@@ -95,6 +95,58 @@ function deleteIndex(indexName) {
 }
 
 /**
+ * Get index settings. https://www.algolia.com/doc/rest-api/search/#get-settings
+ * @param {string} indexName - index to get the settings from
+ * @returns {dw.svc.Result} - result of the call
+ */
+function getIndexSettings(indexName) {
+    var indexingService = algoliaIndexingService.getService(__jobInfo);
+
+    var result = retryableCall(
+        indexingService,
+        {
+            method: 'GET',
+            path: '/1/indexes/' + indexName + '/settings',
+        }
+    );
+
+    if (!result.ok) {
+        if (result.error === 404) {
+            logger.info('Index ' + indexName + ' does not exist.');
+        } else {
+            logger.error(result.getErrorMessage());
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Set index settings. https://www.algolia.com/doc/rest-api/search/#set-settings
+ * @param {string} indexName - targeted index
+ * @param {string} indexSettings - index settings to set
+ * @returns {dw.svc.Result} - result of the call
+ */
+function setIndexSettings(indexName, indexSettings) {
+    var indexingService = algoliaIndexingService.getService(__jobInfo);
+
+    var result = retryableCall(
+        indexingService,
+        {
+            method: 'PUT',
+            path: '/1/indexes/' + indexName + '/settings',
+            body: indexSettings,
+        }
+    );
+
+    if (!result.ok) {
+        logger.error(result.getErrorMessage());
+    }
+
+    return result;
+}
+
+/**
  * Copy the settings of an index to another. https://www.algolia.com/doc/rest-api/search/#copymove-index
  * @param {string} indexNameSrc - index to copy
  * @param {string} indexNameDest - name of the destination index
@@ -191,6 +243,8 @@ module.exports.setJobInfo = setJobInfo;
 module.exports.sendBatch = sendBatch;
 module.exports.sendMultiIndexBatch = sendMultiIndexBatch;
 module.exports.deleteIndex = deleteIndex;
+module.exports.getIndexSettings = getIndexSettings;
+module.exports.setIndexSettings = setIndexSettings;
 module.exports.copyIndexSettings = copyIndexSettings;
 module.exports.moveIndex = moveIndex;
 module.exports.waitTask = waitTask;

--- a/test/unit/int_algolia/scripts/algolia/algoliaIndexingAPI.test.js
+++ b/test/unit/int_algolia/scripts/algolia/algoliaIndexingAPI.test.js
@@ -78,6 +78,26 @@ test('deleteIndex', () => {
     });
 });
 
+test('getIndexSettings', () => {
+    indexingAPI.getIndexSettings('testIndex');
+
+    expect(mockRetryableCall).toHaveBeenCalledWith(mockService, {
+        method: 'GET',
+        path: '/1/indexes/testIndex/settings',
+    });
+});
+
+test('setIndexSettings', () => {
+    const settings = { 'testSetting': 'testValue' };
+    indexingAPI.setIndexSettings('testIndex', settings);
+
+    expect(mockRetryableCall).toHaveBeenCalledWith(mockService, {
+        method: 'PUT',
+        path: '/1/indexes/testIndex/settings',
+        body: settings,
+    });
+});
+
 test('copyIndexSettings', () => {
     indexingAPI.copyIndexSettings('testIndexSrc', 'testIndexDest');
 

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaCategoryIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaCategoryIndex.test.js
@@ -67,6 +67,7 @@ jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
     }
 }, {virtual: true});
 
+const mockCopySettingsFromProdIndices = jest.fn();
 const mockDeleteTemporaryIndices = jest.fn();
 const mockFinishAtomicReindex = jest.fn();
 jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
@@ -74,6 +75,7 @@ jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
     return {
         sendRetryableBatch: originalModule.sendRetryableBatch,
         deleteTemporaryIndices: mockDeleteTemporaryIndices,
+        copySettingsFromProdIndices: mockCopySettingsFromProdIndices,
         finishAtomicReindex: mockFinishAtomicReindex,
         waitForTasks: jest.fn(),
     };
@@ -105,6 +107,14 @@ test('runCategoryExport', () => {
 
     job.runCategoryExport({}, stepExecution);
     expect(mockSetJobInfo).toHaveBeenCalledWith({ jobID: 'TestJobID', stepID: 'TestStepID' });
+    expect(mockDeleteTemporaryIndices).toHaveBeenCalledWith(
+        'categories',
+        expect.arrayContaining(['default', 'fr', 'en'])
+    );
+    expect(mockCopySettingsFromProdIndices).toHaveBeenCalledWith(
+        'categories',
+        expect.arrayContaining(['default', 'fr', 'en'])
+    );
     expect(mockSendMultiIndexBatch).toMatchSnapshot();
     expect(mockFinishAtomicReindex).toHaveBeenCalledWith(
         'categories',

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -92,6 +92,7 @@ describe('process', () => {
         job.beforeStep({}, stepExecution);
         expect(mockSetJobInfo).toHaveBeenCalledWith({ jobID: 'TestJobID', stepID: 'TestStepID', indexingMethod: 'partialRecordUpdate' });
         expect(mockDeleteTemporaryIndices).not.toHaveBeenCalled();
+        expect(mockDeleteTemporaryIndices).not.toHaveBeenCalled();
 
         var algoliaOperations = job.process(new ProductMock());
         expect(algoliaOperations).toMatchSnapshot(); //  "action" should be "partialUpdateObject" when no indexingMethod is specified
@@ -99,6 +100,7 @@ describe('process', () => {
     test('partialRecordUpdate', () => {
         job.beforeStep({ indexingMethod: 'partialRecordUpdate' }, stepExecution);
         expect(mockSetJobInfo).toHaveBeenCalledWith({ jobID: 'TestJobID', stepID: 'TestStepID', indexingMethod: 'partialRecordUpdate' });
+        expect(mockDeleteTemporaryIndices).not.toHaveBeenCalled();
         expect(mockDeleteTemporaryIndices).not.toHaveBeenCalled();
 
         var algoliaOperations = job.process(new ProductMock());
@@ -108,6 +110,7 @@ describe('process', () => {
         job.beforeStep({ indexingMethod: 'fullRecordUpdate' }, stepExecution);
         expect(mockSetJobInfo).toHaveBeenCalledWith({ jobID: 'TestJobID', stepID: 'TestStepID', indexingMethod: 'fullRecordUpdate' });
         expect(mockDeleteTemporaryIndices).not.toHaveBeenCalled();
+        expect(mockDeleteTemporaryIndices).not.toHaveBeenCalled();
 
         var algoliaOperations = job.process(new ProductMock());
         expect(algoliaOperations).toMatchSnapshot();
@@ -115,6 +118,10 @@ describe('process', () => {
     test('fullCatalogReindex', () => {
         job.beforeStep({ indexingMethod: 'fullCatalogReindex' }, stepExecution);
         expect(mockSetJobInfo).toHaveBeenCalledWith({ jobID: 'TestJobID', stepID: 'TestStepID', indexingMethod: 'fullCatalogReindex' });
+        expect(mockDeleteTemporaryIndices).toHaveBeenCalledWith(
+            'products',
+            expect.arrayContaining(['default', 'fr', 'en'])
+        );
         expect(mockDeleteTemporaryIndices).toHaveBeenCalledWith('products', expect.arrayContaining(['default', 'fr', 'en']));
 
         var algoliaOperations = job.process(new ProductMock());


### PR DESCRIPTION
The [copy settings](https://www.algolia.com/doc/rest-api/search/#copymove-index) behaviour is slightly different between Algolia's Classic and the newer engine:
When copying index settings from a source index that doesn't exist, the engine returns a `taskID` in both cases. But:
- On Classic, this taskID was immediately marked as `published`
- On the newer infra, this taskID will never be marked as `published`, the engine considers that there is nothing to do so it doesn't "publish" anything

The cartridge was relying on the former behaviour, and the `finishAtomicReindex` method was systematically doing a `copyIndex` and then wait for the task to complete, even in the case of a first `fullCatalogReindex`, where the production index doesn't exist yet.
So on the newer infra, the `waitTask` timeouts and the jobs is marked as failed.

### Changes

- Do a `getSettings` + `setSettings` instead of a `copy`, so we can check if the index exists (we get a 404 when the index doesn't exist)
- Bonus: call `copySettingsFromProdIndices` at the beginning of the `fullCatalogReindex` job too, so the settings are present in the `.tmp` if users want to inspect it during a reindex. (Also, it's more efficient to set the index settings before pushing the data, [as explained in the documentation](https://www.algolia.com/doc/api-reference/api-methods/set-settings/#about-this-method))

---
SFCC-212