### PR TITLE
feat: default attribute config for any level

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/objectHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/objectHelper.js
@@ -14,6 +14,9 @@ var AlgoliaUtils = require('*/cartridge/scripts/algolia/lib/utils');
  * @returns {string|boolean|number|null} - value
  */
 function getAttributeValue(extensibleObject, attributeName, escapeEmoji) {
+    if (!extensibleObject) {
+        return null;
+    }
     var properties = attributeName.split('.');
     var result = properties.reduce(function (previousValue, currentProperty) {
         if (previousValue === null || !(currentProperty in previousValue)) {
@@ -30,6 +33,25 @@ function getAttributeValue(extensibleObject, attributeName, escapeEmoji) {
     }, extensibleObject);
 
     return result;
+}
+
+/**
+ * Set a value to an object attribute.
+ * If the attributeName is a path, the function builds the intermediate objects.
+ * @param {Object} obj - JavaScript object
+ * @param {string} attributeName - object attribute name or path
+ * @param {any} attributeValue - value to set
+ */
+function setAttributeValue(obj, attributeName, attributeValue) {
+    const attributeNameArr = attributeName.split('.');
+    attributeNameArr.reduce(function (res, currentValue, index) {
+        if (index === attributeNameArr.length - 1) {
+            res[currentValue] = attributeValue;
+        } else if (!res[currentValue]) {
+            res[currentValue] = {};
+        }
+        return res[currentValue];
+    }, obj);
 }
 
 
@@ -52,4 +74,5 @@ function safelyGetCustomAttribute(customAttributes, caKey) {
 }
 
 module.exports.getAttributeValue = getAttributeValue;
+module.exports.setAttributeValue = setAttributeValue;
 module.exports.safelyGetCustomAttribute = safelyGetCustomAttribute;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -361,20 +361,9 @@ function algoliaLocalizedProduct(parameters) {
         for (var i = 0; i < attributeList.length; i += 1) {
             var attributeName = attributeList[i];
 
-            var attributeNameArr = attributeName.split('.');
-            var parentAttribute = null;
-            var subAttribute = null;
-            if (attributeNameArr.length > 1) {
-                parentAttribute = attributeNameArr[0];
-                subAttribute = attributeNameArr[1];
-            }
-
-            if (baseModel && baseModel[attributeName]) {
-                this[attributeName] = baseModel[attributeName];
-            } else if (baseModel && parentAttribute && subAttribute && baseModel[parentAttribute] && baseModel[parentAttribute][subAttribute]) {
-                var tempObj = this[parentAttribute] || {};
-                tempObj[subAttribute] = baseModel[parentAttribute][subAttribute];
-                this[parentAttribute] = tempObj;
+            var baseAttributeValue = ObjectHelper.getAttributeValue(baseModel, attributeName);
+            if (baseAttributeValue) {
+                ObjectHelper.setAttributeValue(this, attributeName, baseAttributeValue);
             } else if (extendedProductAttributesConfig[attributeName]) {
                 var attributeConfig = extendedProductAttributesConfig[attributeName];
                 if (typeof attributeConfig.attribute === 'function') {
@@ -391,14 +380,11 @@ function algoliaLocalizedProduct(parameters) {
                     config = jobHelper.getDefaultAttributeConfig(attributeName);
                 }
 
-                if (attributeNameArr.length > 1) {
-                    if (!this[parentAttribute]) {
-                        this[parentAttribute] = {};
-                    }
-                    this[parentAttribute][subAttribute] = ObjectHelper.getAttributeValue(product, config.attribute);
-                } else {
-                    this[attributeName] = ObjectHelper.getAttributeValue(product, config.attribute);
-                }
+                ObjectHelper.setAttributeValue(
+                    this,
+                    attributeName,
+                    ObjectHelper.getAttributeValue(product, config.attribute)
+                );
             }
         }
         if (parameters.fullRecordUpdate) {

--- a/test/mocks/dw/catalog/Variant.js
+++ b/test/mocks/dw/catalog/Variant.js
@@ -36,7 +36,10 @@ class Variant extends MasterProduct {
                     default:
                         return '';
                 }
-            }
+            },
+            deeply: {
+                nested: 'nestedValue',
+            },
         };
 
         this.prices = {

--- a/test/unit/int_algolia/scripts/algolia/helper/objectHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/objectHelper.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { getAttributeValue, safelyGetCustomAttribute } = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/objectHelper');
+const { getAttributeValue, setAttributeValue, safelyGetCustomAttribute } = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/objectHelper');
 
 describe('getAttributeValue', () => {
     test('should return correct value for a simple attribute name', () => {
@@ -15,6 +15,13 @@ describe('getAttributeValue', () => {
         expect(getAttributeValue(extensibleObject, 'nested.attribute')).toBe('nestedValue');
     });
 
+    test('should return correct value for a deeply nested attribute name', () => {
+        const extensibleObject = {
+            deeply: { nested: { attribute: 'nestedValue' } }
+        };
+        expect(getAttributeValue(extensibleObject, 'deeply.nested.attribute')).toBe('nestedValue');
+    });
+
     test('should return null for non-existing attribute', () => {
         const extensibleObject = { someAttribute: 'value' };
         expect(getAttributeValue(extensibleObject, 'nonExisting')).toBeNull();
@@ -25,6 +32,45 @@ describe('getAttributeValue', () => {
         expect(getAttributeValue(object1, 'japaneseAttribute')).toBe('春 - ルック');
         const object2 = { emojiAttribute: 'Hi 🐣' };
         expect(getAttributeValue(object2, 'emojiAttribute')).toBe('Hi 🐣');
+    });
+});
+
+describe('setAttributeValue', () => {
+    test('should set a simple attribute name', () => {
+        const res = {};
+        setAttributeValue(res, 'simpleAttribute', 'value');
+        expect(res).toEqual({ simpleAttribute: 'value' });
+    });
+
+    test('should set a nested attribute name', () => {
+        const res = {};
+        setAttributeValue(res, 'nested.attribute', 'nestedValue');
+        expect(res).toEqual({
+            nested: { attribute: 'nestedValue' }
+        });
+    });
+
+    test('should work for any level of nesting', () => {
+        const res = {};
+        setAttributeValue(res, 'deeply.nested.attribute', 'nestedValue');
+        expect(res).toEqual({
+            deeply: {
+                nested: {
+                    attribute: 'nestedValue'
+                }
+            }
+        });
+    });
+
+    test('should set a second nested attribute name', () => {
+        const res = { nested: { firstAttribute: 'nestedValue1' } };
+        setAttributeValue(res, 'nested.secondAttribute', 'nestedValue2');
+        expect(res).toEqual({
+            nested: {
+                firstAttribute: 'nestedValue1',
+                secondAttribute: 'nestedValue2'
+            }
+        });
     });
 });
 

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedContent.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedContent.test.js
@@ -12,10 +12,6 @@ jest.mock('*/cartridge/scripts/algolia/lib/pageDesignerHelper', () => {
     return jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/pageDesignerHelper');
 }, {virtual: true});
 
-jest.mock('*/cartridge/scripts/algolia/helper/objectHelper', () => {
-    return jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/objectHelper');
-}, {virtual: true});
-
 jest.mock('*/cartridge/scripts/algolia/lib/algoliaContentConfig', () => {
     return jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaContentConfig');
 }, {virtual: true});

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -57,13 +57,6 @@ jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => {
 jest.mock('*/cartridge/scripts/algolia/lib/utils', () => {
     return jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/utils');
 }, {virtual: true});
-jest.mock('*/cartridge/scripts/algolia/helper/objectHelper', () => {
-    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/objectHelper');
-    return {
-        getAttributeValue: originalModule.getAttributeValue,
-        safelyGetCustomAttribute: originalModule.safelyGetCustomAttribute,
-    }
-}, {virtual: true});
 jest.mock('*/cartridge/scripts/algolia/lib/algoliaProductConfig', () => {
     return jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig');
 }, {virtual: true});
@@ -374,10 +367,39 @@ describe('algoliaLocalizedProduct default custom attribute logic', function () {
             objectID: '701644031206M',
             custom: {
                 algoliaTest: 'default locale',
-                displaySize: '14cm'
+                displaySize: '14cm',
+                deeply: { nested: 'nestedValue' },
             }
         };
-        expect(new AlgoliaLocalizedProduct({ product: product, locale: 'default', attributeList: ['custom.algoliaTest', 'custom.displaySize'] })).toEqual(expected);
+        expect(new AlgoliaLocalizedProduct({
+            product: product,
+            locale: 'default',
+            attributeList: ['custom.algoliaTest', 'custom.displaySize', 'custom.deeply.nested']
+        })).toEqual(expected);
+    });
+
+    test('default attribute configuration logic with baseModel', function () {
+        const product = new ProductMock();
+        const baseModel = {
+            custom: {
+                algoliaTest: 'value from base model',
+                deeply: {
+                    nested: 'value from base model',
+                }
+            }
+        }
+        const expected = {
+            objectID: '701644031206M',
+            custom: {
+                algoliaTest: 'value from base model',
+                deeply: { nested: 'value from base model' },
+            }
+        };
+        expect(new AlgoliaLocalizedProduct({
+            product: product,
+            baseModel: baseModel,
+            attributeList: ['custom.algoliaTest', 'custom.deeply.nested'],
+        })).toEqual(expected);
     });
 
     test('algoliaLocalizedProduct default custom attribute logic for fr locale', function () {
@@ -399,7 +421,7 @@ describe('algoliaLocalizedProduct default custom attribute logic', function () {
             }
         }
 
-        // Because default logic is non localized we are expecting it should 
+        // Because default config is localized:false, we are expecting to have the default locale in the record
         expect(new AlgoliaLocalizedProduct({ product: product, locale: 'fr', attributeList: ['custom.algoliaTest', 'custom.displaySize', 'name'], baseModel: baseModel})).toEqual(expected);
     });
 });
@@ -456,4 +478,3 @@ describe('algoliaLocalizedProduct overriding custom attributes', function () {
         expect(new AlgoliaLocalizedProductModel({ product: product, locale: 'fr', attributeList: ['algoliaTest', 'custom.displaySize'], baseModel: baseModel})).toEqual(expectedProductModel);
     });
 });
-

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
@@ -18,14 +18,6 @@ jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
     }
 }, {virtual: true});
 
-jest.mock('*/cartridge/scripts/algolia/helper/objectHelper', () => {
-    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/objectHelper');
-    return {
-        getAttributeValue: originalModule.getAttributeValue,
-        safelyGetCustomAttribute: originalModule.safelyGetCustomAttribute,
-    }
-}, {virtual: true});
-
 let mockLocalesForIndexing;
 jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => {
     const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData');

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -6,13 +6,6 @@ global.empty = GlobalMock.empty;
 global.request = new GlobalMock.RequestMock();
 
 jest.mock('*/cartridge/scripts/algolia/helper/logHelper', () => {}, {virtual: true});
-jest.mock('*/cartridge/scripts/algolia/helper/objectHelper', () => {
-    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/objectHelper');
-    return {
-        getAttributeValue: originalModule.getAttributeValue,
-        safelyGetCustomAttribute: originalModule.safelyGetCustomAttribute,
-    }
-}, {virtual: true});
 const mockDeleteTemporaryIndices = jest.fn();
 const mockCopySettingsFromProdIndices = jest.fn();
 const mockMoveTemporaryIndices = jest.fn();


### PR DESCRIPTION
This PR implements the improvement suggested here: https://github.com/algolia/algoliasearch-sfcc-b2c/pull/182#discussion_r1711608099:

- Introduce a `objectHelper.setAttributeValue()` function, that permits to set a nested attribute to an object
- Use those generic `ObjectHelper.getAttributeValue` / `ObjectHelper.setAttributeValue` in the model instead of manually manipulating `parentAttribute`/`subAttribute`

This permits to simplify the logic and support any level of nesting.

### Tests

Unit:
- Added tests for the `setAttributeValue()` method
- Added tests for the `algoliaLocalizedProduct` model that use a deeply nested property (`custom.deeply.nested`)
- All existing tests are passing

(I've removed the multiple mocks of `*/cartridge/scripts/algolia/helper/objectHelper` as it's defined in `jest.setup.js`)

Manual:
- Add `availabilityModel.inventoryRecord.ATS.value` to the Additional Product Attributes
- Indexed records contain the following attribute:
  ```json
  {
    "availabilityModel": {
      "inventoryRecord": {
        "ATS": {
          "value": 100
        }
      }
    }
  }
  ```

---
SFCC-319