### PR TITLE
Cache Strategy Improved

### DIFF
--- a/cartridges/int_algolia_sfra/cartridge/controllers/Search.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Search.js
@@ -48,7 +48,7 @@ server.replace('Show', cache.applyShortPromotionSensitiveCache, consentTracking.
             var hits;
             var contentHits;
             var queryHits;
-            // For algolia, we don't need personalized cache, as thereal  results fetched on the front-end
+            //For Algolia, we don't need personalized cache, as the real results are fetched on the front-end.
             res.cachePeriod = 24; // eslint-disable-line no-param-reassign
             res.cachePeriodUnit = 'hours'; // eslint-disable-line no-param-reassign
 

--- a/cartridges/int_algolia_sfra/cartridge/controllers/Search.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Search.js
@@ -51,6 +51,7 @@ server.replace('Show', cache.applyShortPromotionSensitiveCache, consentTracking.
             //For Algolia, we don't need personalized cache, as the real results are fetched on the front-end.
             res.cachePeriod = 24; // eslint-disable-line no-param-reassign
             res.cachePeriodUnit = 'hours'; // eslint-disable-line no-param-reassign
+            res.personalized = true; // eslint-disable-line no-param-reassign
 
             // server-side rendering to improve SEO - makes a server-side request to Algolia to return CLP search results
             // only triggered when the user-agent looks like a bot, as we want it triggered only for search engines bots (DuckDuckBot, GoogleBot, BingBot, YandexBot, Baiduspider, ...)

--- a/cartridges/int_algolia_sfra/cartridge/controllers/Search.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Search.js
@@ -48,6 +48,9 @@ server.replace('Show', cache.applyShortPromotionSensitiveCache, consentTracking.
             var hits;
             var contentHits;
             var queryHits;
+            // For algolia, we don't need personalized cache, as thereal  results fetched on the front-end
+            res.cachePeriod = 24; // eslint-disable-line no-param-reassign
+            res.cachePeriodUnit = 'hours'; // eslint-disable-line no-param-reassign
 
             // server-side rendering to improve SEO - makes a server-side request to Algolia to return CLP search results
             // only triggered when the user-agent looks like a bot, as we want it triggered only for search engines bots (DuckDuckBot, GoogleBot, BingBot, YandexBot, Baiduspider, ...)


### PR DESCRIPTION
## What is changed

When we use Algolia, we do not need a personalized cache because the SSR result always will be same and we will fetch the results in the frontend. It will improve caching performance.