### PR TITLE
feat: multiple pricebooks

### DIFF
--- a/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
+++ b/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
@@ -71,7 +71,7 @@
                 <iscomment> Algolia_SearchApiKey </iscomment>
                 <tr>
                     <td class="table_detail w s" colspan="1">
-                        <isprint value="${Resource.msg('algolia.label.preference.searchkey', 'algolia', null)}" encoding="jshtml" /><span class="red b">
+                        <isprint value="${Resource.msg('algolia.label.preference.searchkey', 'algolia', null)}" encoding="jshtml" />
                         <i class="fa fa-info-circle dw-nc-text-info info-hover"></i>
                         <div class="tooltip">${Resource.msg('algolia.label.preference.searchkey.help', 'algolia', null)}</div>
                     </td>

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
@@ -589,7 +589,7 @@ function updateCPObjectFromXML(xmlFile, changedProducts, resourceType) {
  * The colorVariations are built using the master's variation model
  *
  * @param {Object} parameters - model parameters
- * @param {dw.order.Product} parameters.masterProduct - A master product
+ * @param {dw.catalog.Product} parameters.masterProduct - A master product
  * @param {string} parameters.locales - The requested locales
  * @param {Array} parameters.attributeList - list of attributes to be fetched
  * @param {Array} parameters.nonLocalizedAttributes - list of non-localized attributes

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -214,7 +214,7 @@ var aggregatedValueHandlers = {
     pricebooks: function (product) {
         const pricebooks = {};
         const siteCurrencies = Site.getCurrent().getAllowedCurrencies();
-        const sitePriceBooks = PriceBookMgr.sitePriceBooks.iterator();
+        const sitePriceBooks = PriceBookMgr.getSitePriceBooks().iterator();
 
         while (sitePriceBooks.hasNext()) {
             var pricebook = sitePriceBooks.next();

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -310,6 +310,30 @@ function enableInstantSearch(config) {
                             item.price = item.price[algoliaData.currencyCode]
                         }
 
+                        // If no promotionalPrice, use the pricebooks to display the strikeout price
+                        if (!item.promotionalPrice &&
+                            item.pricebooks &&
+                            item.pricebooks[algoliaData.currencyCode] &&
+                            item.pricebooks[algoliaData.currencyCode].length > 0
+                        ) {
+                            const prices = item.pricebooks[algoliaData.currencyCode].filter(pricebook => {
+                                if (pricebook.onlineFrom && pricebook.onlineFrom > Date.now()) {
+                                    return false;
+                                }
+                                if (pricebook.onlineTo && pricebook.onlineTo < Date.now()) {
+                                    return false;
+                                }
+                                return true;
+                            }).map(pricebook => pricebook.price);
+                            const maxPrice = prices.reduce((acc, currentValue) => {
+                                return Math.max(acc, currentValue);
+                            });
+                            if (maxPrice > item.price) {
+                                item.promotionalPrice = item.price;
+                                item.price = maxPrice;
+                            }
+                        }
+
                         // currency symbol
                         item.currencySymbol = algoliaData.currencySymbol;
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -34,6 +34,31 @@ jest.mock('dw/catalog/ProductMgr', () => {
         }),
     }
 }, {virtual: true});
+jest.mock('dw/catalog/PriceBookMgr', () => {
+    return {
+        getSitePriceBooks: jest.fn(() => {
+            const collectionHelper = require("./test/mocks/helpers/collectionHelper");
+            return collectionHelper.createCollection([
+                {
+                    ID: 'list-prices-usd',
+                    currencyCode: 'USD',
+                },
+                {
+                    ID: 'sale-prices-usd',
+                    currencyCode: 'USD',
+                },
+                {
+                    ID: 'list-prices-eur',
+                    currencyCode: 'EUR',
+                },
+                {
+                    ID: 'sale-prices-eur',
+                    currencyCode: 'EUR',
+                },
+            ]);
+        }),
+    }
+}, { virtual: true });
 jest.mock('dw/io/File', () => {
     class MockedFile {
         constructor() {
@@ -94,10 +119,7 @@ jest.mock('dw/system/Site', () => {
                     return arr;
                 },
                 getAllowedCurrencies: function () {
-                    var arr = [
-                        { currencyCode: 'USD' },
-                        { currencyCode: 'EUR' }
-                    ];
+                    var arr = ['USD', 'EUR'];
                     arr.size = function () {
                         return arr.length;
                     };
@@ -155,8 +177,12 @@ jest.mock('dw/util/Calendar', () => {
     }
 }, {virtual: true});
 jest.mock('dw/util/Currency', () => {
+    const currencies = {
+        USD: { currencyCode: 'USD' },
+        EUR: { currencyCode: 'EUR' },
+    }
     return {
-        getCurrency: function (currency) { return currency; }
+        getCurrency: function (currency) { return currencies[currency]; }
     }
 }, {virtual: true});
 

--- a/test/mocks/dw/catalog/Variant.js
+++ b/test/mocks/dw/catalog/Variant.js
@@ -57,27 +57,30 @@ class Variant extends MasterProduct {
 
     getPriceModel() {
         const currency = request.getSession().getCurrency();
+        let price;
         switch (currency.currencyCode) {
             case 'USD':
-                return {
-                    price: this.prices['sale-prices-usd'],
-                    getPriceBookPriceInfo: (priceBookID) => {
-                        return {
-                            price: this.prices[priceBookID],
-                        }
-                    }
-                };
+                price = this.prices['sale-prices-usd'];
+                break;
             case 'EUR':
-                return {
-                    price: this.prices['sale-prices-eur'],
-                    getPriceBookPriceInfo: (priceBookID) => {
-                        return {
-                            price: this.prices[priceBookID],
-                        }
-                    }
-                };
+                price = this.prices['sale-prices-eur'];
+                break;
             default:
                 return null;
+        }
+        return {
+            price,
+            getPriceBookPriceInfo: (priceBookID) => {
+                const priceInfo = {
+                    price: this.prices[priceBookID],
+                }
+                if (priceBookID === 'sale-prices-eur') {
+                    priceInfo.onlineFrom = {
+                        getTime: () => 1704067200000,
+                    }
+                }
+                return priceInfo;
+            }
         }
     }
 

--- a/test/mocks/dw/catalog/Variant.js
+++ b/test/mocks/dw/catalog/Variant.js
@@ -26,6 +26,29 @@ class Variant extends MasterProduct {
             },
             refinementSize: '4',
         };
+
+        this.prices = {
+            'sale-prices-usd': {
+                available: true,
+                currencyCode: 'USD',
+                value: 129,
+            },
+            'list-prices-usd': {
+                available: true,
+                currencyCode: 'USD',
+                value: 132,
+            },
+            'sale-prices-eur': {
+                available: true,
+                currencyCode: 'EUR',
+                value: 92.88,
+            },
+            'list-prices-eur': {
+                available: true,
+                currencyCode: 'EUR',
+                value: 94,
+            }
+        }
     }
 
     getOnlineCategories() {
@@ -37,19 +60,21 @@ class Variant extends MasterProduct {
         switch (currency.currencyCode) {
             case 'USD':
                 return {
-                    price: {
-                        available: true,
-                        currencyCode: 'USD',
-                        value: 129,
-                    },
+                    price: this.prices['sale-prices-usd'],
+                    getPriceBookPriceInfo: (priceBookID) => {
+                        return {
+                            price: this.prices[priceBookID],
+                        }
+                    }
                 };
             case 'EUR':
                 return {
-                    price: {
-                        available: true,
-                        currencyCode: 'EUR',
-                        value: 92.88,
-                    },
+                    price: this.prices['sale-prices-eur'],
+                    getPriceBookPriceInfo: (priceBookID) => {
+                        return {
+                            price: this.prices[priceBookID],
+                        }
+                    }
                 };
             default:
                 return null;

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -18,10 +18,7 @@ jest.mock('dw/system/Site', () => {
                     return arr;
                 },
                 getAllowedCurrencies: function () {
-                    var arr = [
-                        { currencyCode: 'USD' },
-                        { currencyCode: 'EUR' }
-                    ];
+                    var arr = ['USD', 'EUR'];
                     arr.size = function () {
                         return arr.length;
                     };
@@ -29,11 +26,6 @@ jest.mock('dw/system/Site', () => {
                 }
             };
         }
-    }
-}, {virtual: true});
-jest.mock('dw/util/Currency', () => {
-    return {
-        getCurrency: function (currency) { return currency; }
     }
 }, {virtual: true});
 jest.mock('dw/util/StringUtils', () => {
@@ -317,5 +309,37 @@ describe('algoliaLocalizedProduct', function () {
             name: 'Test name',
         };
         expect(new AlgoliaLocalizedProduct({ product: product, locale: 'default', attributeList: ['price', 'UPC', 'name'], baseModel: baseModel })).toEqual(expectedProductModel);
+    });
+
+    test('pricebooks', function () {
+        const product = new ProductMock();
+        const expected = {
+            objectID: '701644031206M',
+            pricebooks: {
+                USD: [{
+                    price: 132,
+                    pricebookID: 'list-prices-usd',
+                    onlineFrom: undefined,
+                    onlineTo: undefined,
+                }, {
+                    price: 129,
+                    pricebookID: 'sale-prices-usd',
+                    onlineFrom: undefined,
+                    onlineTo: undefined,
+                }],
+                EUR: [{
+                    price: 94,
+                    pricebookID: 'list-prices-eur',
+                    onlineFrom: undefined,
+                    onlineTo: undefined,
+                }, {
+                    price: 92.88,
+                    pricebookID: 'sale-prices-eur',
+                    onlineFrom: undefined,
+                    onlineTo: undefined,
+                }],
+            },
+        };
+        expect(new AlgoliaLocalizedProduct({ product: product, attributeList: ['pricebooks'] })).toEqual(expected);
     });
 });

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -335,7 +335,7 @@ describe('algoliaLocalizedProduct', function () {
                 }, {
                     price: 92.88,
                     pricebookID: 'sale-prices-eur',
-                    onlineFrom: undefined,
+                    onlineFrom: 1704067200000,
                     onlineTo: undefined,
                 }],
             },


### PR DESCRIPTION
## Multiple pricebooks
### Indexing

Add a new `pricebooks` field declaration. When used, it will add all prices from available pricebooks to the records, for each enabled currency:

```json
{
  "pricebooks": {
    "USD": {
      "price": 10,
      "pricebookID": "sale-prices",
      "onlineFrom": 0,
      "onlineTo": 3155760000000,
    }
  }
}
```

### Frontend
When present in the records, the default UI will use it to display the strikeout price:
Our default UI display a strikeout price when we have a `price` and a `promotionalPrice`. If we have a price higher than the actual `price` in the pricebooks

**note**: This only works for Variation Level record model. We indeed don't have a way to configure which fields should go in the `variants` objects for the "Base Level" record model currently.

### Tests :test_tube: 

- Added unit tests
  - note: fixed a small mistake in our tests. `getAllowedCurrencies()` actually returns a list of currencyCodes ([doc](https://salesforcecommercecloud.github.io/b2c-dev-doc/docs/current/scriptapi/html/api/class_dw_system_Site.html#dw_system_Site_getAllowedCurrencies_DetailAnchor))

To test manually:
- Add `pricebooks` to the Additional Product Attributes
- Use "Variant Level" record model
- Run a fullCatalogReindex
- In the frontend, look for products that have a sales price, for example "Mens > Accessories"

---
SFCC-265