### PR TITLE
feat: Handling Dynamic content Values

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaSplitter.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaSplitter.js
@@ -39,7 +39,7 @@ function splitHtmlContent(htmlContent, maxByteSize, splitterElement) {
 
 
         //remove all HTML tags
-        section = removeHtmlTags(section);
+        section = removeHtmlTagsAndFormat(section);
 
         var sectionSize = new Bytes(section).getLength();
         if (sectionSize > maxByteSize) {
@@ -70,12 +70,16 @@ function removeIgnoredContent(content) {
 }
 
 /**
- * removes all HTML tags
+ * removes all HTML tags and formats
  * @param {string} content - Content will be sanitized
  * @returns {string} Sanitized content
  */
-function removeHtmlTags(content) {
-    return content.replace(/<[^>]*>/g, '');
+function removeHtmlTagsAndFormat(content) {
+    return content
+        .replace(/<[^>]*>/g, '') // Removes HTML tags
+        .replace(/&nbsp;/g, ' ') // Replaces non-breaking spaces with a space
+        .replace(/\r\n/g, ' ') // Replaces carriage returns and newlines with spaces
+        .replace(/\s+/g, ' '); // Condenses multiple consecutive spaces into a single space
 }
 
 /**
@@ -126,5 +130,6 @@ function getMaxBodySize(content) {
 
 module.exports = {
     splitHtmlContent: splitHtmlContent,
-    getMaxBodySize: getMaxBodySize
+    getMaxBodySize: getMaxBodySize,
+    removeHtmlTagsAndFormat: removeHtmlTagsAndFormat
 };

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil.js
@@ -53,13 +53,6 @@ function contentLinkHandler(body) {
         return '';
     }
 
-    // Check and Replace static links in the body text
-    if (body.indexOf('$staticlink$') !== -1) {
-        body = body.replace(/(\()?([^"']+)\?\$staticlink\$/gi, function(match, p1, path) {
-            return contentAssetFunctions.staticURL(path);
-        });
-    }
-
     // Check and Replace URL functions in the body text
     if (body.indexOf('$Url(') !== -1 || body.indexOf('$url(') !== -1){
         body = body.replace(/\$Url\((.*?)\)\$/gi, function(match, argsStr) {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil.js
@@ -15,7 +15,7 @@ var contentAssetFunctions = {
             var args = Array.prototype.slice.call(arguments);
             var action = args.shift();
             try {
-                return URLUtils[method].apply(URLUtils, [action].concat(args));
+                return URLUtils[method].apply(URLUtils, args);
             } catch (e) {
                 // Log or handle the error as appropriate for your application
                 logger.error('Error calling URLUtils.: ' + method + ': ', e);

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil.js
@@ -55,26 +55,26 @@ function contentLinkHandler(body) {
     }
 
     // Replace static links in the body text
-    body = body.replace(/(\()?([^"']+)\?\$staticlink\$/g, function(match, p1, path) {
+    body = body.replace(/(\()?([^"']+)\?\$staticlink\$/gi, function(match, p1, path) {
         return contentAssetFunctions.staticURL(path);
     });
 
     // Replace URL functions in the body text
-    body = body.replace(/\$Url\((.*?)\)\$/g, function(match, argsStr) {
+    body = body.replace(/\$Url\((.*?)\)\$/gi, function(match, argsStr) {
         var args = splitAndTrim(argsStr);
         var action = args.shift();
         return contentAssetFunctions.url.apply(null, [action].concat(args));
     });
 
     // Replace HTTP URL functions in the body text
-    body = body.replace(/\$httpUrl\((.*?)\)\$/g, function(match, argsStr) {
+    body = body.replace(/\$httpUrl\((.*?)\)\$/gi, function(match, argsStr) {
         var args = splitAndTrim(argsStr);
         var action = args.shift();
         return contentAssetFunctions.http.apply(null, [action].concat(args));
     });
 
     // Replace HTTPS URL functions in the body text
-    body = body.replace(/\$httpsUrl\((.*?)\)\$/g, function(match, argsStr) {
+    body = body.replace(/\$httpsUrl\((.*?)\)\$/gi, function(match, argsStr) {
         var args = splitAndTrim(argsStr);
         var action = args.shift();
         return contentAssetFunctions.https.apply(null, [action].concat(args));

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil.js
@@ -44,41 +44,48 @@ function splitAndTrim(argsStr) {
 }
 
 /**
-* Handles content links in the body text
-* @param {string} body - The body text to handle
-* @returns {string} The body text with content links handled
-*/
+ * Handles content links in the body text
+ * @param {string} body - The body text to handle
+ * @returns {string} The body text with content links handled
+ */
 function contentLinkHandler(body) {
-
     if (!body) {
         return '';
     }
 
-    // Replace static links in the body text
-    body = body.replace(/(\()?([^"']+)\?\$staticlink\$/gi, function(match, p1, path) {
-        return contentAssetFunctions.staticURL(path);
-    });
+    // Check and Replace static links in the body text
+    if (body.indexOf('$staticlink$') !== -1) {
+        body = body.replace(/(\()?([^"']+)\?\$staticlink\$/gi, function(match, p1, path) {
+            return contentAssetFunctions.staticURL(path);
+        });
+    }
 
-    // Replace URL functions in the body text
-    body = body.replace(/\$Url\((.*?)\)\$/gi, function(match, argsStr) {
-        var args = splitAndTrim(argsStr);
-        var action = args.shift();
-        return contentAssetFunctions.url.apply(null, [action].concat(args));
-    });
+    // Check and Replace URL functions in the body text
+    if (body.indexOf('$Url(') !== -1) {
+        body = body.replace(/\$Url\((.*?)\)\$/gi, function(match, argsStr) {
+            var args = splitAndTrim(argsStr);
+            var action = args.shift();
+            return contentAssetFunctions.url.apply(null, [action].concat(args));
+        });
+    }
 
-    // Replace HTTP URL functions in the body text
-    body = body.replace(/\$httpUrl\((.*?)\)\$/gi, function(match, argsStr) {
-        var args = splitAndTrim(argsStr);
-        var action = args.shift();
-        return contentAssetFunctions.http.apply(null, [action].concat(args));
-    });
+    // Check and Replace HTTP URL functions in the body text
+    if (body.indexOf('$httpUrl(') !== -1) {
+        body = body.replace(/\$httpUrl\((.*?)\)\$/gi, function(match, argsStr) {
+            var args = splitAndTrim(argsStr);
+            var action = args.shift();
+            return contentAssetFunctions.http.apply(null, [action].concat(args));
+        });
+    }
 
-    // Replace HTTPS URL functions in the body text
-    body = body.replace(/\$httpsUrl\((.*?)\)\$/gi, function(match, argsStr) {
-        var args = splitAndTrim(argsStr);
-        var action = args.shift();
-        return contentAssetFunctions.https.apply(null, [action].concat(args));
-    });
+    // Check and Replace HTTPS URL functions in the body text
+    if (body.indexOf('$httpsUrl(') !== -1) {
+        body = body.replace(/\$httpsUrl\((.*?)\)\$/gi, function(match, argsStr) {
+            var args = splitAndTrim(argsStr);
+            var action = args.shift();
+            return contentAssetFunctions.https.apply(null, [action].concat(args));
+        });
+    }
 
     return body;
 }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil.js
@@ -1,0 +1,87 @@
+'use strict';
+
+var URLUtils = require('dw/web/URLUtils');
+var jobHelper = require('*/cartridge/scripts/algolia/helper/jobHelper');
+var logger = jobHelper.getAlgoliaLogger();
+
+var contentAssetFunctions = {
+    // Generates a static URL based on the relative path provided
+    staticURL: function(relPath) {
+        return URLUtils.httpsStatic(relPath);
+    },
+    // A higher-order function to reduce duplication in creating URL functions
+    createUrlFunction: function(method) {
+        return function() {
+            var args = Array.prototype.slice.call(arguments);
+            var action = args.shift();
+            try {
+                return URLUtils[method].apply(URLUtils, [action].concat(args));
+            } catch (e) {
+                // Log or handle the error as appropriate for your application
+                logger.error('Error calling URLUtils.: ' + method + ': ', e);
+                return null;
+            }
+        };
+    }
+};
+
+// Extending contentAssetFunctions with URL utility methods
+contentAssetFunctions.url = contentAssetFunctions.createUrlFunction('url');
+contentAssetFunctions.https = contentAssetFunctions.createUrlFunction('https');
+contentAssetFunctions.http = contentAssetFunctions.createUrlFunction('http');
+
+/**
+* Splits and trims the arguments string
+* @param {string} argsStr - The string of arguments to split and trim
+* @returns {Array} The array of split and trimmed arguments
+*/
+function splitAndTrim(argsStr) {
+    var args = argsStr.split(',');
+    for (var i = 0; i < args.length; i++) {
+        args[i] = args[i].trim();
+    }
+    return args;
+}
+
+/**
+* Handles content links in the body text
+* @param {string} body - The body text to handle
+* @returns {string} The body text with content links handled
+*/
+function contentLinkHandler(body) {
+
+    if (!body) {
+        return '';
+    }
+
+    // Replace static links in the body text
+    body = body.replace(/(\()?([^"']+)\?\$staticlink\$/g, function(match, p1, path) {
+        return contentAssetFunctions.staticURL(path);
+    });
+
+    // Replace URL functions in the body text
+    body = body.replace(/\$Url\((.*?)\)\$/g, function(match, argsStr) {
+        var args = splitAndTrim(argsStr);
+        var action = args.shift();
+        return contentAssetFunctions.url.apply(null, [action].concat(args));
+    });
+
+    // Replace HTTP URL functions in the body text
+    body = body.replace(/\$httpUrl\((.*?)\)\$/g, function(match, argsStr) {
+        var args = splitAndTrim(argsStr);
+        var action = args.shift();
+        return contentAssetFunctions.http.apply(null, [action].concat(args));
+    });
+
+    // Replace HTTPS URL functions in the body text
+    body = body.replace(/\$httpsUrl\((.*?)\)\$/g, function(match, argsStr) {
+        var args = splitAndTrim(argsStr);
+        var action = args.shift();
+        return contentAssetFunctions.https.apply(null, [action].concat(args));
+    });
+
+    return body;
+}
+
+// Export the content link handler function
+exports.contentLinkHandler = contentLinkHandler;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil.js
@@ -13,7 +13,6 @@ var contentAssetFunctions = {
     createUrlFunction: function(method) {
         return function() {
             var args = Array.prototype.slice.call(arguments);
-            var action = args.shift();
             try {
                 return URLUtils[method].apply(URLUtils, args);
             } catch (e) {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil.js
@@ -61,7 +61,7 @@ function contentLinkHandler(body) {
     }
 
     // Check and Replace URL functions in the body text
-    if (body.indexOf('$Url(') !== -1) {
+    if (body.indexOf('$Url(') !== -1 || body.indexOf('$url(') !== -1){
         body = body.replace(/\$Url\((.*?)\)\$/gi, function(match, argsStr) {
             var args = splitAndTrim(argsStr);
             var action = args.shift();

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedContent.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedContent.js
@@ -4,6 +4,8 @@ var URLUtils = require('dw/web/URLUtils');
 var AlgoliaUtils = require('*/cartridge/scripts/algolia/lib/utils');
 var AlgoliaContentConfig = require('*/cartridge/scripts/algolia/lib/algoliaContentConfig');
 var ObjectHelper = require('*/cartridge/scripts/algolia/helper/objectHelper');
+var ContentUtil = require('*/cartridge/scripts/algolia/lib/contentUtil');
+var enableContentFunctionHandler = false; // This feature has a big impact on performance, so it is disabled by default
 
 var ACTION_ENDPOINT_CONTENT = 'Page-Show';
 
@@ -16,17 +18,23 @@ var aggregatedValueHandlers = {
         return pageURL ? pageURL.toString() : null;
     },
     body: function (content, includedContent) {
+        var body = null;
         var pageDesignerContent;
+
         if (content.isPage() && (includedContent === 'allContents' || includedContent === 'pageDesignerComponents')) {
             var pageDesignerHelper = require('*/cartridge/scripts/algolia/lib/pageDesignerHelper');
-            var body = pageDesignerHelper.getContainerContent(content, 'pages');
-            return body;
+            body = pageDesignerHelper.getContainerContent(content, 'pages');
         }
 
         if (content && content.custom && content.custom.body && (includedContent === 'allContents' || includedContent === 'contentAssets')) {
-            return content.custom.body.source;
+            body = content.custom.body.source;
         }
-        return null;
+
+        if (enableContentFunctionHandler) {
+            body = ContentUtil.contentLinkHandler(body);
+        }
+
+        return body;
     }
 };
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedContent.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedContent.js
@@ -4,8 +4,6 @@ var URLUtils = require('dw/web/URLUtils');
 var AlgoliaUtils = require('*/cartridge/scripts/algolia/lib/utils');
 var AlgoliaContentConfig = require('*/cartridge/scripts/algolia/lib/algoliaContentConfig');
 var ObjectHelper = require('*/cartridge/scripts/algolia/helper/objectHelper');
-var ContentUtil = require('*/cartridge/scripts/algolia/lib/contentUtil');
-var enableContentFunctionHandler = false; // This feature has a big impact on performance, so it is disabled by default
 
 var ACTION_ENDPOINT_CONTENT = 'Page-Show';
 
@@ -28,10 +26,6 @@ var aggregatedValueHandlers = {
 
         if (content && content.custom && content.custom.body && (includedContent === 'allContents' || includedContent === 'contentAssets')) {
             body = content.custom.body.source;
-        }
-
-        if (enableContentFunctionHandler) {
-            body = ContentUtil.contentLinkHandler(body);
         }
 
         return body;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
@@ -8,7 +8,7 @@ var logger;
 var paramAttributeList, paramFailureThresholdPercentage, includedContent;
 
 // Algolia requires
-var algoliaData, AlgoliaLocalizedContent, jobHelper, reindexHelper, algoliaIndexingAPI, contentFilter, AlgoliaJobReport, algoliaSplitter, algoliaContentConfig;
+var algoliaData, AlgoliaLocalizedContent, jobHelper, reindexHelper, algoliaIndexingAPI, contentFilter, AlgoliaJobReport, algoliaSplitter, algoliaContentConfig, ContentUtil;
 var indexingOperation;
 
 // logging-related variables
@@ -16,7 +16,7 @@ var jobReport;
 
 var contents = [], siteLocales, nonLocalizedAttributes = [], attributesToSend, count;
 var lastIndexingTasks = {};
-
+var enableContentFunctionHandler = false; // This feature has a big impact on performance, so it is disabled by default
 
 /**
  * before-step-function (steptypes.json)
@@ -35,6 +35,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     algoliaContentConfig = require('*/cartridge/scripts/algolia/lib/algoliaContentConfig');
     AlgoliaJobReport = require('*/cartridge/scripts/algolia/helper/AlgoliaJobReport');
     algoliaSplitter = require('*/cartridge/scripts/algolia/lib/algoliaSplitter');
+    ContentUtil = require('*/cartridge/scripts/algolia/lib/contentUtil');
 
     /* --- initializing custom object logging --- */
     jobReport = new AlgoliaJobReport(stepExecution.getJobExecution().getJobID(), 'content');
@@ -166,6 +167,9 @@ exports.process = function(content, parameters, stepExecution) {
                 splittedContent.objectID = localizedContent.objectID + '_' + i;
                 splittedContent.id = localizedContent.id;
                 splittedContent.algolia_chunk_order = i;
+                if (enableContentFunctionHandler)   {
+                    splits[i] = ContentUtil.contentLinkHandler(splits[i]);
+                }
                 splittedContent.body = splits[i];
                 algoliaOperations.push(new jobHelper.AlgoliaOperation(indexingOperation, splittedContent, indexName));
             }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
@@ -16,8 +16,7 @@ var jobReport;
 
 var contents = [], siteLocales, nonLocalizedAttributes = [], attributesToSend, count;
 var lastIndexingTasks = {};
-var enableContentFunctionHandler = false; // This feature has a big impact on performance, so it is disabled by default
-
+var enableContentFunctionHandler = true;
 /**
  * before-step-function (steptypes.json)
  * Any returns from this function result in skipping to the afterStep() function (omitting read-process-writealtogether)

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
@@ -16,7 +16,6 @@ var jobReport;
 
 var contents = [], siteLocales, nonLocalizedAttributes = [], attributesToSend, count;
 var lastIndexingTasks = {};
-var enableContentFunctionHandler = true;
 /**
  * before-step-function (steptypes.json)
  * Any returns from this function result in skipping to the afterStep() function (omitting read-process-writealtogether)
@@ -166,9 +165,8 @@ exports.process = function(content, parameters, stepExecution) {
                 splittedContent.objectID = localizedContent.objectID + '_' + i;
                 splittedContent.id = localizedContent.id;
                 splittedContent.algolia_chunk_order = i;
-                if (enableContentFunctionHandler)   {
-                    splits[i] = ContentUtil.contentLinkHandler(splits[i]);
-                }
+                splits[i] = ContentUtil.contentLinkHandler(splits[i]);
+
                 splittedContent.body = splits[i];
                 algoliaOperations.push(new jobHelper.AlgoliaOperation(indexingOperation, splittedContent, indexName));
             }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -184,6 +184,13 @@ jest.mock('dw/web/URLUtils', () => {
             var absURL = 'https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/';
             return absURL + global.request.getLocale() + '/' + endpoint + '?' + param + '=' + id;
         },
+        http: function(endpoint, param, id) {
+            var absURL = 'http://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/';
+            return absURL + global.request.getLocale() + '/' + endpoint + '?' + param + '=' + id;
+        },
+        httpsStatic: function(url) {
+            return 'https://test.commercecloud.salesforce.com/on/demandware.static/-/Library-Sites-test/default/testversion/' + url;
+        },
         url: function(endpoint, param, id) {
             var relURL = '/on/demandware.store/Sites-Algolia_SFRA-Site/';
             relURL += global.request.getLocale() + '/' + endpoint + '?' + param + '=' + id;
@@ -268,6 +275,10 @@ jest.mock('*/cartridge/scripts/algolia/lib/utils', () => {
 
 jest.mock('*/cartridge/scripts/algolia/model/algoliaLocalizedProduct', () => {
     return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct');
+}, {virtual: true});
+
+jest.mock('*/cartridge/scripts/algolia/lib/contentUtil', () => {
+    return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil');
 }, {virtual: true});
 
 jest.mock('dw/experience/PageMgr', () => {

--- a/test/unit/int_algolia/scripts/algolia/lib/__snapshots__/contentUtil.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/lib/__snapshots__/contentUtil.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`contentLinkHandler should return changed body 1`] = `
+"<!DOCTYPE html>
+            <html>
+            <head>
+                <title>Test Page</title>
+            </head>
+            <body>
+                <p>This is a test page.</p>
+                <a href="$staticlink$">Static Link</a>
+                <a href="/on/demandware.store/Sites-Algolia_SFRA-Site/default/action?arg1=arg2">URL Token</a>
+                <a href="http://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/action?arg1=arg2">HTTP URL Token</a>
+                <a href="https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/action?arg1=arg2">HTTPS URL Token</a>
+            </body>
+            </html>"
+`;

--- a/test/unit/int_algolia/scripts/algolia/lib/__snapshots__/contentUtil.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/lib/__snapshots__/contentUtil.test.js.snap
@@ -8,7 +8,7 @@ exports[`contentLinkHandler should return changed body 1`] = `
             </head>
             <body>
                 <p>This is a test page.</p>
-                <a href="$staticlink$">Static Link</a>
+                <a href="test$staticlink$">Static Link</a>
                 <a href="/on/demandware.store/Sites-Algolia_SFRA-Site/default/action?arg1=arg2">URL Token</a>
                 <a href="http://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/action?arg1=arg2">HTTP URL Token</a>
                 <a href="https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/action?arg1=arg2">HTTPS URL Token</a>

--- a/test/unit/int_algolia/scripts/algolia/lib/__snapshots__/contentUtil.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/lib/__snapshots__/contentUtil.test.js.snap
@@ -8,7 +8,6 @@ exports[`contentLinkHandler should return changed body 1`] = `
             </head>
             <body>
                 <p>This is a test page.</p>
-                <a href="test$staticlink$">Static Link</a>
                 <a href="/on/demandware.store/Sites-Algolia_SFRA-Site/default/action?arg1=arg2">URL Token</a>
                 <a href="http://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/action?arg1=arg2">HTTP URL Token</a>
                 <a href="https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/action?arg1=arg2">HTTPS URL Token</a>

--- a/test/unit/int_algolia/scripts/algolia/lib/algoliaSplitter.test.js
+++ b/test/unit/int_algolia/scripts/algolia/lib/algoliaSplitter.test.js
@@ -1,4 +1,4 @@
-const { splitHtmlContent, getMaxBodySize } = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaSplitter');
+const { splitHtmlContent, getMaxBodySize, removeHtmlTagsAndFormat } = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaSplitter');
 
 jest.mock('dw/util/Bytes', () => {
     class BytesMock {
@@ -85,6 +85,14 @@ describe('Extreme Content Manipulation', () => {
         const result = getMaxBodySize(mockedContent);
         // expect result near to %1 of expectedMaxByteSize
         expect(result).toBeLessThan(expectedMaxByteSize);
+    });
+
+    describe('removeHtmlTagsAndFormat', () => {
+        test('removes HTML tags, &nbsp;, and replaces \\r\\n, \\n, and \\r with spaces', () => {
+            const input = '<div><a href="test.com">This</a> is a test&nbsp;string with <b>HTML</b> tags,\r\nnew lines, and \nmore \rbreaks.</div>';
+            const expectedOutput = 'This is a test string with HTML tags, new lines, and more breaks.';
+            expect(removeHtmlTagsAndFormat(input)).toBe(expectedOutput);
+        });
     });
 });
 

--- a/test/unit/int_algolia/scripts/algolia/lib/contentUtil.test.js
+++ b/test/unit/int_algolia/scripts/algolia/lib/contentUtil.test.js
@@ -6,16 +6,6 @@ const URLUtils = require('dw/web/URLUtils');
 
 describe('contentLinkHandler', () => {
 
-    it('should replace static links in the body text with quote', () => {
-        const result = contentLinkHandler('path?$staticlink$');
-        expect(result).toBe('https://test.commercecloud.salesforce.com/on/demandware.static/-/Library-Sites-test/default/testversion/path');
-    });
-
-    it('should replace static links in the body text with parwenthesis', () => {
-        const result = contentLinkHandler('(path?$staticlink$');
-        expect(result).toBe('https://test.commercecloud.salesforce.com/on/demandware.static/-/Library-Sites-test/default/testversion/path');
-    });
-
     it('should replace URL tokens in the body text', () => {
         const result = contentLinkHandler('$Url(action, arg1, arg2)$');
         expect(result).toBe('/on/demandware.store/Sites-Algolia_SFRA-Site/default/action?arg1=arg2');
@@ -44,7 +34,6 @@ describe('contentLinkHandler', () => {
             </head>
             <body>
                 <p>This is a test page.</p>
-                <a href="test$staticlink$">Static Link</a>
                 <a href="$url(action, arg1, arg2)$">URL Token</a>
                 <a href="$httpUrl(action, arg1, arg2)$">HTTP URL Token</a>
                 <a href="$httpsUrl(action, arg1, arg2)$">HTTPS URL Token</a>

--- a/test/unit/int_algolia/scripts/algolia/lib/contentUtil.test.js
+++ b/test/unit/int_algolia/scripts/algolia/lib/contentUtil.test.js
@@ -45,7 +45,7 @@ describe('contentLinkHandler', () => {
             <body>
                 <p>This is a test page.</p>
                 <a href="test$staticlink$">Static Link</a>
-                <a href="$Url(action, arg1, arg2)$">URL Token</a>
+                <a href="$url(action, arg1, arg2)$">URL Token</a>
                 <a href="$httpUrl(action, arg1, arg2)$">HTTP URL Token</a>
                 <a href="$httpsUrl(action, arg1, arg2)$">HTTPS URL Token</a>
             </body>

--- a/test/unit/int_algolia/scripts/algolia/lib/contentUtil.test.js
+++ b/test/unit/int_algolia/scripts/algolia/lib/contentUtil.test.js
@@ -44,7 +44,7 @@ describe('contentLinkHandler', () => {
             </head>
             <body>
                 <p>This is a test page.</p>
-                <a href="$staticlink$">Static Link</a>
+                <a href="test$staticlink$">Static Link</a>
                 <a href="$Url(action, arg1, arg2)$">URL Token</a>
                 <a href="$httpUrl(action, arg1, arg2)$">HTTP URL Token</a>
                 <a href="$httpsUrl(action, arg1, arg2)$">HTTPS URL Token</a>

--- a/test/unit/int_algolia/scripts/algolia/lib/contentUtil.test.js
+++ b/test/unit/int_algolia/scripts/algolia/lib/contentUtil.test.js
@@ -1,0 +1,58 @@
+const {
+    contentLinkHandler
+} = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil');
+
+const URLUtils = require('dw/web/URLUtils');
+
+describe('contentLinkHandler', () => {
+
+    it('should replace static links in the body text with quote', () => {
+        const result = contentLinkHandler('path?$staticlink$');
+        expect(result).toBe('https://test.commercecloud.salesforce.com/on/demandware.static/-/Library-Sites-test/default/testversion/path');
+    });
+
+    it('should replace static links in the body text with parwenthesis', () => {
+        const result = contentLinkHandler('(path?$staticlink$');
+        expect(result).toBe('https://test.commercecloud.salesforce.com/on/demandware.static/-/Library-Sites-test/default/testversion/path');
+    });
+
+    it('should replace URL tokens in the body text', () => {
+        const result = contentLinkHandler('$Url(action, arg1, arg2)$');
+        expect(result).toBe('/on/demandware.store/Sites-Algolia_SFRA-Site/default/action?arg1=arg2');
+    });
+
+    it('should replace HTTP URL tokens in the body text', () => {
+        const result = contentLinkHandler('$httpUrl(action, arg1, arg2)$');
+        expect(result).toBe('http://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/action?arg1=arg2');
+    });
+
+    it('should replace HTTPS URL tokens in the body text', () => {
+        const result = contentLinkHandler('$httpsUrl(action, arg1, arg2)$');
+        expect(result).toBe('https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/action?arg1=arg2');
+    });
+
+    it('should return an empty string if the body is not provided', () => {
+        const result = contentLinkHandler();
+        expect(result).toBe('');
+    });
+
+    it('should return changed body', () => {
+        const testHTML = `<!DOCTYPE html>
+            <html>
+            <head>
+                <title>Test Page</title>
+            </head>
+            <body>
+                <p>This is a test page.</p>
+                <a href="$staticlink$">Static Link</a>
+                <a href="$Url(action, arg1, arg2)$">URL Token</a>
+                <a href="$httpUrl(action, arg1, arg2)$">HTTP URL Token</a>
+                <a href="$httpsUrl(action, arg1, arg2)$">HTTPS URL Token</a>
+            </body>
+            </html>`;
+        const result = contentLinkHandler(testHTML);
+        expect(result).toMatchSnapshot();
+    });
+
+
+});


### PR DESCRIPTION
## Handling Dynamic content Values

Replaced ```$url(), $httpUrl(), $httpsUrl()``` with SFCC rendered values

## Changes
- Handled dynamic content values for both content asset and page designer pages
- Created a hard-coded configuration
- Wrote unit tests


## How to test

- Enable hardcoded `enableContentFunctionHandler` config in `cartridges/int_algolia/cartridge/scripts/algolia/lib/contentUtil.js`
- Add following content to any content asset and check index on Algolia

```
<h1>---TESTS---</h1>
<div>
    URL:
    <a title="My URL Search Link" target="_new" href="$Url('Search-ShowContent', 'q', 'customer')$"><span>URL Search
            Link Content Asset Link </span></a>
    <p>XXXXX$Url('Search-ShowContent', 'q', 'customer')$XXXX</p>
</div>
<div>
    HTTP
    XXXXX$httpUrl('Search-Show', 'cgid', 'J','psortb1','category-pos_J')$XXXX
</div>
<div>
    HTTPS
    XXXX$httpsUrl('Search-Show', 'cgid', 'J','psortb1','category-pos_J')$XXXX
</div>
```