### PR TITLE
Dynamic logic for handling different product types and and index models

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -9,6 +9,11 @@ global.customPreferences = {
     Algolia_IndexPrefix: 'test_index_',
     Algolia_RecordModel: 'variant-level',
 }
+global.session = {
+    privacy: {
+        algoliaAnchorProducts: null,
+    }
+};
 
 // System classes, alphabetical order
 jest.mock('dw/catalog/ProductMgr', () => {

--- a/test/unit/int_algolia/scripts/algolia/recommend/utils.test.js
+++ b/test/unit/int_algolia/scripts/algolia/recommend/utils.test.js
@@ -80,7 +80,7 @@ describe('getAnchorProductIds', () => {
         expect(utils.getAnchorProductIds(slotcontent)).toBe(JSON.stringify(['product1', 'product1']));
     });
 
-    it('should return appropriate product IDs based on record model (variant model/variant product)', () => {
+    it('should return a variant when we use variant-model and anchor product is a variant product', () => {
         global.session.privacy.algoliaAnchorProducts = JSON.stringify(['product1']);
         const slotcontent = {
             content: []
@@ -89,8 +89,8 @@ describe('getAnchorProductIds', () => {
         expect(utils.getAnchorProductIds(slotcontent)).toBe(JSON.stringify(['product1']));
     });
 
-    it('should return appropriate product IDs based on record model (variant model/master product)', () => {
-        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['product1']);
+    it('should return a variant when we use variant-model and anchor product is a master product', () => {
+        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['masterProduct1']);
         const slotcontent = {
             content: []
         };
@@ -98,8 +98,8 @@ describe('getAnchorProductIds', () => {
         expect(utils.getAnchorProductIds(slotcontent)).toBe(JSON.stringify(['product1']));
     });
 
-    it('should return appropriate product IDs based on record model(variant model/variant group product)', () => {
-        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['product1']);
+    it('should return a variant when we use variant-model and anchor product is a VG product', () => {
+        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['variantGroupProduct1']);
         const slotcontent = {
             content: []
         };
@@ -107,8 +107,8 @@ describe('getAnchorProductIds', () => {
         expect(utils.getAnchorProductIds(slotcontent)).toBe(JSON.stringify(['product1']));
     });
 
-    it('should return appropriate product IDs based on record model(base model/base product)', () => {
-        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['product1']);
+    it('should return a master when we use master-model and anchor product is a master product', () => {
+        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['masterProduct1']);
         const slotcontent = {
             content: []
         };
@@ -117,8 +117,8 @@ describe('getAnchorProductIds', () => {
         expect(utils.getAnchorProductIds(slotcontent)).toBe(JSON.stringify(['masterProduct1']));
     });
 
-    it('should return appropriate product IDs based on record model(base model/variant group product)', () => {
-        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['product1']);
+    it('should return a master when we use master-model and anchor product is a VG product', () => {
+        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['variantGroupProduct1']);
         const slotcontent = {
             content: []
         };
@@ -128,7 +128,7 @@ describe('getAnchorProductIds', () => {
     });
 
 
-    it('should return appropriate product IDs based on record model(base model/variant product)', () => {
+    it('should return a master when we use variant-model and anchor product is a variant product', () => {
         global.session.privacy.algoliaAnchorProducts = JSON.stringify(['product1']);
         const slotcontent = {
             content: []

--- a/test/unit/int_algolia/scripts/algolia/recommend/utils.test.js
+++ b/test/unit/int_algolia/scripts/algolia/recommend/utils.test.js
@@ -2,12 +2,6 @@ describe('getAnchorProductIds', () => {
     const productMgrMock = require('dw/catalog/ProductMgr');
     const algoliaDataMock = jest.mock('*/cartridge/scripts/algolia/lib/algoliaData');
 
-    const session = {
-        privacy: {
-            algoliaAnchorProducts: null,
-        },
-    }
-
     const variantProduct = {
         ID: 'product1',
         isVariationGroup: jest.fn(() => false),

--- a/test/unit/int_algolia/scripts/algolia/recommend/utils.test.js
+++ b/test/unit/int_algolia/scripts/algolia/recommend/utils.test.js
@@ -1,0 +1,146 @@
+describe('getAnchorProductIds', () => {
+    const productMgrMock = require('dw/catalog/ProductMgr');
+    const algoliaDataMock = jest.mock('*/cartridge/scripts/algolia/lib/algoliaData');
+
+    const session = {
+        privacy: {
+            algoliaAnchorProducts: null,
+        },
+    }
+
+    const variantProduct = {
+        ID: 'product1',
+        isVariationGroup: jest.fn(() => false),
+        isVariant: jest.fn(() => true),
+        master: false,
+        masterProduct: {
+            ID: 'masterProduct1'
+        },
+    };
+
+    const masterProduct = {
+        ID: 'masterProduct1',
+        isVariationGroup: jest.fn(() => false),
+        isVariant: jest.fn(() => false),
+        master: true,
+        variationModel: {
+            defaultVariant: {
+                ID: 'product1'
+            },
+        }
+    };
+
+    const variationGroupProduct = {
+        ID: 'variantGroupProduct1',
+        isVariationGroup: jest.fn(() => true),
+        isVariant: jest.fn(() => false),
+        master: false,
+        variationModel: {
+            defaultVariant: {
+                ID: 'product1'
+            },
+        },
+        masterProduct: {
+            ID: 'masterProduct1'
+        },
+    };
+
+    beforeEach(() => {
+        productMgrMock.getProduct.mockReset();
+
+        if (algoliaDataMock.getPreference && algoliaDataMock.getPreference.mockReset) {
+            algoliaDataMock.getPreference.mockReset();
+        } else {
+            algoliaDataMock.getPreference = jest.fn();
+        }
+    });
+
+    const utils = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/recommend/utils');
+
+    it('should return empty string if no anchor products or slot content', () => {
+        const slotcontent = {
+            content: []
+        };
+        expect(utils.getAnchorProductIds(slotcontent)).toBe('');
+    });
+
+    it('should return anchor product IDs from session if available', () => {
+        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['product1']);
+        const slotcontent = {
+            content: []
+        };
+        productMgrMock.getProduct.mockReturnValue(variantProduct);
+        expect(utils.getAnchorProductIds(slotcontent)).toBe(JSON.stringify(['product1']));
+    });
+
+    it('should return product IDs from slot content if no anchor products in session', () => {
+        global.session.privacy.algoliaAnchorProducts = null;
+        const slotcontent = {
+            content: [{
+                ID: 'product1'
+            }, {
+                ID: 'product1'
+            }]
+        };
+        productMgrMock.getProduct.mockReturnValue(variantProduct);
+        expect(utils.getAnchorProductIds(slotcontent)).toBe(JSON.stringify(['product1', 'product1']));
+    });
+
+    it('should return appropriate product IDs based on record model (variant model/variant product)', () => {
+        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['product1']);
+        const slotcontent = {
+            content: []
+        };
+        productMgrMock.getProduct.mockReturnValue(variantProduct);
+        expect(utils.getAnchorProductIds(slotcontent)).toBe(JSON.stringify(['product1']));
+    });
+
+    it('should return appropriate product IDs based on record model (variant model/master product)', () => {
+        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['product1']);
+        const slotcontent = {
+            content: []
+        };
+        productMgrMock.getProduct.mockReturnValue(masterProduct);
+        expect(utils.getAnchorProductIds(slotcontent)).toBe(JSON.stringify(['product1']));
+    });
+
+    it('should return appropriate product IDs based on record model(variant model/variant group product)', () => {
+        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['product1']);
+        const slotcontent = {
+            content: []
+        };
+        productMgrMock.getProduct.mockReturnValue(variationGroupProduct);
+        expect(utils.getAnchorProductIds(slotcontent)).toBe(JSON.stringify(['product1']));
+    });
+
+    it('should return appropriate product IDs based on record model(base model/base product)', () => {
+        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['product1']);
+        const slotcontent = {
+            content: []
+        };
+        global.customPreferences.Algolia_RecordModel = 'master-level';
+        productMgrMock.getProduct.mockReturnValue(masterProduct);
+        expect(utils.getAnchorProductIds(slotcontent)).toBe(JSON.stringify(['masterProduct1']));
+    });
+
+    it('should return appropriate product IDs based on record model(base model/variant group product)', () => {
+        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['product1']);
+        const slotcontent = {
+            content: []
+        };
+        algoliaDataMock.getPreference.mockReturnValue('master-level');
+        productMgrMock.getProduct.mockReturnValue(variationGroupProduct);
+        expect(utils.getAnchorProductIds(slotcontent)).toBe(JSON.stringify(['masterProduct1']));
+    });
+
+
+    it('should return appropriate product IDs based on record model(base model/variant product)', () => {
+        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['product1']);
+        const slotcontent = {
+            content: []
+        };
+        algoliaDataMock.getPreference.mockReturnValue('master-level');
+        productMgrMock.getProduct.mockReturnValue(variantProduct);
+        expect(utils.getAnchorProductIds(slotcontent)).toBe(JSON.stringify(['masterProduct1']));
+    });
+});


### PR DESCRIPTION
## Changes

- Refactoring the getMasterProductIds function to use the getProductType function
- Adding the getProductType and getAppropriateProduct functions
- Updating the getAnchorProductIds function to use the getProductType and getAppropriateProduct functions
- Added unit tests

These changes improve the logic for getting master product IDs and anchor product IDs in the Algolia recommend feature.

## Test

See how it works for variant and base model indexing for the following products: (adjust URL for your sandbox)
- https://zzgk-004.dx.commercecloud.salesforce.com/s/RefArch/3/4-sleeve-v-neck-top/25519318M.html?lang=en_US
- https://zzgk-004.dx.commercecloud.salesforce.com/s/RefArch/3/4-sleeve-v-neck-top/25519318M.html?lang=en_US
- https://zzgk-004.dx.commercecloud.salesforce.com/s/RefArch/mens-basic-leg-trousers/73910532-8M.html?lang=en_US
- https://zzgk-004.dx.commercecloud.salesforce.com/s/RefArch/mens-summer-bomber-jacket/11736753M.html?lang=en_US&queryID=a06f9941447d9167457a1a73b3fc0ae5&objectID=25762732M

(Master, Variation Group, Variation Base, Variant)