### PR TITLE
feat: localesForIndexing parameter at job level

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/AlgoliaJobReport.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/AlgoliaJobReport.js
@@ -85,9 +85,13 @@ AlgoliaJobReport.prototype.formatCustomObject = function(customObject) {
     startTime.setTimeZone(timeZone);
     this.startTime = StringUtils.formatCalendar(startTime);
 
-    let endTime = new Calendar(customObject.custom.endTime);
-    endTime.setTimeZone(timeZone);
-    this.endTime = StringUtils.formatCalendar(endTime);
+    if (customObject.custom.endTime) {
+        let endTime = new Calendar(customObject.custom.endTime);
+        endTime.setTimeZone(timeZone);
+        this.endTime = StringUtils.formatCalendar(endTime);
+    } else {
+        this.endTime = 'N/A';
+    }
 
     this.processedItems = customObject.custom.processedItems.toFixed();
     this.processedItemsToSend = customObject.custom.processedItemsToSend.toFixed();

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
@@ -6,7 +6,7 @@ var ContentSearchModel = require('dw/content/ContentSearchModel');
 var logger;
 
 // job step parameters
-var paramAttributeList, paramFailureThresholdPercentage, includedContent;
+var paramAttributeList, paramFailureThresholdPercentage, includedContent, paramLocalesForIndexing;
 
 // Algolia requires
 var algoliaData, AlgoliaLocalizedContent, jobHelper, reindexHelper, algoliaIndexingAPI, contentFilter, AlgoliaJobReport, algoliaSplitter, algoliaContentConfig, ContentUtil;
@@ -45,6 +45,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     paramAttributeList = algoliaData.csvStringToArray(parameters.attributeList);
     paramFailureThresholdPercentage = parameters.failureThresholdPercentage || 0;
     includedContent = parameters.includedContent || 'allContents';
+    paramLocalesForIndexing = algoliaData.csvStringToArray(parameters.localesForIndexing);
 
 
     attributesToSend = algoliaContentConfig.defaultAttributes;
@@ -70,8 +71,11 @@ exports.beforeStep = function(parameters, stepExecution) {
 
 
     /* --- site locales --- */
-    const localesForIndexing = algoliaData.getSetOfArray('LocalesForIndexing');
     siteLocales = Site.getCurrent().getAllowedLocales();
+    logger.info('localesForIndexing parameter: ' + paramLocalesForIndexing);
+    const localesForIndexing = paramLocalesForIndexing.length > 0 ?
+        paramLocalesForIndexing :
+        algoliaData.getSetOfArray('LocalesForIndexing');
     localesForIndexing.forEach(function(locale) {
         if (siteLocales.indexOf(locale) < 0) {
             throw new Error('Locale "' + locale + '" is not enabled on ' + Site.getCurrent().getName());

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -504,3 +504,6 @@ exports.afterStep = function(success, parameters, stepExecution) {
 exports.__getJobReport = function() {
     return jobReport;
 }
+exports.__getLocalesForIndexing = function() {
+    return siteLocales.toArray();
+}

--- a/cartridges/int_algolia/steptypes.json
+++ b/cartridges/int_algolia/steptypes.json
@@ -11,7 +11,17 @@
                 "function": "runCategoryExport",
                 "transactional": "false",
                 "timeout-in-seconds": "600",
-                "parameters": {},
+                "parameters": {
+                    "parameter": [
+                        {
+                            "@name": "localesForIndexing",
+                            "@type": "string",
+                            "description": "Specify which locales to index in a comma-separated list. If not specified, the Algolia_LocalesForIndexing custom preference is used.",
+                            "@required": false,
+                            "@trim": true
+                        }
+                    ]
+                },
                 "status-codes": {
                     "status": [
                         {
@@ -124,6 +134,13 @@
                             "@required": false,
                             "min-value":"0",
                             "max-value":"100"
+                        },
+                        {
+                            "@name": "localesForIndexing",
+                            "@type": "string",
+                            "description": "Specify which locales to index in a comma-separated list. If not specified, the Algolia_LocalesForIndexing custom preference is used.",
+                            "@required": false,
+                            "@trim": true
                         }
                     ]
                 },
@@ -174,6 +191,13 @@
                             "@required": false,
                             "min-value":"0",
                             "max-value":"100"
+                        },
+                        {
+                            "@name": "localesForIndexing",
+                            "@type": "string",
+                            "description": "Specify which locales to index in a comma-separated list. If not specified, the Algolia_LocalesForIndexing custom preference is used.",
+                            "@required": false,
+                            "@trim": true
                         }
                     ]
                 },
@@ -249,6 +273,13 @@
                             "@required": false,
                             "min-value":"0",
                             "max-value":"100"
+                        },
+                        {
+                            "@name": "localesForIndexing",
+                            "@type": "string",
+                            "description": "Specify which locales to index in a comma-separated list. If not specified, the Algolia_LocalesForIndexing custom preference is used.",
+                            "@required": false,
+                            "@trim": true
                         }
                     ]
                 },
