### PR TITLE
Remove constraint to have to declare attributes

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
@@ -647,6 +647,24 @@ function generateVariantRecords(parameters) {
     return algoliaRecordsPerLocale;
 }
 
+
+/**
+ * Returns the default configuration for a given attribute.
+ * You can override this behavior by adding a specific configuration for the attribute.
+ * @param {string} attributeName - The name of the attribute to get the default configuration for.
+ * @returns {Object} The default configuration object for the attribute.
+ * @returns {string} return.attributeName - The name of the attribute.
+ * @returns {boolean} return.localized - Indicates if the attribute is localized.
+ * @returns {boolean} return.variantAttribute - Indicates if the attribute is a variant attribute.
+ */
+function getCustomAttributeConfig(attributeName) {
+    return {
+        attribute: attributeName,
+        localized: false,
+        variantAttribute: true
+    };
+}
+
 module.exports = {
     // productsIndexJob & categoryIndexJob
     appendObjToXML: appendObjToXML,
@@ -673,4 +691,6 @@ module.exports = {
     isObjectsArrayEmpty: isObjectsArrayEmpty,
     getObjectsArrayLength: getObjectsArrayLength,
     updateCPObjectFromXML: updateCPObjectFromXML,
+
+    getCustomAttributeConfig: getCustomAttributeConfig
 };

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
@@ -657,7 +657,7 @@ function generateVariantRecords(parameters) {
  * @returns {boolean} return.localized - Indicates if the attribute is localized.
  * @returns {boolean} return.variantAttribute - Indicates if the attribute is a variant attribute.
  */
-function getCustomAttributeConfig(attributeName) {
+function getDefaultAttributeConfig(attributeName) {
     return {
         attribute: attributeName,
         localized: false,
@@ -692,5 +692,5 @@ module.exports = {
     getObjectsArrayLength: getObjectsArrayLength,
     updateCPObjectFromXML: updateCPObjectFromXML,
 
-    getCustomAttributeConfig: getCustomAttributeConfig
+    getDefaultAttributeConfig: getDefaultAttributeConfig
 };

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -360,11 +360,6 @@ function algoliaLocalizedProduct(parameters) {
 
         for (var i = 0; i < attributeList.length; i += 1) {
             var attributeName = attributeList[i];
-            var attributeNameArr = attributeName.split('.');
-            if (attributeNameArr.length > 1) {
-                var parentAttribute = attributeNameArr[0];
-                var subAttribute = attributeNameArr[1];
-            }
 
             if (baseModel && baseModel[attributeName]) {
                 this[attributeName] = baseModel[attributeName];
@@ -386,15 +381,17 @@ function algoliaLocalizedProduct(parameters) {
 
                 if (empty(config)) {
                     config = jobHelper.getDefaultAttributeConfig(attributeName);
+                }
 
-                    if (attributeNameArr.length > 1) {
-                        if (!this[parentAttribute]) {
-                            this[parentAttribute] = {};
-                        }
-                        this[parentAttribute][subAttribute] = ObjectHelper.getAttributeValue(product, config.attribute);
-                    } else {
-                        this[attributeName] = ObjectHelper.getAttributeValue(product, config.attribute);
+                var attributeNameArr = attributeName.split('.');
+
+                if (attributeNameArr.length > 1) {
+                    var parentAttribute = attributeNameArr[0];
+                    var subAttribute = attributeNameArr[1];
+                    if (!this[parentAttribute]) {
+                        this[parentAttribute] = {};
                     }
+                    this[parentAttribute][subAttribute] = ObjectHelper.getAttributeValue(product, config.attribute);
                 } else {
                     this[attributeName] = ObjectHelper.getAttributeValue(product, config.attribute);
                 }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -373,6 +373,17 @@ function algoliaLocalizedProduct(parameters) {
                 this[attributeName] = aggregatedValueHandlers[attributeName](product, parameters);
             } else {
                 var config = algoliaProductConfig.attributeConfig_v2[attributeName];
+
+                // if there is no config for the attribute, but it's a custom or activeData attribute, we assume some defaults
+                if (!config && (attributeName.indexOf('custom.') > -1 || attributeName.indexOf('activeData.') > -1)) {
+                    // if the attribute is a custom attribute, we assume it's localized, you can override this behavior by adding a config for the attribute
+                    config = {
+                        attribute: attributeName,
+                        localized: true,
+                        variantAttribute: true
+                    };
+                }
+
                 if (!empty(config)) {
                     this[attributeName] = ObjectHelper.getAttributeValue(product, config.attribute);
                 }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -361,6 +361,14 @@ function algoliaLocalizedProduct(parameters) {
         for (var i = 0; i < attributeList.length; i += 1) {
             var attributeName = attributeList[i];
 
+            var attributeNameArr = attributeName.split('.');
+            var parentAttribute = null;
+            var subAttribute = null;
+            if (attributeNameArr.length > 1) {
+                parentAttribute = attributeNameArr[0];
+                subAttribute = attributeNameArr[1];
+            }
+
             if (baseModel && baseModel[attributeName]) {
                 this[attributeName] = baseModel[attributeName];
             } else if (baseModel && parentAttribute && subAttribute && baseModel[parentAttribute] && baseModel[parentAttribute][subAttribute]) {
@@ -383,11 +391,7 @@ function algoliaLocalizedProduct(parameters) {
                     config = jobHelper.getDefaultAttributeConfig(attributeName);
                 }
 
-                var attributeNameArr = attributeName.split('.');
-
                 if (attributeNameArr.length > 1) {
-                    var parentAttribute = attributeNameArr[0];
-                    var subAttribute = attributeNameArr[1];
                     if (!this[parentAttribute]) {
                         this[parentAttribute] = {};
                     }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -360,10 +360,10 @@ function algoliaLocalizedProduct(parameters) {
 
         for (var i = 0; i < attributeList.length; i += 1) {
             var attributeName = attributeList[i];
-            var attributeNameObj = attributeName.split('.');
-            if (attributeNameObj.length > 1) {
-                var parentAttribute = attributeNameObj[0];
-                var subAttribute = attributeNameObj[1];
+            var attributeNameArr = attributeName.split('.');
+            if (attributeNameArr.length > 1) {
+                var parentAttribute = attributeNameArr[0];
+                var subAttribute = attributeNameArr[1];
             }
 
             if (baseModel && baseModel[attributeName]) {
@@ -385,18 +385,13 @@ function algoliaLocalizedProduct(parameters) {
                 var config = algoliaProductConfig.attributeConfig_v2[attributeName];
 
                 if (empty(config)) {
-                    config = jobHelper.getCustomAttributeConfig(attributeName);
+                    config = jobHelper.getDefaultAttributeConfig(attributeName);
 
-                    if (attributeNameObj.length > 1) {
-                        var tempObj;
-                        if (this[parentAttribute]) {
-                            tempObj = this[parentAttribute];
-                            tempObj[subAttribute] = ObjectHelper.getAttributeValue(product, config.attribute);
-                        } else {
-                            tempObj = {};
-                            tempObj[subAttribute] = ObjectHelper.getAttributeValue(product, config.attribute);
+                    if (attributeNameArr.length > 1) {
+                        if (!this[parentAttribute]) {
+                            this[parentAttribute] = {};
                         }
-                        this[parentAttribute] = tempObj;
+                        this[parentAttribute][subAttribute] = ObjectHelper.getAttributeValue(product, config.attribute);
                     } else {
                         this[attributeName] = ObjectHelper.getAttributeValue(product, config.attribute);
                     }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaProduct.js
@@ -343,8 +343,8 @@ function algoliaProduct(product, fieldListOverride) {
                     value[parentAttribute] = tempObj;
                 } else {
                     value = aggregatedValueHandlers[attributeName]
-                    ? aggregatedValueHandlers[attributeName](product)
-                    : ObjectHelper.getAttributeValue(product, config.attribute, true);
+                        ? aggregatedValueHandlers[attributeName](product)
+                        : ObjectHelper.getAttributeValue(product, config.attribute, true);
                 }
             }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaProduct.js
@@ -287,37 +287,16 @@ function algoliaProduct(product, fieldListOverride) {
     } else {
         for (var i = 0; i < algoliaFields.length; i += 1) {
             var attributeName = algoliaFields[i];
-            var config = algoliaProductConfig.attributeConfig[attributeName]
-            var attributeNameObj = attributeName.split('.');
+            var config = algoliaProductConfig.attributeConfig[attributeName];
 
-            if (empty(config)) {
-                config = jobHelper.getDefaultConfig(attributeName);
-            }
+            if (!empty(config)) {
+                var value = null;
+                if (config.localized) {
+                    var currentSites = Site.getCurrent();
+                    var siteLocales = currentSites.getAllowedLocales();
+                    var siteLocalesSize = siteLocales.size();
+                    var currentLocale = request.getLocale();
 
-            var value = null;
-            if (config.localized) {
-                var currentSites = Site.getCurrent();
-                var siteLocales = currentSites.getAllowedLocales();
-                var siteLocalesSize = siteLocales.size();
-                var currentLocale = request.getLocale();
-                if (attributeNameObj.length > 1) {
-                    var parentAttributeName = attributeNameObj[0];
-                    var childAttributeName = attributeNameObj[1];
-                    value = {};
-                    for (var l = 0; l < siteLocalesSize; l += 1) {
-                        var localeName = siteLocales[l];
-                        request.setLocale(localeName);
-                        if (this[parentAttribute][localeName]) {
-                            tempObj = this[parentAttribute][localeName];
-                            tempObj[subAttribute] = ObjectHelper.getAttributeValue(product, config.attribute);
-                        } else {
-                            tempObj = {};
-                            tempObj[subAttribute] = ObjectHelper.getAttributeValue(product, config.attribute);
-                        }
-                        value[parentAttributeName][localeName] = tempObj;
-                    }
-                    request.setLocale(currentLocale);
-                } else {
                     value = {};
                     for (var l = 0; l < siteLocalesSize; l += 1) {
                         var localeName = siteLocales[l];
@@ -326,29 +305,15 @@ function algoliaProduct(product, fieldListOverride) {
                             ? aggregatedValueHandlers[attributeName](product)
                             : ObjectHelper.getAttributeValue(product, config.attribute, true);
                     }
-                }
-                request.setLocale(currentLocale);
-            } else {
-                if (attributeNameObj.length > 1) {
-                    var parentAttribute = attributeNameObj[0];
-                    var subAttribute = attributeNameObj[1];
-                    var tempObj;
-                    if (this[parentAttribute]) {
-                        tempObj = this[parentAttribute];
-                        tempObj[subAttribute] = ObjectHelper.getAttributeValue(product, config.attribute);
-                    } else {
-                        tempObj = {};
-                        tempObj[subAttribute] = ObjectHelper.getAttributeValue(product, config.attribute);
-                    }
-                    value[parentAttribute] = tempObj;
+                    request.setLocale(currentLocale);
                 } else {
                     value = aggregatedValueHandlers[attributeName]
                         ? aggregatedValueHandlers[attributeName](product)
                         : ObjectHelper.getAttributeValue(product, config.attribute, true);
                 }
-            }
 
-            if (!empty(value)) { this[attributeName] = value; }
+                if (!empty(value)) { this[attributeName] = value; }
+            }
         }
         productModelCustomizer.customizeProductModel(this);
     }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -136,7 +136,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     attributesToSend.forEach(function(attribute) {
         var attributeConfig = extendedProductAttributesConfig[attribute] ||
             algoliaProductConfig.attributeConfig_v2[attribute] ||
-            {};
+            jobHelper.getCustomAttributeConfig(attribute);
 
         if (attributeConfig.variantAttribute) {
             variantAttributes.push(attribute);

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -136,7 +136,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     attributesToSend.forEach(function(attribute) {
         var attributeConfig = extendedProductAttributesConfig[attribute] ||
             algoliaProductConfig.attributeConfig_v2[attribute] ||
-            jobHelper.getCustomAttributeConfig(attribute);
+            jobHelper.getDefaultAttributeConfig(attribute);
 
         if (attributeConfig.variantAttribute) {
             variantAttributes.push(attribute);

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -123,7 +123,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     attributesToSend.forEach(function(attribute) {
         var attributeConfig = extendedProductAttributesConfig[attribute] ||
             algoliaProductConfig.attributeConfig_v2[attribute] ||
-            jobHelper.getCustomAttributeConfig(attribute);
+            jobHelper.getDefaultAttributeConfig(attribute);
 
         if (attributeConfig.variantAttribute) {
             variantAttributes.push(attribute);

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -123,7 +123,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     attributesToSend.forEach(function(attribute) {
         var attributeConfig = extendedProductAttributesConfig[attribute] ||
             algoliaProductConfig.attributeConfig_v2[attribute] ||
-            {};
+            jobHelper.getCustomAttributeConfig(attribute);
 
         if (attributeConfig.variantAttribute) {
             variantAttributes.push(attribute);

--- a/test/mocks/dw/catalog/Variant.js
+++ b/test/mocks/dw/catalog/Variant.js
@@ -24,6 +24,7 @@ class Variant extends MasterProduct {
                     }
                 }
             },
+            displaySize: '14cm',
             refinementSize: '4',
             get algoliaTest() {
                 switch (request.getLocale()) {

--- a/test/mocks/dw/catalog/Variant.js
+++ b/test/mocks/dw/catalog/Variant.js
@@ -25,6 +25,17 @@ class Variant extends MasterProduct {
                 }
             },
             refinementSize: '4',
+            get algoliaTest() {
+                switch (request.getLocale()) {
+                    case 'fr':
+                        return 'fr locale';
+                    case 'default':
+                        return 'default locale';
+                    case 'en':
+                    default:
+                        return '';
+                }
+            }
         };
 
         this.prices = {

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -74,7 +74,7 @@ jest.mock('*/cartridge/scripts/algolia/customization/productModelCustomizer', ()
 const AlgoliaLocalizedProduct = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct');
 const algoliaProductConfig = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig')
 const attributes = algoliaProductConfig.defaultAttributes_v2.concat(['url', 'UPC', 'searchable', 'variant', 'color', 'refinementColor', 'size', 'refinementSize', 'brand', 'online', 'pageDescription', 'pageKeywords',
-    'pageTitle', 'short_description', 'name', 'long_description', 'image_groups']);
+    'pageTitle', 'short_description', 'name', 'long_description', 'image_groups', 'custom.algoliaTest']);
 
 describe('algoliaLocalizedProduct', function () {
     test('default locale', function () {
@@ -168,6 +168,8 @@ describe('algoliaLocalizedProduct', function () {
             refinementColor: 'Pink',
             size: '4',
             refinementSize: '4',
+            'custom.algoliaTest': 'default locale'
+
         };
         expect(new AlgoliaLocalizedProduct({ product: product, locale: 'default', attributeList: attributes })).toEqual(algoliaProductModel);
         // Tags are added in case of fullRecordUpdate
@@ -268,6 +270,7 @@ describe('algoliaLocalizedProduct', function () {
             refinementColor: 'Rose',
             size: '4',
             refinementSize: '4',
+            'custom.algoliaTest': 'fr locale'
         };
         expect(new AlgoliaLocalizedProduct({ product: product, locale: 'fr', attributeList: attributes })).toEqual(algoliaProductModel);
         // Tags are added in case of fullRecordUpdate

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -168,8 +168,9 @@ describe('algoliaLocalizedProduct', function () {
             refinementColor: 'Pink',
             size: '4',
             refinementSize: '4',
-            'custom.algoliaTest': 'default locale'
-
+            custom: {
+                algoliaTest: 'default locale'
+            }
         };
         expect(new AlgoliaLocalizedProduct({ product: product, locale: 'default', attributeList: attributes })).toEqual(algoliaProductModel);
         // Tags are added in case of fullRecordUpdate
@@ -270,7 +271,9 @@ describe('algoliaLocalizedProduct', function () {
             refinementColor: 'Rose',
             size: '4',
             refinementSize: '4',
-            'custom.algoliaTest': 'fr locale'
+            custom: {
+                algoliaTest: 'fr locale'
+            }
         };
         expect(new AlgoliaLocalizedProduct({ product: product, locale: 'fr', attributeList: attributes })).toEqual(algoliaProductModel);
         // Tags are added in case of fullRecordUpdate


### PR DESCRIPTION
### What's New
- feat: Add logic to handle custom and activeData values without any code changes with some default values. We can still use Extension mechanism for customization
- Added grouping mechanism for nested objects


Unit tests are extended

### How to test :test_tube: 
- Create a new localized custom attribute in your sandbox (I created in 003 is named `algoliaTest`, and feel free to use it)
- Add it in indexable attributes like custom.algoliaTest
- See it in your index
- You can also change some locale name and try to override and observe different results

