### PR TITLE
feat: show searchbox

### DIFF
--- a/cartridges/int_algolia_sfra/cartridge/static/default/css/algolia/index.css
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/css/algolia/index.css
@@ -14,3 +14,11 @@
 .algolia-results-tab {
     cursor: pointer;
 }
+
+.ais-SearchBox-reset {
+    position: absolute;
+    border: none;
+    top: 0.5625em;
+    right: 0.5625em;
+    padding: 0 1em;
+}

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -38,6 +38,7 @@ function enableInstantSearch(config) {
         indexName: productsIndex,
         searchClient: config.searchClient,
         initialUiState: initialUiState,
+        routing: true,
     });
 
     if (algoliaData.enableInsights) {

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -74,8 +74,11 @@ function enableInstantSearch(config) {
             instantsearch.widgets.searchBox({
                 container: '#algolia-searchbox-placeholder',
                 cssClasses: {
-                    root: 'd-none'
-                }
+                    root: 'refinement',
+                    input: 'form-control',
+                },
+                placeholder: 'Search...',
+                showSubmit: false,
             }),
             instantsearch.widgets.stats({
                 container: '#algolia-stats-placeholder',

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -77,7 +77,7 @@ function enableInstantSearch(config) {
                     root: 'refinement',
                     input: 'form-control',
                 },
-                placeholder: 'Search...',
+                placeholder: algoliaData.strings.placeholder,
                 showSubmit: false,
             }),
             instantsearch.widgets.stats({

--- a/cartridges/int_algolia_sfra/cartridge/templates/default/algolia/search/searchResultsNoDecorator.isml
+++ b/cartridges/int_algolia_sfra/cartridge/templates/default/algolia/search/searchResultsNoDecorator.isml
@@ -48,7 +48,6 @@
         <div class="tab-content col-12">
             <div class="ais-InstantSearch tab-pane container active"  id="product-search-results" role="tabpanel" aria-labelledby="product-tab">
                 <div class="row grid-header">
-                        <div id="algolia-searchbox-placeholder" ></div>
                         <div id="algolia-stats-placeholder" class="result-count text-center col-12 col-md-9 col-sm-6 order-sm-2"></div>
                         <div id="algolia-sort-by-placeholder" class="col-6 col-sm-3 order-sm-1"></div>
 
@@ -60,6 +59,7 @@
                 </div>
                 <div class="row">
                     <div class="refinement-bar col-md-3">
+                        <div id="algolia-searchbox-placeholder"></div>
 
                         <div id="algolia-clear-refinements-placeholder"></div>
 


### PR DESCRIPTION
If you trigger a search using Autocomplete (and hitting the enter key), results are displayed using InstantSearch.

You can refine using facets, but you can’t clear the current query because the searchBox is hidden. To update/clear the query, you have to do a new search from Autocomplete, which is not obvious.

This PR makes the searchbox visible:

![image](https://github.com/algolia/algoliasearch-sfcc-b2c/assets/2042109/bffc7dbd-1fe2-443d-93d7-5c4ac690f207)


### How to test

- Trigger a search using Autocomplete
- The query will be visible in the searchbox and you can update it

---
SFCC-263