### PR TITLE
Bugfix for content indexing ignored tags

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaSplitter.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaSplitter.js
@@ -61,11 +61,19 @@ function splitHtmlContent(htmlContent, maxByteSize, splitterElement) {
  * @returns {string} Sanitized content
  */
 function removeIgnoredContent(content) {
-    //remove restricted tags and their content
-    IGNORED_TAGS.forEach(function(tag) {
-        content = content.replace(new RegExp('<' + tag + '.*?' + tag + '>', 'g'), '');
-    });
-
+    for (let i = 0; i < IGNORED_TAGS.length; i++) {
+        let tag = IGNORED_TAGS[i];
+        let startIndex = content.indexOf('<' + tag);
+        while (startIndex !== -1) {
+            let endIndex = content.indexOf('</' + tag + '>', startIndex);
+            if (endIndex !== -1) {
+                content = content.substring(0, startIndex) + content.substring(endIndex + tag.length + 3); // +3 for </tag>
+            } else {
+                break;
+            }
+            startIndex = content.indexOf('<' + tag);
+        }
+    }
     return content;
 }
 

--- a/test/unit/int_algolia/scripts/algolia/lib/algoliaSplitter.test.js
+++ b/test/unit/int_algolia/scripts/algolia/lib/algoliaSplitter.test.js
@@ -36,6 +36,24 @@ describe('HTML Content Manipulation', () => {
             const result = splitHtmlContent(htmlContent, maxByteSize, splitterElement);
             expect(result).toEqual(['Bold Text and normal text']);
         });
+
+        test('should remove self-closing ignored tags', () => {
+            const htmlContent = '<div>Content with image<img src="image.jpg" alt="Image"> more content</div>';
+            const result = splitHtmlContent(htmlContent, maxByteSize, splitterElement);
+            expect(result).toEqual(['Content with image more content']);
+        });
+
+        test('should remove nested ignored tags', () => {
+            const htmlContent = '<div>Content <p><script>Some script</script>Nested content</p> more content</div>';
+            const result = splitHtmlContent(htmlContent, maxByteSize, splitterElement);
+            expect(result).toEqual(['Content Nested content more content']);
+        });
+
+        test('should handle ignored tags without closing tags', () => {
+            const htmlContent = '<div>Content <img src="image.jpg" alt="Image"></div>';
+            const result = splitHtmlContent(htmlContent, maxByteSize, splitterElement);
+            expect(result).toEqual(['Content ']);
+        });
     });
 
     describe('getMaxBodySize', () => {
@@ -95,5 +113,4 @@ describe('Extreme Content Manipulation', () => {
         });
     });
 });
-
 

--- a/test/unit/int_algolia/scripts/algolia/lib/algoliaSplitter.test.js
+++ b/test/unit/int_algolia/scripts/algolia/lib/algoliaSplitter.test.js
@@ -38,7 +38,7 @@ describe('HTML Content Manipulation', () => {
         });
 
         test('should remove self-closing ignored tags', () => {
-            const htmlContent = '<div>Content with image<img src="image.jpg" alt="Image"> more content</div>';
+            const htmlContent = '<div>Content with image<img src="image.jpg" alt="Image"/> more content</div>';
             const result = splitHtmlContent(htmlContent, maxByteSize, splitterElement);
             expect(result).toEqual(['Content with image more content']);
         });


### PR DESCRIPTION
## Change

- Ignored tags logic changed
- Used an approach like that because of Rhino engine restrictions