### PR TITLE
fix: don't send empty batches

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -209,6 +209,9 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
     // algoliaOperations contains all the returned Algolia operations from process() as a List of arrays
     var algoliaOperationsArray = algoliaOperations.toArray();
     var productCount = algoliaOperationsArray.length;
+    if (!productCount) {
+        return;
+    }
 
     var batch = [];
     for (let i = 0; i < productCount; ++i) {

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -164,7 +164,7 @@ describe('send', () => {
 
         expect(mockSendMultiIndexBatch).not.toHaveBeenCalled();
     });
-})
+});
 
 describe('afterStep', () => {
     beforeAll(() => {

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -129,28 +129,42 @@ describe('process', () => {
     });
 });
 
-test('send', () => {
-    job.beforeStep({}, stepExecution);
+describe('send', () => {
+    test('normal batch', () => {
+        job.beforeStep({}, stepExecution);
 
-    const algoliaOperationsChunk = [];
-    for (let i = 0; i < 3; ++i) {
-        const algoliaOperations = [
-            { action: 'addObject', indexName: 'test_en', body: { id: `${i}` } },
-            { action: 'addObject', indexName: 'test_fr', body: { id: `${i}` } },
-        ];
-        algoliaOperations.toArray = function () {
-            return algoliaOperations;
+        const algoliaOperationsChunk = [];
+        for (let i = 0; i < 3; ++i) {
+            const algoliaOperations = [
+                { action: 'addObject', indexName: 'test_en', body: { id: `${i}` } },
+                { action: 'addObject', indexName: 'test_fr', body: { id: `${i}` } },
+            ];
+            algoliaOperations.toArray = function () {
+                return algoliaOperations;
+            };
+            algoliaOperationsChunk.push(algoliaOperations);
+        }
+        algoliaOperationsChunk.toArray = function () {
+            return algoliaOperationsChunk;
         };
-        algoliaOperationsChunk.push(algoliaOperations);
-    }
-    algoliaOperationsChunk.toArray = function () {
-        return algoliaOperationsChunk;
-    };
 
-    job.send(algoliaOperationsChunk);
+        job.send(algoliaOperationsChunk);
 
-    expect(mockSendMultiIndexBatch).toHaveBeenCalledWith(algoliaOperationsChunk.flat());
-});
+        expect(mockSendMultiIndexBatch).toHaveBeenCalledWith(algoliaOperationsChunk.flat());
+    });
+
+    test('empty batch', () => {
+        job.beforeStep({}, stepExecution);
+
+        const algoliaOperationsChunk = [];
+        algoliaOperationsChunk.toArray = function () {
+            return algoliaOperationsChunk;
+        };
+        job.send(algoliaOperationsChunk);
+
+        expect(mockSendMultiIndexBatch).not.toHaveBeenCalled();
+    });
+})
 
 describe('afterStep', () => {
     beforeAll(() => {


### PR DESCRIPTION
When sending an empty batch of records, the `taskID` field of the Algolia response is set to `0` instead of an object:
`{"taskID":0,"objectIDs":[]}`

As the cartridge expects an object and tries to iterate on the taskIDs (using `Object.keys()`), sending an empty batch was generating an error.

### Changes

- Don't send batches of 0 records

### How to test

Temporarily change the `isInclude()` method of the [`productFilter`](https://github.com/algolia/algoliasearch-sfcc-b2c/blob/master/cartridges/int_algolia/cartridge/scripts/algolia/filters/productFilter.js) to `return false;` and run the AlgoliaProducIndex_v2 job.