### PR TITLE
chore: fix price facet

### DIFF
--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -169,7 +169,8 @@ function enableInstantSearch(config) {
 
             rangeInputWithPanel({
                 container: '#algolia-price-filter-placeholder',
-                attribute: 'price.' + algoliaData.currencyCode,
+                attribute: (algoliaData.recordModel === 'master-level' ? 'variants.price.' : 'price.') +
+                    algoliaData.currencyCode,
                 cssClasses: {
                     form: 'flex-nowrap',
                     input: 'form-control form-control-sm',


### PR DESCRIPTION
I had forgotten to adjust the `price` facet in #135:
For the master-level records, the price is located in the `variants.price` attribute by default.