### PR TITLE
fix: increase waitTask timeout

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
@@ -212,7 +212,7 @@ function moveIndex(indexNameSrc, indexNameDest) {
  */
 function waitTask(indexName, taskID) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
-    var maxWait = 5 * 60 * 1000;
+    var maxWait = 10 * 60 * 1000;
     var start = Date.now();
     var nbRequestsSent = 0;
 


### PR DESCRIPTION
Search clusters can sometimes experience exceptional load, resulting in some indexing operations taking more than 5 minutes to complete.
Let's increase the `waitTask` timeout to avoid having the job failing in those cases.

---
CR-5491