### PR TITLE
fix: dont load instantsearch everywhere

### DIFF
--- a/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/index.js
+++ b/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/index.js
@@ -16,13 +16,15 @@ document.addEventListener('DOMContentLoaded', function () {
         searchPageRoot: searchPageRoot
     });
 
-    // FIXME: only enable on search and category page
-    enableInstantSearch({
-        searchClient: searchClient,
-        urlQuery: urlQuery,
-        categoryDisplayNamePath: categoryDisplayNamePath,
-        categoryDisplayNamePathSeparator: categoryDisplayNamePathSeparator,
-    });
+    if (document.querySelector('.cat-banner h1') ||
+        document.querySelector('#algolia-searchbox-placeholder')) {
+        enableInstantSearch({
+            searchClient: searchClient,
+            urlQuery: urlQuery,
+            categoryDisplayNamePath: categoryDisplayNamePath,
+            categoryDisplayNamePathSeparator: categoryDisplayNamePathSeparator,
+        });
+    }
 
     if (algoliaData.enableInsights) {
         enableInsights(algoliaData.applicationID, algoliaData.searchApiKey, algoliaData.productsIndex);

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/index.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/index.js
@@ -31,13 +31,15 @@ document.addEventListener('DOMContentLoaded', function () {
         recommendClient,
     });
 
-    // FIXME: only enable on search and category page
-    enableInstantSearch({
-        searchClient,
-        urlQuery,
-        categoryDisplayNamePath,
-        categoryDisplayNamePathSeparator,
-    });
+    if (document.querySelector('#algolia-category-title-placeholder') ||
+        document.querySelector('#algolia-searchbox-placeholder')) {
+        enableInstantSearch({
+            searchClient,
+            urlQuery,
+            categoryDisplayNamePath,
+            categoryDisplayNamePathSeparator,
+        });
+    }
 
     if (algoliaData.enableInsights) {
         enableInsights(algoliaData.applicationID, algoliaData.searchApiKey, algoliaData.productsIndex);


### PR DESCRIPTION
Only enable InstantSearch on pages where the DOM containers are present, to avoid triggering an empty search on pages where it's not displayed.

### How to test

Open a page with no search results such as the Term & Conditions and observe the network requests.