### PR TITLE
fix: retry batch strategy

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
@@ -135,13 +135,19 @@ function sendRetryableBatch(batch) {
                 }
             }
             logger.info('[Retryable batch] Removing records for product "' + objectIdToRemove + '"');
+            var removedRecords = 0;
             for (var i = batch.length - 1; i >= 0; --i) {
                 if (batch[i].body.objectID === objectIdToRemove) {
                     batch.splice(i, 1);
                     failedRecords++;
+                    removedRecords++;
                 }
             }
-            logger.info('[Retryable batch] Retrying batch...');
+            if (removedRecords === 0) {
+                logger.warn('[Retryable batch] could not remove any record. Not retrying the batch.');
+                break;
+            }
+            logger.info('[Retryable batch] Removed ' + removedRecords + ' records. Retrying batch...');
             result = algoliaIndexingAPI.sendMultiIndexBatch(batch);
         } catch(e) {
             // Error message is not JSON, ignoring

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
@@ -118,16 +118,25 @@ function sendRetryableBatch(batch) {
         ++attempt;
         try {
             var apiResponse = JSON.parse(result.getErrorMessage());
-            // When records are failing, Algolia returns the following:
-            // {"message":"Record at the position 6 objectID=008884303996M is too big size=11072/10000 bytes. Please have a look at [...]", "position":6,"objectID":"008884303996M","status":400}
-            if (!apiResponse.objectID || !apiResponse.message || !apiResponse.message.startsWith('Record at the position')) {
-                // No faulty record detected, nothing else to do
+            // When records are failing, Algolia returns the following (those are examples for records too big):
+            // - For Classic: {"message":"Record at the position 6 objectID=008884303996M is too big size=11072/10000 bytes. Please have a look at [...]", "position":6,"objectID":"008884303996M","status":400}
+            // - For Current: {"message":"Record 008884303996M is too big: size: 11072 byte(s), maximum allowed: 100000 byte(s). Please have a look at [...]","status":400}
+            if (!apiResponse.objectID && (!apiResponse.message || !apiResponse.message.indexOf('is too big') > 0)) {
+                // No identified objectID, and not an "is too big" error. Nothing else to do
                 break;
             }
-            logger.info('[Retryable batch] Removing records for product ' + apiResponse.objectID);
+            var objectIdToRemove;
+            if (apiResponse.objectID) {
+                objectIdToRemove = apiResponse.objectID
+            } else {
+                var match = apiResponse.message.match(/^Record (.*) is too big/);
+                if (match) {
+                    objectIdToRemove = match[1];
+                }
+            }
+            logger.info('[Retryable batch] Removing records for product "' + objectIdToRemove + '"');
             for (var i = batch.length - 1; i >= 0; --i) {
-                if (batch[i].body.objectID === apiResponse.objectID) {
-                    logger.info('[Retryable batch] Removing record for product ' + apiResponse.objectID + ' from the batch (index '+ batch[i].indexName + ')');
+                if (batch[i].body.objectID === objectIdToRemove) {
                     batch.splice(i, 1);
                     failedRecords++;
                 }


### PR DESCRIPTION
The Batch API response when some records are refused by the engine is different on the new Algolia infra:
- It previously had a `objectID` field to identify the faulty record
- The `message` field is slightly different

This PR updates the logic that identifies and removes faulty records from a batch:
- If the payload contains the `objectID` field, we still rely on it
- Otherwise, if the message contains `is too big`, we use a regex to extract the faulty objectID

### How to test

@htuzel if you want to test I've invited you to the "Ingestion test" app that runs on the new infra.

- Modify the cartridge to generate a big record for one of the products. To do so, I've added the following code to the `customizeLocalizedProductModel()` function, that sets 100KB of text in a `test` attribute, for product "vizio-vw46lfM":
  ```js
  if (productModel.objectID === 'vizio-vw46lfM') {
      var _100kb = '';
      for (let i = 0; i < 10000; ++i) {
          _100kb += '10b.oftext';
      }
      productModel.test = _100kb;
  }
  ```
- Point your cartridge to the app running on the new infra
- Run the `algoliaProductIndex` job. You will see in the logs that only the records for product "vizio-vw46lfM" were removed from the batches and the total number of failed record matches the number of locales.

---
SRCH-6898