### PR TITLE
fix: partially revert #114 and use 'copyIndex' to copy index settings

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
@@ -37,12 +37,13 @@ function copySettingsFromProdIndices(indexType, locales) {
         var tmpIndexName = indexName + '.tmp';
         var getSettingsRes = algoliaIndexingAPI.getIndexSettings(indexName);
         if (getSettingsRes.ok) {
-            var setSettingsRes = algoliaIndexingAPI.setIndexSettings(tmpIndexName, getSettingsRes.object.body);
-            if (!setSettingsRes.ok) {
-                throw new Error('Error while setting index settings to ' + tmpIndexName + ': ' + setSettingsRes.getErrorMessage())
+            var copySettingsRes = algoliaIndexingAPI.copyIndexSettings(indexName, tmpIndexName);
+            if (copySettingsRes.ok) {
+                logger.info('Settings copied to ' + tmpIndexName + '. ' + JSON.stringify(copySettingsRes.object.body));
+                copySettingsTasks[tmpIndexName] = copySettingsRes.object.body.taskID;
+            } else {
+                throw new Error('Error while copying index settings: ' + copySettingsRes.getErrorMessage())
             }
-            logger.info('Settings copied to ' + tmpIndexName + ': ' + JSON.stringify(setSettingsRes.object.body));
-            copySettingsTasks[tmpIndexName] = setSettingsRes.object.body.taskID;
         } else if (getSettingsRes.error !== 404) {
             throw new Error('Error while getting index settings from ' + indexName + ': ' + getSettingsRes.getErrorMessage())
         }

--- a/test/unit/int_algolia/scripts/algolia/helper/reindexHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/reindexHelper.test.js
@@ -11,7 +11,7 @@ const mockCopySettingsFromProdIndices = jest.fn().mockReturnValue({
     ok: true,
     object: {
         body: {
-            taskID: 42,
+            taskID: 43,
             updatedAt: '2023-10-01T12:00:00.000Z'
         }
     }
@@ -64,26 +64,15 @@ test('copyIndexSettings', () => {
             }
         }
     });
-    mockSetIndexSettings.mockImplementation((indexName, settings) => {
-        return {
-            ok: true,
-            object: {
-                body: {
-                    taskID:  indexName.endsWith('fr.tmp') ? 806 : 807,
-                    updatedAt: '2023-10-01T12:00:00.000Z'
-                }
-            }
-        }
-    });
 
     var res = reindexHelper.copySettingsFromProdIndices('products', ['fr', 'en']);
     expect(mockGetIndexSettings).nthCalledWith(1, 'test_index___products__fr');
-    expect(mockSetIndexSettings).nthCalledWith(1, 'test_index___products__fr.tmp', frSettings);
     expect(mockGetIndexSettings).nthCalledWith(2, 'test_index___products__en');
-    expect(mockSetIndexSettings).nthCalledWith(2, 'test_index___products__en.tmp', enSettings);
+    expect(mockCopySettingsFromProdIndices).nthCalledWith(1, 'test_index___products__fr', 'test_index___products__fr.tmp');
+    expect(mockCopySettingsFromProdIndices).nthCalledWith(2, 'test_index___products__en', 'test_index___products__en.tmp');
     expect(res).toEqual({
-        "test_index___products__fr.tmp": 806,
-        "test_index___products__en.tmp": 807,
+        "test_index___products__fr.tmp": 43,
+        "test_index___products__en.tmp": 43,
     });
 });
 


### PR DESCRIPTION
For reasons detailed in #114, we can't do a [`copyIndex`](https://www.algolia.com/doc/rest-api/search/#copymove-index) without checking first if the index exists on Algolia's newer engine.

To check if an index exist, the common way is to do a [`getSettings`](https://www.algolia.com/doc/rest-api/search/#get-settings) on it.
Since a `getSettings` returns the index settings, I used the response to then call `setSettings`.
The problem with that approach is that it copies only the settings, while the `copyIndex` endpoint also copies Rules and Synonyms.

### Changes

- Still check if the index exists with a `getSettings` call, but use the `copyIndex` endpoint to actually do the settings copy.