### PR TITLE
fix: naming convention for splittingTag

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
@@ -152,10 +152,10 @@ exports.process = function(content, parameters, stepExecution) {
         indexName += '.tmp';
         let localizedContent = new AlgoliaLocalizedContent({ content: content, locale: locale, attributeList: attributesToSend, baseModel: baseModel, includedContent: includedContent });
         let splits = [];
-        let tagDelimiter = parameters.tagDelimiter;
+        let splittingTag = parameters.splittingTag;
         if (attributesToSend.indexOf('body') >= 0 && localizedContent.body) {
             let maxRecordBytes = algoliaSplitter.getMaxBodySize(localizedContent);
-            splits = algoliaSplitter.splitHtmlContent(localizedContent.body, maxRecordBytes, tagDelimiter);
+            splits = algoliaSplitter.splitHtmlContent(localizedContent.body, maxRecordBytes, splittingTag);
             for (let i = 0; i < splits.length; i++) {
                 var splittedContent = {};
                 for (var key in localizedContent) {

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -352,7 +352,7 @@
                             "max-value":"100"
                         },
                         {
-                            "@name": "tagDelimiter",
+                            "@name": "splittingTag",
                             "@type": "string",
                             "description": "The HTML tag used to split the content into chunks. If not specified, the content will be split according to DEFAULT_MAX_RECORD_BYTES.",
                             "@required": false,

--- a/metadata/algolia/jobs.xml
+++ b/metadata/algolia/jobs.xml
@@ -131,7 +131,7 @@ Can perform full records updates or partial records updates. See the 'indexingMe
             <step step-id="algoliaContentIndex" type="custom.algoliaContentIndex" enforce-restart="false">
                 <description>Index all searchable contents assigned to the selected site to Algolia. The list of indexed attributes is configurable.</description>
                 <parameters>
-                    <parameter name="tagDelimiter">h1</parameter>
+                    <parameter name="splittingTag">h1</parameter>
                     <parameter name="attributeList">id,name,description,url,body,page</parameter>
                 </parameters>
             </step>


### PR DESCRIPTION
## Changes

- Just changed variable name from `delimiterTag` to `splittingTag` to make it more clear