### PR TITLE
feat: new 'computedFromBaseProduct' attribute configuration

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig.js
@@ -2,7 +2,6 @@
 
 var defaultAttributes = ['id', 'primary_category_id', 'in_stock', 'price', 'categories'];
 var defaultAttributes_v2 = ['name', 'primary_category_id', 'categories', 'in_stock', 'price', 'image_groups', 'url'];
-var COLOR_VARIATIONS_FIELD_NAME = 'colorVariations';
 // Configurations for master-level indexing mode
 var defaultMasterAttributes_v2 = ['variants', 'defaultVariantID', 'colorVariations'];
 var defaultVariantAttributes_v2 = ['in_stock', 'price', 'color', 'size', 'url'];
@@ -220,6 +219,7 @@ var attributeConfig_v2 = {
     },
     colorVariations: {
         localized: true,
+        computedFromBaseProduct: true,
     },
     image_groups: {
         localized: true
@@ -268,5 +268,4 @@ module.exports = {
     defaultMasterAttributes_v2: defaultMasterAttributes_v2,
     attributeConfig: attributeConfig,
     attributeConfig_v2: attributeConfig_v2,
-    COLOR_VARIATIONS_FIELD_NAME: COLOR_VARIATIONS_FIELD_NAME,
 };

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -119,35 +119,28 @@ exports.beforeStep = function(parameters, stepExecution) {
     logger.info('Record model: ' + paramRecordModel);
 
 
-    /* --- master/variant attributes --- */
+    /* --- categorize attributes (master/variant, non-localized, shared) --- */
     variantAttributes = algoliaProductConfig.defaultVariantAttributes_v2.slice();
     masterAttributes = algoliaProductConfig.defaultMasterAttributes_v2.slice();
     attributesToSend.forEach(function(attribute) {
-        if (algoliaProductConfig.attributeConfig_v2[attribute] &&
-            algoliaProductConfig.attributeConfig_v2[attribute].variantAttribute) {
-            if (variantAttributes.indexOf(attribute) < 0) {
-                variantAttributes.push(attribute);
-            }
-        } else if (masterAttributes.indexOf(attribute) < 0) {
+        var attributeConfig = algoliaProductConfig.attributeConfig_v2[attribute] || {};
+
+        if (attributeConfig.variantAttribute) {
+            variantAttributes.push(attribute);
+        } else {
             masterAttributes.push(attribute);
+        }
+
+        if (attributeConfig.computedFromBaseProduct) {
+            attributesComputedFromBaseProduct.push(attribute);
+        } else if (!attributeConfig.localized) {
+            nonLocalizedAttributes.push(attribute);
+            if (!attributeConfig.variantAttribute) {
+                nonLocalizedMasterAttributes.push(attribute);
+            }
         }
     });
 
-    /* --- non-localized/shared attributes --- */
-    Object.keys(algoliaProductConfig.attributeConfig_v2).forEach(function(attributeName) {
-        if (algoliaProductConfig.attributeConfig_v2[attributeName].computedFromBaseProduct) {
-            if (attributesToSend.indexOf(attributeName) >= 0) {
-                attributesComputedFromBaseProduct.push(attributeName);
-            }
-        } else if (!algoliaProductConfig.attributeConfig_v2[attributeName].localized) {
-            if (attributesToSend.indexOf(attributeName) >= 0) {
-                nonLocalizedAttributes.push(attributeName);
-            }
-            if (masterAttributes.indexOf(attributeName) >= 0) {
-                nonLocalizedMasterAttributes.push(attributeName);
-            }
-        }
-    });
     logger.info('Non-localized attributes: ' + JSON.stringify(nonLocalizedAttributes));
     logger.info('Attributes computed from base product and shared with siblings: ' + JSON.stringify(attributesComputedFromBaseProduct));
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -312,6 +312,8 @@ exports.process = function(cpObj, parameters, stepExecution) {
 
     if (!empty(product) && cpObj.available && product.isAssignedToSiteCatalog()) {
         if (paramRecordModel === MASTER_LEVEL || attributesComputedFromBaseProduct.length > 0) {
+            // When there are attributes shared in all variants (such as 'colorVariations')
+            // or for master-level indexing, we work with the master products.
             if (product.isVariant()) {
                 // This variant will be indexed when we treat its master product
                 return [];

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -224,8 +224,9 @@ exports.process = function(product, parameters, stepExecution) {
     jobReport.processedItems++; // counts towards the total number of products processed
 
     if (paramRecordModel === MASTER_LEVEL || attributesComputedFromBaseProduct.length > 0) {
+        // When there are attributes shared in all variants (such as 'colorVariations')
+        // or for master-level indexing, we work with the master products.
         if (product.isVariant()) {
-            // To generate 'colorVariations' or for master-level indexing, we need to work with the master products.
             // This variant will be indexed when we treat its master product, skip it.
             return [];
         }


### PR DESCRIPTION
In the Variant-level record model, there can be "siblings" data in each records. For example for the color swatches, every variant record has a `colorVariations` field, containing all available color variations of the master product.

For optimization purposes, we want to compute those fields only once for each master product and inject it in each variants.

This PR introduces a new `computedFromBaseProduct` configuration parameter.
When some attributes are declared with `computedFromBaseProduct: true`:
- the jobs do the indexing based on the master product (before it was the case only for the hardcoded `colorVariations` attribute)
- the `generateVariantRecords()` method compute those attributes only once, and inject it into each variant

---
SFCC-298