### PR TITLE
chore: rename Algolia_Enable description and move it below

### DIFF
--- a/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
+++ b/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
@@ -44,18 +44,6 @@
                     </td>
                 </tr>
 
-                <iscomment> Algolia_Enable </iscomment>
-                <tr>
-                    <td class="table_detail w s" colspan="1">
-                        <isprint value="${Resource.msg('algolia.label.preference.enable', 'algolia', null)}" encoding="jshtml" />
-                        <i class="fa fa-info-circle dw-nc-text-info info-hover"></i>
-                        <div class="tooltip">${Resource.msg('algolia.label.preference.enable.help', 'algolia', null)}</div>
-                    </td>
-                    <td class="table_detail w e s">
-                        <input type="checkbox" ${pdict.algoliaData.getPreference('Enable') ? "checked": ""} id="Enable" name="Enable" />
-                    </td>
-                </tr>
-
                 <iscomment> Algolia_ApplicationID </iscomment>
                 <tr>
                     <td class="table_detail w s" colspan="1">
@@ -158,6 +146,18 @@
                     </td>
                     <td class="table_detail w e s">
                         <input type="text" value="${pdict.algoliaData.getSetOfStrings('LocalesForIndexing') ? pdict.algoliaData.getSetOfStrings('LocalesForIndexing') : ''}" id="LocalesForIndexing" name="LocalesForIndexing" placeholder="${Resource.msg('algolia.label.util.optional', 'algolia', null)}"/>
+                    </td>
+                </tr>
+
+                <iscomment> Algolia_Enable </iscomment>
+                <tr>
+                    <td class="table_detail w s" colspan="1">
+                        <isprint value="${Resource.msg('algolia.label.preference.enable', 'algolia', null)}" encoding="jshtml" />
+                        <i class="fa fa-info-circle dw-nc-text-info info-hover"></i>
+                        <div class="tooltip">${Resource.msg('algolia.label.preference.enable.help', 'algolia', null)}</div>
+                    </td>
+                    <td class="table_detail w e s">
+                        <input type="checkbox" ${pdict.algoliaData.getPreference('Enable') ? "checked": ""} id="Enable" name="Enable" onclick="updateStorefrontCheckboxes();" />
                     </td>
                 </tr>
 
@@ -369,5 +369,16 @@
         <isinclude template="algoliabm/dashboard/productInventoryLog" />
         <isinclude template="algoliabm/dashboard/categoryLog" />
     </isloop>
+
+    <script>
+        function updateStorefrontCheckboxes() {
+            const storefrontEnabled = document.getElementById("Enable").checked;
+            document.getElementById("EnableInsights").disabled = !storefrontEnabled;
+            document.getElementById("EnableSSR").disabled = !storefrontEnabled;
+            document.getElementById("EnableContentSearch").disabled = !storefrontEnabled;
+            document.getElementById("EnableRecommend").disabled = !storefrontEnabled;
+        }
+        updateStorefrontCheckboxes();
+    </script>
 
 </isdecorate>

--- a/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
+++ b/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
@@ -6,7 +6,7 @@ algolia.label.dashboard=Algolia dashboard
 # site preferences table
 algolia.label.enable=Enable
 algolia.label.preference.name=Preference Name
-algolia.label.preference.enable=Enable Algolia
+algolia.label.preference.enable=Enable Algolia frontend cartridge
 algolia.label.preference.applicationid=Application ID
 algolia.label.preference.searchkey=Search API key
 algolia.label.preference.adminkey=Admin API key
@@ -28,7 +28,7 @@ algolia.label.util.required=*
 algolia.label.util.version=Cartridge Version:
 
 # Preferences Info
-algolia.label.preference.enable.help=Enable or disable Algolia on your Storefront.
+algolia.label.preference.enable.help=Enable the SFRA or SiteGenesis cartridge on your Storefront.
 algolia.label.preference.applicationid.help=The Application ID is the unique identifier of your Algolia application. It is available in the API Keys section of your Algolia Dashboard.
 algolia.label.preference.searchkey.help=The Search API key is used to perform search queries. It is available in the API Keys section of your Algolia Dashboard.
 algolia.label.preference.adminkey.help=The Admin API key is used to perform indexing operations. It is available in the API Keys section of your Algolia Dashboard.

--- a/metadata/algolia/meta/system-objecttype-extensions.xml
+++ b/metadata/algolia/meta/system-objecttype-extensions.xml
@@ -102,14 +102,6 @@
     <type-extension type-id="SitePreferences">
         <custom-attribute-definitions>
 
-            <attribute-definition attribute-id="Algolia_Enable">
-                <display-name xml:lang="x-default">Enable Algolia</display-name>
-                <description xml:lang="x-default">Enable/disable all Algolia</description>
-                <type>boolean</type>
-                <mandatory-flag>true</mandatory-flag>
-                <externally-managed-flag>false</externally-managed-flag>
-            </attribute-definition>
-
             <attribute-definition attribute-id="Algolia_ApplicationID">
                 <display-name xml:lang="x-default">Application ID</display-name>
                 <description xml:lang="x-default">This is your unique application identifier. If you haven't already, please signup to Algolia and create an Algolia application on the Algolia Dashboard.</description>
@@ -188,6 +180,14 @@ Setting this preference replaces the first two segments, the final index name be
                 <description xml:lang="x-default">List of locales that will be used by the indexing jobs</description>
                 <type>set-of-string</type>
                 <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+            </attribute-definition>
+
+            <attribute-definition attribute-id="Algolia_Enable">
+                <display-name xml:lang="x-default">Enable Algolia frontend cartridge</display-name>
+                <description xml:lang="x-default">Enable the SFRA or SiteGenesis cartridge on your Storefront</description>
+                <type>boolean</type>
+                <mandatory-flag>true</mandatory-flag>
                 <externally-managed-flag>false</externally-managed-flag>
             </attribute-definition>
 


### PR DESCRIPTION
Since 23.5.0, the `Algolia_Enable` setting is only used by the Storefront.

This PR renames its label and description and move it below, next to all the Storefront checkboxes.

Also, other checkboxes that enable Storefront features are now disabled when `Algolia_Enable` is not checked, to make it clear that they are linked to the Storefront.