### PR TITLE
Fixing pricing re-rendering issue by using cache

### DIFF
--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/recommend-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/recommend-config.js
@@ -1,7 +1,7 @@
 /* global instantsearch */
 
 const { frequentlyBoughtTogether, relatedProducts, trendingItems, lookingSimilar } = window['@algolia/recommend-js'];
-
+const itemComponentCache = new Map();
 /**
  * Enable recommendations
  * @param {Object} config - Configuration object
@@ -132,33 +132,41 @@ function contentComponent({ item, html }) {
             </div>
         </a>`;
 }
-
 /**
  * Item component used in widgets
  * @param {Object} param0 - Item and HTML from Algolia widget
  * @returns {string} HTML string
  */
 function itemComponent({ item, html }) {
+    const cacheKey = JSON.stringify(item.objectID);
+
+    if (itemComponentCache.has(cacheKey)) {
+        return itemComponentCache.get(cacheKey);
+    }
 
     const hit = transformItem(item);
 
-    return html`
+    const renderedHtml = html `
         <div class="col-12" data-pid="${hit.objectID}" data-query-id="${hit.__queryID}" data-index-name="${hit.__indexName}">
-            <div class="product-tile">
-                <div class="image-container">
-                    <a href="${hit.url}">
-                        <img class="tile-image" src="${hit.image.dis_base_link}" alt="${hit.image.alt}" title="${hit.name}"/>
-                    </a>
-                </div>
-                <div class="tile-body">
-                    <div class="pdp-link">
-                        <a href="${hit.url}">${hit.name}</a>
-                    </div>
-                    <div class="price">${getPriceHtml(hit, html)}</div>
-                </div>
+          <div class="product-tile">
+            <div class="image-container">
+              <a href="${hit.url}">
+                <img class="tile-image" src="${hit.image.dis_base_link}" alt="${hit.image.alt}" title="${hit.name}"/>
+              </a>
             </div>
+            <div class="tile-body">
+              <div class="pdp-link">
+                <a href="${hit.url}">${hit.name}</a>
+              </div>
+              <div class="price">${getPriceHtml(hit, html)}</div>
+            </div>
+          </div>
         </div>
     `;
+
+    itemComponentCache.set(cacheKey, renderedHtml);
+
+    return renderedHtml;
 }
 
 /**


### PR DESCRIPTION
## Change

- Cached the item and returned rendered html from the cache to prevent the re-rendering issue.


**Root Cause:** It seems that the itemComponents function is being called twice, even though we only created the widget once.

By the way, I spent a lot of time investigating an issue but couldn't why the root cause is happening. I even asked for assistance on Stack Overflow teams from recommend team, but they couldn't understand the issue. I eventually found a workaround. @sbellone, if you have any ideas about this mysterious bug, please let me know. This pull request is just a suggestion to address the issue.

[Question and screenshots for the bug is here](https://stackoverflowteams.com/c/algolia/questions/6278)

## Reproducing the issue:

- [Train Recommendation Models ](https://algolia.atlassian.net/wiki/spaces/SFCC/pages/4934041682/Recommendations+Model+Training+For+SFCC)(Frequently Bought together and trending products) or use `4ISNL568WT` Application for already trained models
- Upload [Demo Cartridge](https://github.com/algolia/sfcc-demo-cartridge) to your instance and add `app_algolia_demo` to your cartridge path
- Import slots.xml file to your BM from `app_algolia_demo` repository
- Visit PDP and see how FBT and looking similar widget added
- Refresh page until prices are broken. (you may need to refresh page 50 times, you can also check StackOverflow link to see issue with a video.

