### PR TITLE
chore: introduce release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Draft release
+run-name: Draft release ${{ inputs.next_version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      next_version:
+        required: true
+        type: string
+        description: 'Version name'
+
+permissions:
+  contents: write
+
+jobs:
+  draft_release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+
+      - name: Merge develop
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git checkout main
+          git merge origin/develop
+          git push
+
+      - name: Draft release
+        run: gh release create $VERSION --generate-notes --draft
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.next_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git checkout main
+          git checkout master
           git merge origin/develop
           git push
 


### PR DESCRIPTION
Our current release flow is too manual and error prone (cf #123).
This PR introduces a GitHub workflow to handle it. It will:
- Checkout the project
- Merge the `develop` branch into `master`
- Draft a new release

After the workflow is merged, the release flow will become:
- Create a PR to bump the version number and write a changelog
- Merge the PR on `develop`
- Go into **Actions > Draft release** and trigger the release workflow [manually](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) (The version/tag name is a required parameter)
- Go in the [Releases](https://github.com/algolia/algoliasearch-sfcc-b2c/releases) section to edit the draft and publish it

I've tested the workflow on a private repo so I couldn't test how it behaves with branches protection, but we will be able to adjust.