@@ -371,6 +402,13 @@
                                 ]
                             },
                             "default-value": "allContents"
+                        },
+                        {
+                            "@name": "localesForIndexing",
+                            "@type": "string",
+                            "description": "Specify which locales to index in a comma-separated list. If not specified, the Algolia_LocalesForIndexing custom preference is used.",
+                            "@required": false,
+                            "@trim": true
                         }
                     ]
                 },

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaCategoryIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaCategoryIndex.test.js
@@ -151,4 +151,11 @@ describe('runCategoryExport', () => {
         expect(mockCopySettingsFromProdIndices).toHaveBeenCalledWith('categories', ['fr']);
         expect(mockSendMultiIndexBatch).toMatchSnapshot();
     });
+
+    test('with localesForIndexing at step level', () => {
+        job.runCategoryExport({ localesForIndexing: 'en' }, stepExecution);
+        expect(mockSetJobInfo).toHaveBeenCalledWith({ jobID: 'TestJobID', stepID: 'TestStepID' });
+        expect(mockDeleteTemporaryIndices).toHaveBeenCalledWith('categories', ['en']);
+        expect(mockCopySettingsFromProdIndices).toHaveBeenCalledWith('categories', ['en']);
+    });
 });

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -103,7 +103,6 @@ describe('beforeStep', () => {
     });
     test('locales for indexing', () => {
         job.beforeStep({}, stepExecution);
-        const test = job.__getLocalesForIndexing()
         expect(job.__getLocalesForIndexing()).toStrictEqual(['default', 'fr', 'en']);
 
         mockLocalesForIndexing = ['fr'];
@@ -113,6 +112,11 @@ describe('beforeStep', () => {
         mockLocalesForIndexing = ['fr_FR'];
         expect(() =>  job.beforeStep({}, stepExecution))
             .toThrow(new Error('Locale "fr_FR" is not enabled on Name of the Test-Site'));
+
+        // Job-step level overrides the global custom preference
+        mockLocalesForIndexing = ['fr'];
+        job.beforeStep({ localesForIndexing: 'en, fr' }, stepExecution);
+        expect(job.__getLocalesForIndexing()).toStrictEqual(['en', 'fr']);
     });
 });
 


### PR DESCRIPTION
## Changes

Add a new `localesForIndexing` parameter at the job step level for all our jobs.

Our jobs will now use the locales from:
- This new `localesForIndexing` parameter in priority
- The `Algolia_LocalesForIndexing` custom preference if the job level parameter is empty
- The locales enabled on the Site if both parameters are empty

### Misc

- Small fix added to the `AlgoliaJobReport.formatCustomObject` function: it could throw an exception when no `endDate` was defined, causing a crash on the BM:
  ```
  com.demandware.core.script.capi.ScriptingException: Wrapped java.lang.NullPointerException (int_algolia/cartridge/scripts/algolia/helper/AlgoliaJobReport.js#88)
	at int_algolia/cartridge/scripts/algolia/helper/AlgoliaJobReport.js:88 (anonymous)
	at bm_algolia/cartridge/scripts/helper/BMHelper.js:35 (anonymous)
	at bm_algolia/cartridge/scripts/helper/BMHelper.js:34 (getLatestCOReportsByJob)
	at bm_algolia/cartridge/controllers/AlgoliaBM.js:19 (start)
  ```

---
SFCC-365