### PR TITLE
fix: system object definitions

### DIFF
--- a/metadata/algolia/meta/system-objecttype-extensions.xml
+++ b/metadata/algolia/meta/system-objecttype-extensions.xml
@@ -140,9 +140,9 @@
                 <display-name xml:lang="x-default">InStock Threshold</display-name>
                 <description xml:lang="x-default">Stock Threshold</description>
                 <type>double</type>
-                <default-value>0.0</default-value>
                 <mandatory-flag>true</mandatory-flag>
                 <externally-managed-flag>false</externally-managed-flag>
+                <default-value>0.0</default-value>
             </attribute-definition>
 
             <attribute-definition attribute-id="Algolia_AdditionalAttributes">


### PR DESCRIPTION
System Object types definitions have been broken in #110
Trying to import them result in the following error:

> ERROR [144|33] cvc-complex-type.2.4.d: Invalid content was found starting with element 'mandatory-flag'. No child element is expected at this point.

It turns out that the `default-value` is apparently expected at the end.

Also quick question: why has it been marked as mandatory in the definition? It's not marked as mandatory in the UI, and since it's a number, it defaults to 0.0 in any case I think?