### PR TITLE
feat: Add logic to handle PWA variant ID in color variations

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
@@ -56,7 +56,7 @@ function getColorVariations(product, locale) {
             if (IS_PWA) {
                 var variantID = getVariantID(variationModel, colorVariationAttribute, colorValue);
 
-                variationObject.variantID = variantID;
+                variationObject.variantID = variantID; // This used for generating PWA URL structure.
             }
 
             colorVariations.push(variationObject);

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
@@ -54,9 +54,7 @@ function getColorVariations(product, locale) {
             };
 
             if (IS_PWA) {
-                var variantID = getVariantID(variationModel, colorVariationAttribute, colorValue);
-
-                variationObject.variantID = variantID; // Required to create product detail page URL in PWA
+                variationObject.colorCode = colorValue.value; // Required to create product detail page URL in PWA
             }
 
             colorVariations.push(variationObject);
@@ -121,29 +119,6 @@ function getImageGroups(imagesList, viewtype) {
     }
 
     return result;
-}
-
-/**
- * Function returning the color variations of a product
- * @param {dw.catalog.ProductVariationModel} variationModel a variation model
- * @param {string} colorVariationAttribute a 'color' variation attribute
- * @param {dw.catalog.ProductVariationAttributeValue} colorAttributeValue a 'color' variation value
- * @param {string} productID the product ID
- * @returns {string|null} the variant ID of the product
- */
-function getVariantID(variationModel, colorVariationAttribute, colorAttributeValue) {
-    var variants = variationModel.getVariants();
-
-    var variantArr = variants.toArray();
-
-    for (var i = 0; i < variantArr.length; i++) {
-        var variant = variantArr[i];
-        if (variant.custom.color === colorAttributeValue.value) {
-            return variant.ID;
-        }
-    }
-
-    return null;
 }
 
 module.exports = {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
@@ -56,7 +56,7 @@ function getColorVariations(product, locale) {
             if (IS_PWA) {
                 var variantID = getVariantID(variationModel, colorVariationAttribute, colorValue);
 
-                variationObject.variantID = variantID; // For the PWA product detail page URL.
+                variationObject.variantID = variantID; // Required to create product detail page URL in PWA
             }
 
             colorVariations.push(variationObject);

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
@@ -129,6 +129,7 @@ function getImageGroups(imagesList, viewtype) {
  * @param {string} colorVariationAttribute a 'color' variation attribute
  * @param {dw.catalog.ProductVariationAttributeValue} colorAttributeValue a 'color' variation value
  * @param {string} productID the product ID
+ * @returns {string|null} the variant ID of the product
  */
 function getVariantID(variationModel, colorVariationAttribute, colorAttributeValue) {
     var variants = variationModel.getVariants();

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
@@ -56,7 +56,7 @@ function getColorVariations(product, locale) {
             if (IS_PWA) {
                 var variantID = getVariantID(variationModel, colorVariationAttribute, colorValue);
 
-                variationObject.variantID = variantID; // This used for generating PWA URL structure.
+                variationObject.variantID = variantID; // For the PWA product detail page URL.
             }
 
             colorVariations.push(variationObject);

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
@@ -4,7 +4,7 @@ const logger = require('*/cartridge/scripts/algolia/helper/jobHelper').getAlgoli
 
 const COLOR_ATTRIBUTE_ID = 'color';
 
-const IS_PWA = true; // You can set this to false if you are not using PWA, this is used to determine if we should return the variantID that necessary for PWA
+const IS_PWA = false; // You can set this to true if you are using PWA, this is used to determine if we should return the variantID that necessary for PWA
 
 /**
  * Return colorVariations for a product, based on its variation model
@@ -38,7 +38,6 @@ function getColorVariations(product, locale) {
         }
         var image_groups = getColorVariationImagesGroup(variationModel, colorValue);
 
-        var variantID = getVariantID(variationModel, colorVariationAttribute, colorValue);
 
         if (image_groups) {
 
@@ -54,7 +53,9 @@ function getColorVariations(product, locale) {
                 color: colorValue.displayValue,
             };
 
-            if (variantID && IS_PWA) {
+            if (IS_PWA) {
+                var variantID = getVariantID(variationModel, colorVariationAttribute, colorValue);
+
                 variationObject.variantID = variantID;
             }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
@@ -4,7 +4,7 @@ const logger = require('*/cartridge/scripts/algolia/helper/jobHelper').getAlgoli
 
 const COLOR_ATTRIBUTE_ID = 'color';
 
-const IS_PWA = false; // You can set this to true if you are using PWA, this is used to determine if we should return the variantID that necessary for PWA
+const IS_PWA = false; // You can set this to true if you are using PWA, this is used to determine if we should return the colorCode that is necessary for PWA
 
 /**
  * Return colorVariations for a product, based on its variation model

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
@@ -4,6 +4,8 @@ const logger = require('*/cartridge/scripts/algolia/helper/jobHelper').getAlgoli
 
 const COLOR_ATTRIBUTE_ID = 'color';
 
+const IS_PWA = true; // You can set this to false if you are not using PWA, this is used to determine if we should return the variantID that necessary for PWA
+
 /**
  * Return colorVariations for a product, based on its variation model
  * @param {dw.catalog.Product} product Product
@@ -36,8 +38,11 @@ function getColorVariations(product, locale) {
         }
         var image_groups = getColorVariationImagesGroup(variationModel, colorValue);
 
+        var variantID = getVariantID(variationModel, colorVariationAttribute, colorValue);
+
         if (image_groups) {
-            colorVariations.push({
+
+            var variationObject = {
                 image_groups: image_groups,
                 variationURL: URLUtils.url(
                     'Product-Show',
@@ -47,7 +52,13 @@ function getColorVariations(product, locale) {
                     colorValue.value
                 ).toString(),
                 color: colorValue.displayValue,
-            });
+            };
+
+            if (variantID && IS_PWA) {
+                variationObject.variantID = variantID;
+            }
+
+            colorVariations.push(variationObject);
         }
     }
     return colorVariations;
@@ -109,6 +120,28 @@ function getImageGroups(imagesList, viewtype) {
     }
 
     return result;
+}
+
+/**
+ * Function returning the color variations of a product
+ * @param {dw.catalog.ProductVariationModel} variationModel a variation model
+ * @param {string} colorVariationAttribute a 'color' variation attribute
+ * @param {dw.catalog.ProductVariationAttributeValue} colorAttributeValue a 'color' variation value
+ * @param {string} productID the product ID
+ */
+function getVariantID(variationModel, colorVariationAttribute, colorAttributeValue) {
+    var variants = variationModel.getVariants();
+
+    var variantArr = variants.toArray();
+
+    for (var i = 0; i < variantArr.length; i++) {
+        var variant = variantArr[i];
+        if (variant.custom.color === colorAttributeValue.value) {
+            return variant.ID;
+        }
+    }
+
+    return null;
 }
 
 module.exports = {


### PR DESCRIPTION
The code changes in `modelHelper.js` introduce logic to handle PWA variant ID in color variations. The `IS_PWA` flag is used to determine if the variant ID should be included in the color variations object. This change improves the functionality for PWA users.