### PR TITLE
chore: use action-semantic-pull-request to validate PR title

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,14 @@ on:
   pull_request:
 
 jobs:
+  pr-checks:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
We use the Conventional Commits syntax in most other places as it forces us to use a meaningful title and make it easier to draft the release notes. Let's enforce it on our repo.

This PR adds a job to our CI workflow, that uses [action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request) to check the PR title.