### PR TITLE
Small accessibility imporvement that comes with SFRA v7

### DIFF
--- a/cartridges/int_algolia_sfra/cartridge/templates/default/algolia/search/searchResultsNoDecorator.isml
+++ b/cartridges/int_algolia_sfra/cartridge/templates/default/algolia/search/searchResultsNoDecorator.isml
@@ -38,7 +38,7 @@
                         </a>
                     </li>
                     <li class="nav-item" role="presentation">
-                        <a class="nav-link content-search" id="content-search-bar-button" aria-controls="content-search-results-pane" data-toggle="tab" role="tab" aria-selected="false" id="articles-tab">
+                        <a class="nav-link content-search" id="content-search-bar-button" aria-controls="content-search-results-pane" data-toggle="tab" role="tab" aria-selected="false" tabindex="0" id="articles-tab">
                             ${Resource.msg('tab.nav.search.artclesresults', 'search', null)}<span class="ai-nb-hits" id="ai-content-count"></span>
                         </a>
                     </li>


### PR DESCRIPTION
# What is Changed?
- [Minor improvement] Added tabindex="0" to the <a> element (id="articles-tab") to ensure it is keyboard-focusable and included in the natural tabbing order that came with SFRA v7