### PR TITLE
SFCC-284 | Newarrivals Refactoring

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js
@@ -46,7 +46,7 @@ function customizeProductModel(productModel) {
     /*
     * Add New arrivals
     */
-    var CATEGORY_ATTRIBUTE = 'CATEGORIES_NEW_ARRIVALS';
+    var CATEGORY_ATTRIBUTE = 'newArrivals';
     var CATEGORY_ID = 'newarrivals';
 
     var customizedProductModel = productModel;
@@ -102,7 +102,7 @@ function createAlgoliaLocalizedCategoryObject(category) {
  * @param {Array} algoliaAttributes - The attributes to index
  */
 function customizeLocalizedProductModel(productModel, algoliaAttributes) {
-    var CATEGORY_ATTRIBUTE = 'CATEGORIES_NEW_ARRIVALS';
+    var CATEGORY_ATTRIBUTE = 'newArrivals';
     var CATEGORY_ID = 'newarrivals';
 
     if (algoliaAttributes.indexOf(CATEGORY_ATTRIBUTE) >= 0) {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js
@@ -11,23 +11,22 @@ var algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
  *   ]
  * Will generate:
  *   {
- *      level_0: { en: 'New Arrivals', fr: 'Nouveautés' },
- *      level_1: { en: 'New Arrivals > Electronics', fr: 'Nouveautés > Electronique' }
+ *      0: { en: 'New Arrivals', fr: 'Nouveautés' },
+ *      1: { en: 'New Arrivals > Electronics', fr: 'Nouveautés > Electronique' }
  *   }
  * @param {Array} category - array of categories tree
  * @returns {Object} - secondary category Algolia object
  */
 function createAlgoliaCategoryObject(category) {
-    var CATEGORIES_LEVEL_PREFIX = 'level_';
     var result = {};
 
     category
         .concat()
         .reverse()
         .reduce(function (parentCategory, childCategory, index) {
-            result[CATEGORIES_LEVEL_PREFIX + index] = {};
+            result[index] = {};
             Object.keys(childCategory.name).forEach(function (locale) {
-                result[CATEGORIES_LEVEL_PREFIX + index][locale] = parentCategory
+                result[index][locale] = parentCategory
                     ? parentCategory.name[locale] + algoliaData.CATEGORIES_SEPARATOR + childCategory.name[locale]
                     : childCategory.name[locale];
             });
@@ -72,21 +71,20 @@ function customizeProductModel(productModel) {
  *   ]
  * Will generate:
  *   {
- *      level_0: 'New Arrivals',
- *      level_1: 'New Arrivals > Electronics'
+ *      0: 'New Arrivals',
+ *      1: 'New Arrivals > Electronics'
  *   }
  * @param {Array} category - array of categories tree
  * @returns {Object} - secondary category Algolia object
  */
 function createAlgoliaLocalizedCategoryObject(category) {
-    var CATEGORIES_LEVEL_PREFIX = 'level_';
     var result = {};
 
     category
         .concat()
         .reverse()
         .reduce(function (parentCategory, childCategory, index) {
-            result[CATEGORIES_LEVEL_PREFIX + index] = parentCategory
+            result[index] = parentCategory
                 ? parentCategory.name + algoliaData.CATEGORIES_SEPARATOR + childCategory.name
                 : childCategory.name
             return childCategory;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js
@@ -46,7 +46,7 @@ function customizeProductModel(productModel) {
     /*
     * Add New arrivals
     */
-    var CATEGORY_ATTRIBUTE = 'newArrivals';
+    var CATEGORY_ATTRIBUTE = 'newArrivalsCategory';
     var CATEGORY_ID = 'newarrivals';
 
     var customizedProductModel = productModel;
@@ -102,7 +102,7 @@ function createAlgoliaLocalizedCategoryObject(category) {
  * @param {Array} algoliaAttributes - The attributes to index
  */
 function customizeLocalizedProductModel(productModel, algoliaAttributes) {
-    var CATEGORY_ATTRIBUTE = 'newArrivals';
+    var CATEGORY_ATTRIBUTE = 'newArrivalsCategory';
     var CATEGORY_ID = 'newarrivals';
 
     if (algoliaAttributes.indexOf(CATEGORY_ATTRIBUTE) >= 0) {

--- a/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -13,7 +13,7 @@ function enableInstantSearch(config) {
     var hierarchicalMenuValue = {};
     if (config.categoryDisplayNamePath && config.categoryDisplayNamePath.indexOf('New Arrivals') > -1) {
         hierarchicalMenuValue = {
-            "newArrivals.level_0": (config.categoryDisplayNamePath || '').split(config.categoryDisplayNamePathSeparator),
+            "newArrivalsCategory.level_0": (config.categoryDisplayNamePath || '').split(config.categoryDisplayNamePathSeparator),
         }
     } else {
         hierarchicalMenuValue = {
@@ -123,7 +123,7 @@ function enableInstantSearch(config) {
 
             hierarchicalMenuWithPanel({
                 container: '#algolia-newarrivals-list-placeholder',
-                attributes: ['newArrivals.level_0', 'newArrivals.level_1'],
+                attributes: ['newArrivalsCategory.level_0', 'newArrivalsCategory.level_1'],
                 templates: {
                     item(data, { html }) {
                         return html`

--- a/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -13,7 +13,7 @@ function enableInstantSearch(config) {
     var hierarchicalMenuValue = {};
     if (config.categoryDisplayNamePath && config.categoryDisplayNamePath.indexOf('New Arrivals') > -1) {
         hierarchicalMenuValue = {
-            "newArrivalsCategory.level_0": (config.categoryDisplayNamePath || '').split(config.categoryDisplayNamePathSeparator),
+            "newArrivalsCategory.0": (config.categoryDisplayNamePath || '').split(config.categoryDisplayNamePathSeparator),
         }
     } else {
         hierarchicalMenuValue = {
@@ -123,7 +123,7 @@ function enableInstantSearch(config) {
 
             hierarchicalMenuWithPanel({
                 container: '#algolia-newarrivals-list-placeholder',
-                attributes: ['newArrivalsCategory.level_0', 'newArrivalsCategory.level_1'],
+                attributes: ['newArrivalsCategory.0', 'newArrivalsCategory.1'],
                 templates: {
                     item(data, { html }) {
                         return html`

--- a/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -13,7 +13,7 @@ function enableInstantSearch(config) {
     var hierarchicalMenuValue = {};
     if (config.categoryDisplayNamePath && config.categoryDisplayNamePath.indexOf('New Arrivals') > -1) {
         hierarchicalMenuValue = {
-            "CATEGORIES_NEW_ARRIVALS.level_0": (config.categoryDisplayNamePath || '').split(config.categoryDisplayNamePathSeparator),
+            "newArrivals.level_0": (config.categoryDisplayNamePath || '').split(config.categoryDisplayNamePathSeparator),
         }
     } else {
         hierarchicalMenuValue = {
@@ -123,7 +123,7 @@ function enableInstantSearch(config) {
 
             hierarchicalMenuWithPanel({
                 container: '#algolia-newarrivals-list-placeholder',
-                attributes: ['CATEGORIES_NEW_ARRIVALS.level_0', 'CATEGORIES_NEW_ARRIVALS.level_1'],
+                attributes: ['newArrivals.level_0', 'newArrivals.level_1'],
                 templates: {
                     item(data, { html }) {
                         return html`
@@ -303,6 +303,13 @@ function enableInstantSearch(config) {
     }
 
     search.start();
+
+    search.on('render', function () {
+        var emptyFacetSelector = '.ais-HierarchicalMenu--noRefinement';
+        $(emptyFacetSelector).each(function () {
+            $(this).parents().eq(2).hide();
+        });
+    });
 
     /**
      * Generates a menu with the Panel widget

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -18,7 +18,7 @@ function enableInstantSearch(config) {
     var hierarchicalMenuValue = {};
     if (config.categoryDisplayNamePath && config.categoryDisplayNamePath.indexOf('New Arrivals') > -1) {
         hierarchicalMenuValue = {
-            "newArrivals.level_0": (config.categoryDisplayNamePath || '').split(config.categoryDisplayNamePathSeparator),
+            "newArrivalsCategory.level_0": (config.categoryDisplayNamePath || '').split(config.categoryDisplayNamePathSeparator),
         }
     } else {
         hierarchicalMenuValue = {
@@ -137,7 +137,7 @@ function enableInstantSearch(config) {
 
             hierarchicalMenuWithPanel({
                 container: '#algolia-newarrivals-list-placeholder',
-                attributes: ['newArrivals.level_0', 'newArrivals.level_1'],
+                attributes: ['newArrivalsCategory.level_0', 'newArrivalsCategory.level_1'],
                 templates: {
                     item(data, { html }) {
                         return html`

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -18,7 +18,7 @@ function enableInstantSearch(config) {
     var hierarchicalMenuValue = {};
     if (config.categoryDisplayNamePath && config.categoryDisplayNamePath.indexOf('New Arrivals') > -1) {
         hierarchicalMenuValue = {
-            "CATEGORIES_NEW_ARRIVALS.level_0": (config.categoryDisplayNamePath || '').split(config.categoryDisplayNamePathSeparator),
+            "newArrivals.level_0": (config.categoryDisplayNamePath || '').split(config.categoryDisplayNamePathSeparator),
         }
     } else {
         hierarchicalMenuValue = {
@@ -137,7 +137,7 @@ function enableInstantSearch(config) {
 
             hierarchicalMenuWithPanel({
                 container: '#algolia-newarrivals-list-placeholder',
-                attributes: ['CATEGORIES_NEW_ARRIVALS.level_0', 'CATEGORIES_NEW_ARRIVALS.level_1'],
+                attributes: ['newArrivals.level_0', 'newArrivals.level_1'],
                 templates: {
                     item(data, { html }) {
                         return html`
@@ -472,6 +472,13 @@ function enableInstantSearch(config) {
     }
 
     search.start();
+
+    search.on('render', function () {
+        var emptyFacetSelector = '.ais-HierarchicalMenu--noRefinement';
+        $(emptyFacetSelector).each(function () {
+            $(this).parents().eq(2).hide();
+        });
+    });
 
     /**
      * Generates a menu with the Panel widget

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -473,12 +473,12 @@ function enableInstantSearch(config) {
 
     search.start();
 
-    //search.on('render', function () {
-    //    var emptyFacetSelector = '.ais-HierarchicalMenu--noRefinement';
-    //    $(emptyFacetSelector).each(function () {
-    //        $(this).parents().eq(2).hide();
-    //    });
-    //});
+    search.on('render', function () {
+        var emptyFacetSelector = '.ais-HierarchicalMenu--noRefinement';
+        $(emptyFacetSelector).each(function () {
+            $(this).parents().eq(2).hide();
+        });
+    });
 
     /**
      * Generates a menu with the Panel widget

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -18,7 +18,7 @@ function enableInstantSearch(config) {
     var hierarchicalMenuValue = {};
     if (config.categoryDisplayNamePath && config.categoryDisplayNamePath.indexOf('New Arrivals') > -1) {
         hierarchicalMenuValue = {
-            "newArrivalsCategory.level_0": (config.categoryDisplayNamePath || '').split(config.categoryDisplayNamePathSeparator),
+            "newArrivalsCategory.0": (config.categoryDisplayNamePath || '').split(config.categoryDisplayNamePathSeparator),
         }
     } else {
         hierarchicalMenuValue = {
@@ -137,7 +137,7 @@ function enableInstantSearch(config) {
 
             hierarchicalMenuWithPanel({
                 container: '#algolia-newarrivals-list-placeholder',
-                attributes: ['newArrivalsCategory.level_0', 'newArrivalsCategory.level_1'],
+                attributes: ['newArrivalsCategory.0', 'newArrivalsCategory.1'],
                 templates: {
                     item(data, { html }) {
                         return html`
@@ -473,12 +473,12 @@ function enableInstantSearch(config) {
 
     search.start();
 
-    search.on('render', function () {
-        var emptyFacetSelector = '.ais-HierarchicalMenu--noRefinement';
-        $(emptyFacetSelector).each(function () {
-            $(this).parents().eq(2).hide();
-        });
-    });
+    //search.on('render', function () {
+    //    var emptyFacetSelector = '.ais-HierarchicalMenu--noRefinement';
+    //    $(emptyFacetSelector).each(function () {
+    //        $(this).parents().eq(2).hide();
+    //    });
+    //});
 
     /**
      * Generates a menu with the Panel widget

--- a/test/unit/int_algolia/scripts/algolia/customization/productModelCustomizer.test.js
+++ b/test/unit/int_algolia/scripts/algolia/customization/productModelCustomizer.test.js
@@ -27,11 +27,11 @@ describe('customizeProductModel (jobs v1)', () => {
         productModelCustomizer.customizeProductModel(product, ['newArrivalsCategory']);
         expect(product).toHaveProperty('newArrivalsCategory');
         expect(product.newArrivalsCategory).toEqual({
-            level_0: {
+            0: {
                 en: 'New Arrivals',
                 fr: 'Nouveautés',
             },
-            level_1: {
+            1: {
                 en: 'New Arrivals > Electronics',
                 fr: 'Nouveautés > Electronique',
             },
@@ -66,8 +66,8 @@ describe('customizeLocalizedProductModel (jobs v2)', () => {
         productModelCustomizer.customizeLocalizedProductModel(product, ['newArrivalsCategory']);
         expect(product).toHaveProperty('newArrivalsCategory');
         expect(product.newArrivalsCategory).toEqual({
-            level_0: 'New Arrivals',
-            level_1: 'New Arrivals > Electronics',
+            0: 'New Arrivals',
+            1: 'New Arrivals > Electronics',
         });
     });
 

--- a/test/unit/int_algolia/scripts/algolia/customization/productModelCustomizer.test.js
+++ b/test/unit/int_algolia/scripts/algolia/customization/productModelCustomizer.test.js
@@ -23,10 +23,10 @@ describe('customizeProductModel (jobs v1)', () => {
         };
     });
 
-    test('CATEGORIES_NEW_ARRIVALS in the additional attributes list', () => {
-        productModelCustomizer.customizeProductModel(product, ['CATEGORIES_NEW_ARRIVALS']);
-        expect(product).toHaveProperty('CATEGORIES_NEW_ARRIVALS');
-        expect(product.CATEGORIES_NEW_ARRIVALS).toEqual({
+    test('newArrivals in the additional attributes list', () => {
+        productModelCustomizer.customizeProductModel(product, ['newArrivals']);
+        expect(product).toHaveProperty('newArrivals');
+        expect(product.newArrivals).toEqual({
             level_0: {
                 en: 'New Arrivals',
                 fr: 'Nouveautés',
@@ -38,10 +38,10 @@ describe('customizeProductModel (jobs v1)', () => {
         });
     });
 
-    test('CATEGORIES_NEW_ARRIVALS not in the additional attributes list', () => {
+    test('newArrivals not in the additional attributes list', () => {
         productModelCustomizer.customizeProductModel(product, []);
         // Property is present, but won't be read by the indexing pipeline
-        expect(product).toHaveProperty('CATEGORIES_NEW_ARRIVALS');
+        expect(product).toHaveProperty('newArrivals');
     });
 });
 
@@ -62,17 +62,17 @@ describe('customizeLocalizedProductModel (jobs v2)', () => {
         };
     });
 
-    test('CATEGORIES_NEW_ARRIVALS in the additional attributes list', () => {
-        productModelCustomizer.customizeLocalizedProductModel(product, ['CATEGORIES_NEW_ARRIVALS']);
-        expect(product).toHaveProperty('CATEGORIES_NEW_ARRIVALS');
-        expect(product.CATEGORIES_NEW_ARRIVALS).toEqual({
+    test('newArrivals in the additional attributes list', () => {
+        productModelCustomizer.customizeLocalizedProductModel(product, ['newArrivals']);
+        expect(product).toHaveProperty('newArrivals');
+        expect(product.newArrivals).toEqual({
             level_0: 'New Arrivals',
             level_1: 'New Arrivals > Electronics',
         });
     });
 
-    test('CATEGORIES_NEW_ARRIVALS not in the additional attributes list', () => {
+    test('newArrivals not in the additional attributes list', () => {
         productModelCustomizer.customizeLocalizedProductModel(product, []);
-        expect(product).not.toHaveProperty('CATEGORIES_NEW_ARRIVALS');
+        expect(product).not.toHaveProperty('newArrivals');
     });
 });

--- a/test/unit/int_algolia/scripts/algolia/customization/productModelCustomizer.test.js
+++ b/test/unit/int_algolia/scripts/algolia/customization/productModelCustomizer.test.js
@@ -23,8 +23,8 @@ describe('customizeProductModel (jobs v1)', () => {
         };
     });
 
-    test('newArrivals in the additional attributes list', () => {
-        productModelCustomizer.customizeProductModel(product, ['newArrivals']);
+    test('newArrivalsCategory in the additional attributes list', () => {
+        productModelCustomizer.customizeProductModel(product, ['newArrivalsCategory']);
         expect(product).toHaveProperty('newArrivalsCategory');
         expect(product.newArrivalsCategory).toEqual({
             level_0: {
@@ -38,7 +38,7 @@ describe('customizeProductModel (jobs v1)', () => {
         });
     });
 
-    test('newArrivals not in the additional attributes list', () => {
+    test('newArrivalsCategory not in the additional attributes list', () => {
         productModelCustomizer.customizeProductModel(product, []);
         // Property is present, but won't be read by the indexing pipeline
         expect(product).toHaveProperty('newArrivalsCategory');
@@ -62,7 +62,7 @@ describe('customizeLocalizedProductModel (jobs v2)', () => {
         };
     });
 
-    test('newArrivals in the additional attributes list', () => {
+    test('newArrivalsCategory in the additional attributes list', () => {
         productModelCustomizer.customizeLocalizedProductModel(product, ['newArrivalsCategory']);
         expect(product).toHaveProperty('newArrivalsCategory');
         expect(product.newArrivalsCategory).toEqual({
@@ -71,7 +71,7 @@ describe('customizeLocalizedProductModel (jobs v2)', () => {
         });
     });
 
-    test('newArrivals not in the additional attributes list', () => {
+    test('newArrivalsCategory not in the additional attributes list', () => {
         productModelCustomizer.customizeLocalizedProductModel(product, []);
         expect(product).not.toHaveProperty('newArrivalsCategory');
     });

--- a/test/unit/int_algolia/scripts/algolia/customization/productModelCustomizer.test.js
+++ b/test/unit/int_algolia/scripts/algolia/customization/productModelCustomizer.test.js
@@ -25,8 +25,8 @@ describe('customizeProductModel (jobs v1)', () => {
 
     test('newArrivals in the additional attributes list', () => {
         productModelCustomizer.customizeProductModel(product, ['newArrivals']);
-        expect(product).toHaveProperty('newArrivals');
-        expect(product.newArrivals).toEqual({
+        expect(product).toHaveProperty('newArrivalsCategory');
+        expect(product.newArrivalsCategory).toEqual({
             level_0: {
                 en: 'New Arrivals',
                 fr: 'Nouveautés',
@@ -41,7 +41,7 @@ describe('customizeProductModel (jobs v1)', () => {
     test('newArrivals not in the additional attributes list', () => {
         productModelCustomizer.customizeProductModel(product, []);
         // Property is present, but won't be read by the indexing pipeline
-        expect(product).toHaveProperty('newArrivals');
+        expect(product).toHaveProperty('newArrivalsCategory');
     });
 });
 
@@ -63,9 +63,9 @@ describe('customizeLocalizedProductModel (jobs v2)', () => {
     });
 
     test('newArrivals in the additional attributes list', () => {
-        productModelCustomizer.customizeLocalizedProductModel(product, ['newArrivals']);
-        expect(product).toHaveProperty('newArrivals');
-        expect(product.newArrivals).toEqual({
+        productModelCustomizer.customizeLocalizedProductModel(product, ['newArrivalsCategory']);
+        expect(product).toHaveProperty('newArrivalsCategory');
+        expect(product.newArrivalsCategory).toEqual({
             level_0: 'New Arrivals',
             level_1: 'New Arrivals > Electronics',
         });
@@ -73,6 +73,6 @@ describe('customizeLocalizedProductModel (jobs v2)', () => {
 
     test('newArrivals not in the additional attributes list', () => {
         productModelCustomizer.customizeLocalizedProductModel(product, []);
-        expect(product).not.toHaveProperty('newArrivals');
+        expect(product).not.toHaveProperty('newArrivalsCategory');
     });
 });


### PR DESCRIPTION
## What Changed

# Changes:
- The category attribute name has been updated from 'CATEGORIES_NEW_ARRIVALS' to 'newArrivals'.
- Nonapplicable hierarchical facets have been hidden.

# How to test:

- [ ]  Check if the New arrivals facet container is present by default (it shouldn't be).
- Add the `newArrivals` attribute to `AdditionalAttributes`.
- Create a facet for it on the Algolia Dashboard.
- [ ] Check if the New arrivals facet container appears for an applicable search (it should).
- [ ] Verify that the New arrivals facet container does not appear for non-applicable searches, such as very specific searches.