### PR TITLE
fix: disable some no-redeclare errors

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/deltaIterator.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/deltaIterator.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var File = require('dw/io/File');
-var FileReader = require('dw/io/FileReader');
+var File = require('dw/io/File'); // eslint-disable-line no-redeclare
+var FileReader = require('dw/io/FileReader'); // eslint-disable-line no-redeclare
 var XMLStreamReader = require('dw/io/XMLStreamReader');
 var XMLStreamConstants = require('dw/io/XMLStreamConstants');
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/fileReadIterator.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/fileReadIterator.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var File = require('dw/io/File');
-var FileReader = require('dw/io/FileReader');
+var File = require('dw/io/File'); // eslint-disable-line no-redeclare
+var FileReader = require('dw/io/FileReader'); // eslint-disable-line no-redeclare
 var XMLStreamReader = require('dw/io/XMLStreamReader');
 
 var jobHelper = require('*/cartridge/scripts/algolia/helper/jobHelper');

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/logHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/logHelper.js
@@ -1,10 +1,10 @@
 'use strict';
 /** @deprecated */
 
-var File = require('dw/io/File');
+var File = require('dw/io/File'); // eslint-disable-line no-redeclare
 var FileWriter = require('dw/io/FileWriter');
 var XMLStreamWriter = require('dw/io/XMLIndentingStreamWriter');
-var FileReader = require('dw/io/FileReader');
+var FileReader = require('dw/io/FileReader'); // eslint-disable-line no-redeclare
 var XMLStreamReader = require('dw/io/XMLStreamReader');
 
 var jobHelper = require('*/cartridge/scripts/algolia/helper/jobHelper');

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaConstants.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaConstants.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var currentSiteID = require('dw/system/Site').getCurrent().getID();
-var File = require('dw/io/File');
+var File = require('dw/io/File'); // eslint-disable-line no-redeclare
 
 const ALGOLIA_FILES_FOLDER = File.IMPEX + '/src/Algolia/';
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -3,7 +3,7 @@
 var ArrayList = require('dw/util/ArrayList');
 var ProductMgr = require('dw/catalog/ProductMgr');
 var Site = require('dw/system/Site');
-var File = require('dw/io/File');
+var File = require('dw/io/File'); // eslint-disable-line no-redeclare
 var logger;
 
 // job step parameters


### PR DESCRIPTION
I didn't update the branch before merging #196 on develop and it caused some `no-redeclare` rules to trigger after merging.