### PR TITLE
fix(categories): split batches by locale

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
@@ -49,8 +49,6 @@ function runCategoryExport(parameters, stepExecution) {
     var siteCatalog = catalogMgr.getSiteCatalog();
     var siteCatalogID = siteCatalog.getID();
     var siteRootCategory = siteCatalog.getRoot();
-    var topLevelCategories = siteRootCategory.hasOnlineSubCategories()
-        ? siteRootCategory.getOnlineSubCategories().iterator() : null;
 
     var jobReport = new AlgoliaJobReport(stepExecution.getJobExecution().getJobID(), 'category');
     jobReport.startTime = new Date();
@@ -79,57 +77,61 @@ function runCategoryExport(parameters, stepExecution) {
     }
 
     var lastIndexingTasks = {};
-    while (topLevelCategories.hasNext()) {
-        var batch = [];
-        var category = topLevelCategories.next();
-        for (let l = 0; l < siteLocales.size(); ++l) {
-            var locale = siteLocales[l];
-            var tmpIndexName = algoliaData.calculateIndexName('categories', locale) + '.tmp';
+    for (let l = 0; l < siteLocales.size(); ++l) {
+        var locale = siteLocales[l];
+        var topLevelCategories = siteRootCategory.getOnlineSubCategories().iterator();
+        var tmpIndexName = algoliaData.calculateIndexName('categories', locale) + '.tmp';
+        while (topLevelCategories.hasNext()) {
+            var batch = [];
+            var category = topLevelCategories.next();
             var localizedCategories = getSubCategoryModels(category, siteCatalogID, locale);
 
             for (let i = 0; i < localizedCategories.length; ++i) {
                 batch.push(new jobHelper.AlgoliaOperation('addObject', localizedCategories[i], tmpIndexName));
             }
-        }
 
-        jobReport.processedItemsToSend += (batch.length / siteLocales.size()); // number of categories for one locale
-        jobReport.processedItems = jobReport.processedItemsToSend; // same value, there's no filtering for categories
-        jobReport.recordsToSend += batch.length;
+            // We only count the number of categories for the first locales
+            if (l === 0) {
+                jobReport.processedItemsToSend += batch.length; // number of categories for the first locale
+                jobReport.processedItems = jobReport.processedItemsToSend; // same value, there's no filtering for categories
+            }
+            jobReport.recordsToSend += batch.length;
 
-        if (batch.length === 0) {
-            logger.info('No records generated for category: ' + category.getID() + ', continuing...');
-            continue;
-        }
+            if (batch.length === 0) {
+                logger.info('No records generated for category: ' + category.getID() + ', continuing...');
+                continue;
+            }
 
-        logger.info('Sending a batch of ' + batch.length + ' records for top-level category ID: ' + category.getID());
+            logger.info('Sending a batch of ' + batch.length + ' records for top-level category ID "' + category.getID() + '" and locale ' + locale);
 
-        var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
-        var result = retryableBatchRes.result;
-        jobReport.recordsFailed += retryableBatchRes.failedRecords;
+            var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
+            var result = retryableBatchRes.result;
+            jobReport.recordsFailed += retryableBatchRes.failedRecords;
 
-        if (result.ok) {
-            jobReport.recordsSent += batch.length;
-            jobReport.chunksSent++;
+            if (result.ok) {
+                jobReport.recordsSent += batch.length;
+                jobReport.chunksSent++;
 
-            // Store Algolia indexing task IDs
-            var taskIDs = result.object.body.taskID;
-            Object.keys(taskIDs).forEach(function (taskIndexName) {
-                lastIndexingTasks[taskIndexName] = taskIDs[taskIndexName];
-            });
-        } else {
-            let errorMessage = 'Failed to send categories: ' + result.errorMessage + ', stopping job.';
+                // Store Algolia indexing task IDs
+                var taskIDs = result.object.body.taskID;
+                Object.keys(taskIDs).forEach(function (taskIndexName) {
+                    lastIndexingTasks[taskIndexName] = taskIDs[taskIndexName];
+                });
+            } else {
+                let errorMessage = 'Failed to send categories: ' + result.errorMessage + ', stopping job.';
 
-            jobReport.recordsFailed += batch.length;
-            jobReport.chunksFailed++;
-            jobReport.error = true;
-            jobReport.errorMessage = errorMessage;
+                jobReport.recordsFailed += batch.length;
+                jobReport.chunksFailed++;
+                jobReport.error = true;
+                jobReport.errorMessage = errorMessage;
 
-            jobReport.endTime = new Date();
-            jobReport.writeToCustomObject();
+                jobReport.endTime = new Date();
+                jobReport.writeToCustomObject();
 
-            // return ERROR if at least one batch failed, don't proceed with the atomic reindexing
-            logger.error(errorMessage);
-            return new Status(Status.ERROR, '', errorMessage);
+                // return ERROR if at least one batch failed, don't proceed with the atomic reindexing
+                logger.error(errorMessage);
+                return new Status(Status.ERROR, '', errorMessage);
+            }
         }
     }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
@@ -81,57 +81,53 @@ function runCategoryExport(parameters, stepExecution) {
         var locale = siteLocales[l];
         var topLevelCategories = siteRootCategory.getOnlineSubCategories().iterator();
         var tmpIndexName = algoliaData.calculateIndexName('categories', locale) + '.tmp';
+        var batch = [];
+
         while (topLevelCategories.hasNext()) {
-            var batch = [];
             var category = topLevelCategories.next();
             var localizedCategories = getSubCategoryModels(category, siteCatalogID, locale);
 
             for (let i = 0; i < localizedCategories.length; ++i) {
                 batch.push(new jobHelper.AlgoliaOperation('addObject', localizedCategories[i], tmpIndexName));
             }
+        }
 
-            // We only count the number of categories for the first locales
-            if (l === 0) {
-                jobReport.processedItemsToSend += batch.length; // number of categories for the first locale
-                jobReport.processedItems = jobReport.processedItemsToSend; // same value, there's no filtering for categories
-            }
-            jobReport.recordsToSend += batch.length;
+        // We only count the number of items processed for the first locale
+        if (l === 0) {
+            jobReport.processedItemsToSend += batch.length; // number of categories for the first locale
+            jobReport.processedItems = jobReport.processedItemsToSend; // same value, there's no filtering for categories
+        }
+        jobReport.recordsToSend += batch.length;
 
-            if (batch.length === 0) {
-                logger.info('No records generated for category: ' + category.getID() + ', continuing...');
-                continue;
-            }
+        logger.info('Sending a batch of ' + batch.length + ' records for locale ' + locale);
 
-            logger.info('Sending a batch of ' + batch.length + ' records for top-level category ID "' + category.getID() + '" and locale ' + locale);
+        var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
+        var result = retryableBatchRes.result;
+        jobReport.recordsFailed += retryableBatchRes.failedRecords;
 
-            var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
-            var result = retryableBatchRes.result;
-            jobReport.recordsFailed += retryableBatchRes.failedRecords;
+        if (result.ok) {
+            jobReport.recordsSent += batch.length;
+            jobReport.chunksSent++;
 
-            if (result.ok) {
-                jobReport.recordsSent += batch.length;
-                jobReport.chunksSent++;
+            // Store Algolia indexing task IDs
+            var taskIDs = result.object.body.taskID;
+            Object.keys(taskIDs).forEach(function (taskIndexName) {
+                lastIndexingTasks[taskIndexName] = taskIDs[taskIndexName];
+            });
+        } else {
+            let errorMessage = 'Failed to send categories: ' + result.errorMessage + ', stopping job.';
 
-                // Store Algolia indexing task IDs
-                var taskIDs = result.object.body.taskID;
-                Object.keys(taskIDs).forEach(function (taskIndexName) {
-                    lastIndexingTasks[taskIndexName] = taskIDs[taskIndexName];
-                });
-            } else {
-                let errorMessage = 'Failed to send categories: ' + result.errorMessage + ', stopping job.';
+            jobReport.recordsFailed += batch.length;
+            jobReport.chunksFailed++;
+            jobReport.error = true;
+            jobReport.errorMessage = errorMessage;
 
-                jobReport.recordsFailed += batch.length;
-                jobReport.chunksFailed++;
-                jobReport.error = true;
-                jobReport.errorMessage = errorMessage;
+            jobReport.endTime = new Date();
+            jobReport.writeToCustomObject();
 
-                jobReport.endTime = new Date();
-                jobReport.writeToCustomObject();
-
-                // return ERROR if at least one batch failed, don't proceed with the atomic reindexing
-                logger.error(errorMessage);
-                return new Status(Status.ERROR, '', errorMessage);
-            }
+            // return ERROR if at least one batch failed, don't proceed with the atomic reindexing
+            logger.error(errorMessage);
+            return new Status(Status.ERROR, '', errorMessage);
         }
     }
 

--- a/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaCategoryIndex.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaCategoryIndex.test.js.snap
@@ -205,6 +205,10 @@ exports[`runCategoryExport 1`] = `
           },
           "indexName": "test_index___categories__default.tmp",
         },
+      ],
+    ],
+    [
+      [
         AlgoliaOperation {
           "action": "addObject",
           "body": {
@@ -279,6 +283,10 @@ exports[`runCategoryExport 1`] = `
           },
           "indexName": "test_index___categories__fr.tmp",
         },
+      ],
+    ],
+    [
+      [
         AlgoliaOperation {
           "action": "addObject",
           "body": {
@@ -357,6 +365,34 @@ exports[`runCategoryExport 1`] = `
     ],
   ],
   "results": [
+    {
+      "type": "return",
+      "value": {
+        "object": {
+          "body": {
+            "taskID": {
+              "test_index_en": 42,
+              "test_index_fr": 33,
+            },
+          },
+        },
+        "ok": true,
+      },
+    },
+    {
+      "type": "return",
+      "value": {
+        "object": {
+          "body": {
+            "taskID": {
+              "test_index_en": 42,
+              "test_index_fr": 33,
+            },
+          },
+        },
+        "ok": true,
+      },
+    },
     {
       "type": "return",
       "value": {


### PR DESCRIPTION
The categories job was sending one Algolia batch for each top-level category, with all locales:
We were iterating only once on each top level category, and fetching all sub-categories of all locales.

Top-level categories can contain a big amount of sub-categories. Combined with a big amount of locales, this could lead to a batch too big to fit in SFCC limitations (20000 objects in an array).

This PR invert the loops. We will now:
- Iterate on each locale
- For each locale, iterate on each top-level category and build a complete batch for this locale
- Send the batch and continue with the next locale

This will permit the category job to support up to 20000 categories.

### How to test

Run the categories job in a new index.
Index content should be identical to an index generated with the previous version.