### PR TITLE
fix(sg): set insights user token and rely on enableInsights param

### DIFF
--- a/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/index.js
+++ b/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/index.js
@@ -24,5 +24,7 @@ document.addEventListener('DOMContentLoaded', function () {
         categoryDisplayNamePathSeparator: categoryDisplayNamePathSeparator,
     });
 
-    enableInsights(algoliaData.applicationID, algoliaData.searchApiKey);
+    if (algoliaData.enableInsights) {
+        enableInsights(algoliaData.applicationID, algoliaData.searchApiKey, algoliaData.productsIndex);
+    }
 });

--- a/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/insights-config.js
+++ b/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/insights-config.js
@@ -4,8 +4,9 @@
  * Configures Insights
  * @param {string} appId Application ID
  * @param {string} searchApiKey Search API Key
+ * @param {string} productsIndex Products index name
  */
-function enableInsights(appId, searchApiKey) {
+function enableInsights(appId, searchApiKey, productsIndex) {
     const insightsData = document.querySelector('#algolia-insights');
 
     let userToken;
@@ -33,7 +34,7 @@ function enableInsights(appId, searchApiKey) {
     document.addEventListener('click', function (event) {
         var queryID = getUrlParameter('queryID') || lastQueryID;
         var objectID = getUrlParameter('objectID') || lastObjectID;
-        var indexName = getUrlParameter('indexName') || lastIndexName;
+        var indexName = getUrlParameter('indexName') || lastIndexName || productsIndex;
 
         if ($(event.target).is('button.add-to-cart')) {
             handleCartAction('Product Add to cart', queryID, objectID, indexName);

--- a/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/insights-config.js
+++ b/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/insights-config.js
@@ -6,6 +6,26 @@
  * @param {string} searchApiKey Search API Key
  */
 function enableInsights(appId, searchApiKey) {
+    const insightsData = document.querySelector('#algolia-insights');
+
+    let userToken;
+    let authenticatedUserToken;
+
+    const dwanonymousCookieMatch = document.cookie.match(/dwanonymous_\w*=(\w*);/);
+    if (dwanonymousCookieMatch) {
+        userToken = dwanonymousCookieMatch[1];
+    }
+    if (insightsData && insightsData.dataset.userauthenticated === 'true') {
+        authenticatedUserToken = insightsData.dataset.usertoken;
+    }
+
+    window.aa('init', {
+        appId,
+        apiKey: searchApiKey,
+        userToken,
+        authenticatedUserToken,
+    });
+
     var lastQueryID = null;
     var lastIndexName = null;
     var lastObjectID = null;


### PR DESCRIPTION
I've tested more the SiteGenesis cartridge and realized that what we did on SFRA for the userTokens in #115 is also valid on SiteGenesis:
- the `<span id="algolia-insights"` is present in the frontend
- the `dwanonymous_` cookie is also exposed by the platform.

### Changes:
- Set userToken and authenticatedUserToken the same way we did in #115.
- Fix: we weren't checking `algoliaData.enableInsights` before calling `enableInsights()`
- Chore: pass the default `productsIndex` to `enableInsights()`

---
SFCC-227