### PR TITLE
feat: add queryID in purchase events

### DIFF
--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/insights-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/insights-config.js
@@ -15,7 +15,7 @@ function enableInsights(appId, searchApiKey, productsIndex) {
     let userToken;
     let authenticatedUserToken;
     let trackingAllowed = false;
-    let trackedQueryIDs;
+    let trackedQueryIDs = {};
 
     const dwanonymousCookieMatch = document.cookie.match(/dwanonymous_\w*=(\w*);/);
     if (dwanonymousCookieMatch) {
@@ -89,7 +89,9 @@ function enableInsights(appId, searchApiKey, productsIndex) {
 
             objectIDs.push(product.id);
             objectData.push(productInfo);
-            trackedQueryIDs[product.id] = queryID;
+            if (trackingAllowed) {
+                trackedQueryIDs[product.id] = queryID;
+            }
         });
 
         if (trackingAllowed) {
@@ -157,7 +159,7 @@ function enableInsights(appId, searchApiKey, productsIndex) {
                 ).toFixed(2);
             }
             if (trackingAllowed) {
-                productInfo.queryID = trackedQueryIDs && trackedQueryIDs[product.id];
+                productInfo.queryID = trackedQueryIDs[product.id];
                 delete trackedQueryIDs[product.id];
             }
             currency = product.price.sales.currency;

--- a/cartridges/int_algolia_sfra/cartridge/templates/default/algolia/insights.isml
+++ b/cartridges/int_algolia_sfra/cartridge/templates/default/algolia/insights.isml
@@ -1,6 +1,7 @@
 <span id="algolia-insights"
     data-usertoken="${session.customer.ID}"
     data-userauthenticated="${session.customer.authenticated}"
+    data-trackingallowed="${session.trackingAllowed}"
     <iscomment>orderUUID is only present after a completed purchase (Order-Confirm)</iscomment>
     <isif condition="${pdict.orderUUID}">
         data-order="${JSON.stringify(pdict.order)}"


### PR DESCRIPTION
Add the `queryID` in purchase events.
Query IDs are stored in the local storage when products are added to the cart.
We only store them if the user has allowed tracking. The `trackingAllowed` flag is kept in the `algolia-insights` span.

Query IDs are deleted from the local storage when the purchase event is sent.
A cleanup is also done at each `addToCard` event.

### How to test

- Update the insights.isml template to trigger the purchase event on the checkout page: 
  ```diff
  -    <isif condition="${pdict.orderUUID}">
  +    <isif condition="${pdict.order}">
  ```

#### Happy path
- Visit the website after giving tracking consent (note: the page needs to be refreshed after clicking "yes" on the popup for the `span` to be updated)
- Add products to your cart. You will see an `algolia-insight` item created in the local storage
- Visit the checkout page and observe the network events: the purchase event will have the queryID in the `objectData`

#### Local storage cleanup

Add and then delete products from your cart. The `algolia-insights` local storage item will be updated

#### Disabled tracking

- Clean the session cookies, refresh the page and disallow tracking.
- Refresh the page again: the `algolia-insights` item should be deleted from the local storage
- Adding products to the cart shouldn't add anything in the local storage