### PR TITLE
Updated/re-rendered recommend widgets when a variation is selected

### DIFF
--- a/cartridges/int_algolia_sfra/cartridge/controllers/Product.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Product.js
@@ -6,6 +6,10 @@ var algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
 
 server.extend(base);
 
+/**
+ * Append the anchor product IDs to the session
+ * to be used in the algolia recommendation widget
+ */
 server.append('Show', function (req, res, next) {
     if (algoliaData.getPreference('Enable') && algoliaData.getPreference('EnableRecommend')) {
 
@@ -16,6 +20,26 @@ server.append('Show', function (req, res, next) {
         }
     }
 
+    next();
+});
+
+
+/**
+ * Append the selected variation product ID to the session and view data
+ * to be used in the algolia recommendation widget and updating with the selected variation product
+ */
+server.append('Variation', function (req, res, next) {
+    if (algoliaData.getPreference('Enable') && algoliaData.getPreference('EnableRecommend')) {
+
+        var recommendUtils = require('*/cartridge/scripts/algolia/recommend/utils');
+        var viewData = res.getViewData();
+
+        if (viewData.product) {
+            session.privacy.algoliaAnchorProducts = JSON.stringify([viewData.product.id]);
+            viewData.algoliaAnchorProduct = JSON.parse(recommendUtils.getAnchorProductIds())[0];
+            res.setViewData(viewData);
+        }
+    }
     next();
 });
 

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/recommend-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/recommend-config.js
@@ -1,6 +1,8 @@
 /* global instantsearch */
 
 const { frequentlyBoughtTogether, relatedProducts, trendingItems, lookingSimilar } = window['@algolia/recommend-js'];
+
+var registeredWidgets = new Map();
 /**
  * Enable recommendations
  * @param {Object} config - Configuration object
@@ -68,6 +70,12 @@ function createRecommendationWidget(options) {
         maxRecommendations: 4,
         itemComponent: ({ item, html }) => itemComponent({ item, html })
     };
+
+    if (options.algoliaAnchorProduct) {
+        widgetOptions.objectIDs = [options.algoliaAnchorProduct];
+    } else {
+        registeredWidgets.set(containerId, options);
+    }
 
     if (type === 'frequentlyBoughtTogether') {
         frequentlyBoughtTogether(widgetOptions);
@@ -313,4 +321,16 @@ function getPriceHtml(item, html) {
             </span>
         </span>
     `;
+}
+
+if (algoliaData.enableRecommend) {
+    document.addEventListener('DOMContentLoaded', function() {
+        // Re-render the recommendation widgets when an variation is selected
+        $('body').on('product:afterAttributeSelect', function (e, response) {
+            registeredWidgets.forEach(widget => {
+                widget.algoliaAnchorProduct = response.data.algoliaAnchorProduct;
+                createRecommendationWidget(widget);
+            });
+        });
+    });
 }


### PR DESCRIPTION
## Changes

- Updated/re-rendered recommend widgets when a variation is selected

## Test

- Navigate https://zzgk-004.dx.commercecloud.salesforce.com/s/RefArch/3/4-sleeve-v-neck-top/25519318M.html?lang=en_US and select a variant
- See how recommend widgets are re-rendering