### PR TITLE
feat: Add additional SSR params for Algolia search API

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algoliaSearchAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaSearchAPI.js
@@ -20,8 +20,11 @@ function getServerSideHits(query, type, indexType) {
         }
 
         var params = type === 'category' ? "facetFilters=" + encodeURIComponent(facetFiltersParamValue) : "query=" + query;
+
+        var additionalSSRParams = "hitsPerPage=9&analytics=false";
+
         var requestBody = {
-            params: params + "&hitsPerPage=9",
+            params: params + "&" + additionalSSRParams,
         };
 
         // any problems with the request will result in the script simply returning an empty array as server-side rendering

--- a/cartridges/int_algolia/cartridge/scripts/algoliaSearchAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaSearchAPI.js
@@ -21,7 +21,7 @@ function getServerSideHits(query, type, indexType) {
 
         var params = type === 'category' ? "facetFilters=" + encodeURIComponent(facetFiltersParamValue) : "query=" + query;
 
-        var additionalSSRParams = "hitsPerPage=9&analytics=false";
+        var additionalSSRParams = "hitsPerPage=9&analytics=false&enableABTest=false";
 
         var requestBody = {
             params: params + "&" + additionalSSRParams,


### PR DESCRIPTION
The code changes in `algoliaSearchAPI.js` add additional SSR params to the Algolia search API request. This includes setting the `hitsPerPage` to 9 and disabling analytics. This change improves the server-side rendering performance for search results.