### PR TITLE
Fixing pricing re-rendering issue by using another attribute for displaying prices

### DIFF
--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/recommend-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/recommend-config.js
@@ -1,7 +1,7 @@
 /* global instantsearch */
 
 const { frequentlyBoughtTogether, relatedProducts, trendingItems, lookingSimilar } = window['@algolia/recommend-js'];
-
+var counter = 0;
 /**
  * Enable recommendations
  * @param {Object} config - Configuration object
@@ -140,6 +140,11 @@ function contentComponent({ item, html }) {
  */
 function itemComponent({ item, html }) {
 
+    counter++;
+
+    if (counter > 8) {
+        console.log('counter', counter);
+    }
     const hit = transformItem(item);
 
     return html`
@@ -190,7 +195,7 @@ function transformItem(item) {
 
     // price in user currency
     if (item.price && item.price[algoliaData.currencyCode] !== null) {
-        item.price = item.price[algoliaData.currencyCode]
+        item.displayPrice = item.price[algoliaData.currencyCode]
     }
 
     // currency symbol
@@ -259,10 +264,10 @@ function transformItem(item) {
         // 3. Get the variant price
         if (selectedVariant) {
             if (selectedVariant.promotionalPrice && selectedVariant.promotionalPrice[algoliaData.currencyCode] !== null) {
-                item.promotionalPrice = selectedVariant.promotionalPrice[algoliaData.currencyCode];
+                item.promotionaPrice = selectedVariant.promotionalPrice[algoliaData.currencyCode];
             }
             if (selectedVariant.price && selectedVariant.price[algoliaData.currencyCode] !== null) {
-                item.price = selectedVariant.price[algoliaData.currencyCode]
+                item.displayPrice = selectedVariant.price[algoliaData.currencyCode]
             }
             item.url = selectedVariant.url;
         }
@@ -305,12 +310,12 @@ function getPriceHtml(item, html) {
     return html`
         ${item.promotionalPrice && html`
             <span class="strike-through list">
-                <span class="value"> ${item.currencySymbol} ${item.price} </span>
+                <span class="value"> ${item.currencySymbol} ${item.displayPrice} </span>
             </span>
         `}
         <span class="sales">
             <span class="value">
-                ${item.currencySymbol} ${item.promotionalPrice ? item.promotionalPrice : item.price}
+                ${item.currencySymbol} ${item.promotionalPrice ? item.promotionalPrice : item.displayPrice}
             </span>
         </span>
     `;

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/recommend-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/recommend-config.js
@@ -1,7 +1,6 @@
 /* global instantsearch */
 
 const { frequentlyBoughtTogether, relatedProducts, trendingItems, lookingSimilar } = window['@algolia/recommend-js'];
-var counter = 0;
 /**
  * Enable recommendations
  * @param {Object} config - Configuration object
@@ -140,11 +139,6 @@ function contentComponent({ item, html }) {
  */
 function itemComponent({ item, html }) {
 
-    counter++;
-
-    if (counter > 8) {
-        console.log('counter', counter);
-    }
     const hit = transformItem(item);
 
     return html`

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/recommend-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/recommend-config.js
@@ -184,7 +184,7 @@ function transformItem(item) {
 
     // adjusted price in user currency
     if (item.promotionalPrice && item.promotionalPrice[algoliaData.currencyCode] !== null) {
-        item.promotionalPrice = item.promotionalPrice[algoliaData.currencyCode]
+        item.promotionalDisplayPrice = item.promotionalPrice[algoliaData.currencyCode]
     }
 
     // price in user currency
@@ -258,7 +258,7 @@ function transformItem(item) {
         // 3. Get the variant price
         if (selectedVariant) {
             if (selectedVariant.promotionalPrice && selectedVariant.promotionalPrice[algoliaData.currencyCode] !== null) {
-                item.promotionaPrice = selectedVariant.promotionalPrice[algoliaData.currencyCode];
+                item.promotionalDisplayPrice = selectedVariant.promotionalPrice[algoliaData.currencyCode];
             }
             if (selectedVariant.price && selectedVariant.price[algoliaData.currencyCode] !== null) {
                 item.displayPrice = selectedVariant.price[algoliaData.currencyCode]
@@ -302,14 +302,14 @@ function getDefaultImage() {
  */
 function getPriceHtml(item, html) {
     return html`
-        ${item.promotionalPrice && html`
+        ${item.promotionalDisplayPrice && html`
             <span class="strike-through list">
                 <span class="value"> ${item.currencySymbol} ${item.displayPrice} </span>
             </span>
         `}
         <span class="sales">
             <span class="value">
-                ${item.currencySymbol} ${item.promotionalPrice ? item.promotionalPrice : item.displayPrice}
+                ${item.currencySymbol} ${item.promotionalDisplayPrice ? item.promotionalDisplayPrice : item.displayPrice}
             </span>
         </span>
     `;


### PR DESCRIPTION
## Change

- Used another attribute for displaying prices to prevent calculations/renderings side effect on the original attribute.

**Root Cause:** It seems that the itemComponents function is being called twice, even though we only created the widget once.

By the way, I spent a lot of time investigating an issue but couldn't why the root cause is happening. I even asked for assistance on Stack Overflow teams from recommend team, but they couldn't understand the issue. I eventually found a workaround. @sbellone, if you have any ideas about this mysterious bug, please let me know. This pull request is just a suggestion to address the issue.

[Question and screenshots for the bug is here](https://stackoverflowteams.com/c/algolia/questions/6278)

## Reproducing the issue:

- [Train Recommendation Models ](https://algolia.atlassian.net/wiki/spaces/SFCC/pages/4934041682/Recommendations+Model+Training+For+SFCC)(Frequently Bought together and trending products) or use `4ISNL568WT` Application for already trained models
- Upload [Demo Cartridge](https://github.com/algolia/sfcc-demo-cartridge) to your instance and add `app_algolia_demo` to your cartridge path
- Import slots.xml file to your BM from `app_algolia_demo` repository
- Visit PDP and see how FBT and looking similar widget added
- Refresh page until prices are broken. (you may need to refresh page 50 times, you can also check StackOverflow link to see issue with a video.

