### PR TITLE
feat: configurable waittask timeout

### DIFF
--- a/cartridges/int_algolia/algoliaconfig.json
+++ b/cartridges/int_algolia/algoliaconfig.json
@@ -1,3 +1,4 @@
 {
-  "version": "24.4.0"
+  "version": "24.4.0",
+  "waitTaskTimeout": 1800000
 }

--- a/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
@@ -3,6 +3,7 @@
  *  https://www.algolia.com/doc/rest-api/search/#objects-endpoints
  **/
 
+const waitTaskTimeout = require('*/algoliaconfig').waitTaskTimeout;
 const algoliaIndexingService = require('*/cartridge/scripts/services/algoliaIndexingService');
 const retryableCall = require('*/cartridge/scripts/algolia/helper/retryStrategy').retryableCall;
 const logger = require('*/cartridge/scripts/algolia/helper/jobHelper').getAlgoliaLogger();
@@ -212,7 +213,7 @@ function moveIndex(indexNameSrc, indexNameDest) {
  */
 function waitTask(indexName, taskID) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
-    var maxWait = 10 * 60 * 1000;
+    var maxWait = waitTaskTimeout || 10 * 60 * 1000;
     var start = Date.now();
     var nbRequestsSent = 0;
 


### PR DESCRIPTION
We've increased the total job steps timeouts in #181, but some individual tasks can take more than 10 minutes to complete.

This PR makes the `waitTask` timeout configurable and sets the default to 30 min.