### PR TITLE
feat(insights): set user tokens

### DIFF
--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/insights-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/insights-config.js
@@ -14,7 +14,7 @@ function enableInsights(appId, searchApiKey, productsIndex) {
     let userToken;
     let authenticatedUserToken;
 
-    const dwanonymousCookieMatch = document.cookie.match(/dwanonymous_.\w*=(\w*);/);
+    const dwanonymousCookieMatch = document.cookie.match(/dwanonymous_\w*=(\w*);/);
     if (dwanonymousCookieMatch) {
         userToken = dwanonymousCookieMatch[1];
     }

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/insights-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/insights-config.js
@@ -14,7 +14,7 @@ function enableInsights(appId, searchApiKey, productsIndex) {
     let userToken;
     let authenticatedUserToken;
 
-    const dwanonymousCookieMatch = document.cookie.match(/dwanonymous_.\w*=(\w*);/)
+    const dwanonymousCookieMatch = document.cookie.match(/dwanonymous_.\w*=(\w*);/);
     if (dwanonymousCookieMatch) {
         userToken = dwanonymousCookieMatch[1];
     }

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/insights-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/insights-config.js
@@ -9,9 +9,24 @@
  * @param {string} productsIndex Products index name
  */
 function enableInsights(appId, searchApiKey, productsIndex) {
+    const insightsData = document.querySelector('#algolia-insights');
+
+    let userToken;
+    let authenticatedUserToken;
+
+    const dwanonymousCookieMatch = document.cookie.match(/dwanonymous_.\w*=(\w*);/)
+    if (dwanonymousCookieMatch) {
+        userToken = dwanonymousCookieMatch[1];
+    }
+    if (insightsData && insightsData.dataset.userauthenticated === 'true') {
+        authenticatedUserToken = insightsData.dataset.usertoken;
+    }
+
     window.aa('init', {
         appId,
         apiKey: searchApiKey,
+        userToken,
+        authenticatedUserToken,
     });
 
     let lastQueryID = null;
@@ -99,7 +114,6 @@ function enableInsights(appId, searchApiKey, productsIndex) {
     //
     // TODO: keep track of the queryID in the local storage when users give their consent, and send a 'purchasedObjectIDsAfterSearch' event
 
-    const insightsData = document.querySelector('#algolia-insights');
     const order = insightsData && insightsData.dataset.order;
     if (order) {
         const orderObj = JSON.parse(order);

--- a/cartridges/int_algolia_sfra/cartridge/templates/default/algolia/insights.isml
+++ b/cartridges/int_algolia_sfra/cartridge/templates/default/algolia/insights.isml
@@ -1,4 +1,6 @@
 <span id="algolia-insights"
+    data-usertoken="${session.customer.ID}"
+    data-userauthenticated="${session.customer.authenticated}"
     <iscomment>orderUUID is only present after a completed purchase (Order-Confirm)</iscomment>
     <isif condition="${pdict.orderUUID}">
         data-order="${JSON.stringify(pdict.order)}"


### PR DESCRIPTION
ISML gives access to the `dw.system.Session`
We can leverage the recently introduced `algolia-insights` span to expose the authenticated user token and pass it to the `authenticatedUserToken` parameter of the insights library.

The `userToken` is set using the `dwanonymous_` cookie exposed by the platform.

This permits to have both tokens in parallel and ensure continuity when the user logs in.

### How to test :test_tube: 

- Open a CLP
  - a `Hits Viewed` event is sent to the insights API with only the `userToken`. The value match the value of the `dwanonymous_` cookie
- Log in
- Go to a CLP
  - a `Hits Viewed` event is sent with the same `userToken` and a `authenticatedUserToken`

---
SFCC-199