### PR TITLE
fix: check the number of products processed

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -18,6 +18,7 @@ jest.mock('dw/catalog/ProductMgr', () => {
     return {
         queryAllSiteProducts: jest.fn().mockReturnValue({
             close: jest.fn(),
+            count: 4658,
         }),
         getProduct: jest.fn((id) => {
             const VariantMock = require('./test/mocks/dw/catalog/Variant');


### PR DESCRIPTION
We have observed cases were the algoliaProductIndex job didn't have any error but the products were not processed (`process` function never called).

In that case, we want to report an error, and in case of a `fullCatalogReindex`, avoid the temporary index to be moved.

### Changes

- report an error if `processedItems !== products.count`
- slight refactor to simplify the logic
- added unit test