### PR TITLE
fix: abort afterStep in case of previous errors

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
@@ -101,11 +101,16 @@ function runCategoryExport(parameters, stepExecution) {
 
         logger.info('Sending a batch of ' + batch.length + ' records for locale ' + locale);
 
-        var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
-        var result = retryableBatchRes.result;
-        jobReport.recordsFailed += retryableBatchRes.failedRecords;
+        var result;
+        try {
+            var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
+            result = retryableBatchRes.result;
+            jobReport.recordsFailed += retryableBatchRes.failedRecords;
+        } catch (e) {
+            logger.error('Error while sending batch to Algolia: ' + e);
+        }
 
-        if (result.ok) {
+        if (result && result.ok) {
             jobReport.recordsSent += batch.length;
             jobReport.chunksSent++;
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
@@ -199,11 +199,16 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
         batch = batch.concat(contentOperations);
     }
 
-    var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
-    var result = retryableBatchRes.result;
-    jobReport.recordsFailed += retryableBatchRes.failedRecords;
+    var result;
+    try {
+        var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
+        result = retryableBatchRes.result;
+        jobReport.recordsFailed += retryableBatchRes.failedRecords;
+    } catch (e) {
+        logger.error('Error while sending batch to Algolia: ' + e);
+    }
 
-    if (result.ok) {
+    if (result && result.ok) {
         jobReport.recordsSent += batch.length;
         jobReport.chunksSent++;
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
@@ -239,11 +239,19 @@ exports.afterStep = function(success, parameters, stepExecution) {
         jobReport.errorMessage = 'An error occurred during the job. Please see the error log for more details.';
     }
 
-    logger.info('Total number of contents: {0}', jobReport.processedItems);
+    logger.info('Total number of contents: {0} / {1}', jobReport.processedItems, count);
     logger.info('Number of contents marked for sending: {0}', jobReport.processedItemsToSend);
     logger.info('Number of locales configured for the site: {0}', jobReport.siteLocales);
     logger.info('Records sent: {0}; Records failed: {1}', jobReport.recordsSent, jobReport.recordsFailed);
     logger.info('Chunks sent: {0}; Chunks failed: {1}', jobReport.chunksSent, jobReport.chunksFailed);
+
+    if (jobReport.error) {
+        jobReport.endTime = new Date();
+        jobReport.writeToCustomObject();
+        logger.error(jobReport.errorMessage);
+        // Don't try to finish the indexing and show the job in ERROR in the history
+        throw new Error(jobReport.errorMessage);
+    }
 
     const failurePercentage = +((jobReport.recordsFailed / jobReport.recordsToSend * 100).toFixed(2)) || 0;
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -370,11 +370,19 @@ exports.afterStep = function(success, parameters, stepExecution) {
         jobReport.errorMessage = 'An error occurred during the job. Please see the error log for more details.';
     }
 
-    logger.info('Total number of products: {0}', jobReport.processedItems);
+    logger.info('Total number of processed products: {0} / {1}', jobReport.processedItems, products.count);
     logger.info('Number of products marked for sending: {0}', jobReport.processedItemsToSend);
     logger.info('Number of locales configured for the site: {0}', jobReport.siteLocales);
     logger.info('Records sent: {0}; Records failed: {1}', jobReport.recordsSent, jobReport.recordsFailed);
     logger.info('Chunks sent: {0}; Chunks failed: {1}', jobReport.chunksSent, jobReport.chunksFailed);
+
+    if (jobReport.error) {
+        jobReport.endTime = new Date();
+        jobReport.writeToCustomObject();
+        logger.error(jobReport.errorMessage);
+        // Don't try to finish the indexing and show the job in ERROR in the history
+        throw new Error(jobReport.errorMessage);
+    }
 
     const failurePercentage = +((jobReport.recordsFailed / jobReport.recordsToSend * 100).toFixed(2)) || 0;
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -328,11 +328,16 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
         return;
     }
 
-    var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
-    var result = retryableBatchRes.result;
-    jobReport.recordsFailed += retryableBatchRes.failedRecords;
+    var result;
+    try {
+        var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
+        result = retryableBatchRes.result;
+        jobReport.recordsFailed += retryableBatchRes.failedRecords;
+    } catch (e) {
+        logger.error('Error while sending batch to Algolia: ' + e);
+    }
 
-    if (result.ok) {
+    if (result && result.ok) {
         jobReport.recordsSent += batch.length;
         jobReport.chunksSent++;
 


### PR DESCRIPTION
I've reproduced the OOM error. My findings:

- First, we unfortunately can't catch it and give a proper explanation. It's a Java error not sent back to our JavaScript code. Below is my repro code. The exception never passes in the `catch` block.
- Another problem I found is that the `afterStep` part of our job was still trying to finish the indexing even when `success` is false :confused: . So it moves the temporary indices to production even if not all products have been processed.

### Changes

This PR fixes the `afterStep`: don't try to complete the reindex in case of previous errors (i.e. when `success` is `false`).

I've also added a preventive `try/catch` around the sending of the batch. As I said, it doesn't catch the OOM error, but it still may catch other issues we haven't thought about.

### How to test

- Apply the following patch to the current branch:
```diff
diff --git a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
index eba3aaa..c55e648 100644
--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -330,6 +330,21 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
 
     var result;
     try {
+        if (jobReport.chunksSent === 1) {
+            jobReport.chunksSent++;
+            // Create a big record with 10KB of text
+            var bigRecord = { name: "big record" };
+            var tenKbOfText = '';
+            for (var i = 0; i < 1000; ++i) {
+                tenKbOfText += '0123456789';
+            }
+            bigRecord.text = tenKbOfText;
+            var operation = new jobHelper.AlgoliaOperation(indexingOperation, bigRecord, "test_index");
+            for (var i = 0; i < 10000; ++i) {
+                batch.push(operation); // Add 10000 of those operations in the batch: more than 1GB to stringify
+            }
+            logger.info('Trying to send ' + batch.length + ' operations with huge records...');
+        }
         var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
         result = retryableBatchRes.result;
         jobReport.recordsFailed += retryableBatchRes.failedRecords;
```
- Run the product index job
- Observe that it fails without moving the temporary indices into production:
```
[2024-06-28 13:06:42.519 GMT] INFO CustomJobThread|322374591|AlgoliaProductIndex_v2|algoliaProductIndex Total number of processed products: 200 / 4,658
[2024-06-28 13:06:42.520 GMT] INFO CustomJobThread|322374591|AlgoliaProductIndex_v2|algoliaProductIndex Number of products marked for sending: 390
[2024-06-28 13:06:42.520 GMT] INFO CustomJobThread|322374591|AlgoliaProductIndex_v2|algoliaProductIndex Number of locales configured for the site: 2
[2024-06-28 13:06:42.520 GMT] INFO CustomJobThread|322374591|AlgoliaProductIndex_v2|algoliaProductIndex Records sent: 102; Records failed: 0
[2024-06-28 13:06:42.520 GMT] INFO CustomJobThread|322374591|AlgoliaProductIndex_v2|algoliaProductIndex Chunks sent: 2; Chunks failed: 0
[2024-06-28 13:06:42.533 GMT] ERROR CustomJobThread|322374591|AlgoliaProductIndex_v2|algoliaProductIndex An error occurred during the job. Please see the error log for more details.
[2024-06-28 13:06:42.594 GMT] ERROR CustomJobThread|322374591|AlgoliaProductIndex_v2|algoliaProductIndex Execution of step [algoliaProductIndex] failed with status [ERROR]! java.lang.OutOfMemoryError: Java heap space
	at java.base/java.util.Arrays.copyOf(Arrays.java:3745)
	at java.base/java.lang.AbstractStringBuilder.ensureCapacityInternal(AbstractStringBuilder.java:172)
	at java.base/java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:538)
	at java.base/java.lang.StringBuilder.append(StringBuilder.java:179)
```

---
Continuation of #172
SFCC-304