### PR TITLE
feat: new categoryPageId attribute

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig.js
@@ -213,6 +213,9 @@ var attributeConfig_v2 = {
     categories: {
         localized: true
     },
+    categoryPageId: {
+        localized: true,
+    },
     color: {
         localized: true,
         variantAttribute: true,

--- a/test/mocks/dw/catalog/MasterProduct.js
+++ b/test/mocks/dw/catalog/MasterProduct.js
@@ -236,6 +236,7 @@ class Product {
                             return null;
                     }
                 },
+                online: true,
                 root: false,
                 parent: {
                     ID: 'newarrivals',
@@ -250,6 +251,7 @@ class Product {
                                 return null;
                         }
                     },
+                    online: true,
                     root: true,
                     parent: {
                         ID: 'root',

--- a/test/unit/int_algolia/scripts/algolia/helper/__snapshots__/jobHelper.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/helper/__snapshots__/jobHelper.test.js.snap
@@ -15,6 +15,10 @@ exports[`generateVariantRecords 1`] = `
             "id": "newarrivals-womens",
             "name": "Femmes",
           },
+          {
+            "id": "newarrivals",
+            "name": "Nouveaux arrivages",
+          },
         ],
         [
           {
@@ -108,6 +112,10 @@ exports[`generateVariantRecords 1`] = `
           {
             "id": "newarrivals-womens",
             "name": "Femmes",
+          },
+          {
+            "id": "newarrivals",
+            "name": "Nouveaux arrivages",
           },
         ],
         [

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -67,7 +67,7 @@ jest.mock('*/cartridge/scripts/algolia/customization/productModelCustomizer', ()
 const AlgoliaLocalizedProduct = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct');
 const algoliaProductConfig = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig')
 const attributes = algoliaProductConfig.defaultAttributes_v2.concat(['url', 'UPC', 'searchable', 'variant', 'color', 'refinementColor', 'size', 'refinementSize', 'brand', 'online', 'pageDescription', 'pageKeywords',
-    'pageTitle', 'short_description', 'name', 'long_description', 'image_groups', 'custom.algoliaTest']);
+    'pageTitle', 'short_description', 'name', 'long_description', 'image_groups', 'custom.algoliaTest', 'categoryPageId']);
 
 function setupMockConfig(customAttributes) {
     jest.resetModules();
@@ -101,6 +101,10 @@ describe('algoliaLocalizedProduct', function () {
                     {
                         id: 'newarrivals-womens',
                         name: 'Womens',
+                    },
+                    {
+                        id: 'newarrivals',
+                        name: 'New Arrivals',
                     }
                 ],
                 [
@@ -117,6 +121,13 @@ describe('algoliaLocalizedProduct', function () {
                         name: 'Womens',
                     }
                 ]
+            ],
+            categoryPageId: [
+                "newarrivals",
+                "newarrivals-womens",
+                "womens",
+                "womens-clothing",
+                "womens-clothing-bottoms",
             ],
             __primary_category: {
                 0: 'Womens',
@@ -204,6 +215,10 @@ describe('algoliaLocalizedProduct', function () {
                     {
                         id: 'newarrivals-womens',
                         name: 'Femmes',
+                    },
+                    {
+                        id: 'newarrivals',
+                        name: 'Nouveaux arrivages',
                     }
                 ],
                 [
@@ -220,6 +235,13 @@ describe('algoliaLocalizedProduct', function () {
                         name: 'Femmes',
                     }
                 ]
+            ],
+            categoryPageId: [
+                "newarrivals",
+                "newarrivals-womens",
+                "womens",
+                "womens-clothing",
+                "womens-clothing-bottoms",
             ],
             __primary_category: {
                 0: 'Femmes',

--- a/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductDeltaIndex.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductDeltaIndex.test.js.snap
@@ -21,6 +21,10 @@ exports[`process default 1`] = `
             "id": "newarrivals-womens",
             "name": "Womens",
           },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
+          },
         ],
         [
           {
@@ -118,6 +122,10 @@ exports[`process default 1`] = `
             "id": "newarrivals-womens",
             "name": "Femmes",
           },
+          {
+            "id": "newarrivals",
+            "name": "Nouveaux arrivages",
+          },
         ],
         [
           {
@@ -214,6 +222,10 @@ exports[`process default 1`] = `
           {
             "id": "newarrivals-womens",
             "name": "Womens",
+          },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
           },
         ],
         [
@@ -313,6 +325,10 @@ exports[`process master-level indexing 1`] = `
           {
             "id": "newarrivals-womens",
             "name": "Womens",
+          },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
           },
         ],
         [
@@ -470,6 +486,10 @@ exports[`process master-level indexing 1`] = `
             "id": "newarrivals-womens",
             "name": "Femmes",
           },
+          {
+            "id": "newarrivals",
+            "name": "Nouveaux arrivages",
+          },
         ],
         [
           {
@@ -625,6 +645,10 @@ exports[`process master-level indexing 1`] = `
           {
             "id": "newarrivals-womens",
             "name": "Womens",
+          },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
           },
         ],
         [

--- a/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductIndex.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductIndex.test.js.snap
@@ -19,6 +19,10 @@ exports[`process colorVariations 1`] = `
             "id": "newarrivals-womens",
             "name": "Womens",
           },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
+          },
         ],
         [
           {
@@ -157,6 +161,10 @@ exports[`process colorVariations 1`] = `
           {
             "id": "newarrivals-womens",
             "name": "Womens",
+          },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
           },
         ],
         [
@@ -297,6 +305,10 @@ exports[`process colorVariations 1`] = `
             "id": "newarrivals-womens",
             "name": "Femmes",
           },
+          {
+            "id": "newarrivals",
+            "name": "Nouveaux arrivages",
+          },
         ],
         [
           {
@@ -435,6 +447,10 @@ exports[`process colorVariations 1`] = `
           {
             "id": "newarrivals-womens",
             "name": "Femmes",
+          },
+          {
+            "id": "newarrivals",
+            "name": "Nouveaux arrivages",
           },
         ],
         [
@@ -575,6 +591,10 @@ exports[`process colorVariations 1`] = `
             "id": "newarrivals-womens",
             "name": "Womens",
           },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
+          },
         ],
         [
           {
@@ -713,6 +733,10 @@ exports[`process colorVariations 1`] = `
           {
             "id": "newarrivals-womens",
             "name": "Womens",
+          },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
           },
         ],
         [
@@ -857,6 +881,10 @@ exports[`process default 1`] = `
             "id": "newarrivals-womens",
             "name": "Womens",
           },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
+          },
         ],
         [
           {
@@ -951,6 +979,10 @@ exports[`process default 1`] = `
             "id": "newarrivals-womens",
             "name": "Femmes",
           },
+          {
+            "id": "newarrivals",
+            "name": "Nouveaux arrivages",
+          },
         ],
         [
           {
@@ -1044,6 +1076,10 @@ exports[`process default 1`] = `
           {
             "id": "newarrivals-womens",
             "name": "Womens",
+          },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
           },
         ],
         [
@@ -1147,6 +1183,10 @@ exports[`process fullCatalogReindex 1`] = `
             "id": "newarrivals-womens",
             "name": "Womens",
           },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
+          },
         ],
         [
           {
@@ -1244,6 +1284,10 @@ exports[`process fullCatalogReindex 1`] = `
             "id": "newarrivals-womens",
             "name": "Femmes",
           },
+          {
+            "id": "newarrivals",
+            "name": "Nouveaux arrivages",
+          },
         ],
         [
           {
@@ -1340,6 +1384,10 @@ exports[`process fullCatalogReindex 1`] = `
           {
             "id": "newarrivals-womens",
             "name": "Womens",
+          },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
           },
         ],
         [
@@ -1443,6 +1491,10 @@ exports[`process fullRecordUpdate 1`] = `
             "id": "newarrivals-womens",
             "name": "Womens",
           },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
+          },
         ],
         [
           {
@@ -1539,6 +1591,10 @@ exports[`process fullRecordUpdate 1`] = `
           {
             "id": "newarrivals-womens",
             "name": "Femmes",
+          },
+          {
+            "id": "newarrivals",
+            "name": "Nouveaux arrivages",
           },
         ],
         [
@@ -1637,6 +1693,10 @@ exports[`process fullRecordUpdate 1`] = `
             "id": "newarrivals-womens",
             "name": "Womens",
           },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
+          },
         ],
         [
           {
@@ -1733,6 +1793,10 @@ exports[`process master-level indexing 1`] = `
           {
             "id": "newarrivals-womens",
             "name": "Womens",
+          },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
           },
         ],
         [
@@ -1889,6 +1953,10 @@ exports[`process master-level indexing 1`] = `
             "id": "newarrivals-womens",
             "name": "Femmes",
           },
+          {
+            "id": "newarrivals",
+            "name": "Nouveaux arrivages",
+          },
         ],
         [
           {
@@ -2043,6 +2111,10 @@ exports[`process master-level indexing 1`] = `
           {
             "id": "newarrivals-womens",
             "name": "Womens",
+          },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
           },
         ],
         [
@@ -2206,6 +2278,10 @@ exports[`process partialRecordUpdate 1`] = `
             "id": "newarrivals-womens",
             "name": "Womens",
           },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
+          },
         ],
         [
           {
@@ -2300,6 +2376,10 @@ exports[`process partialRecordUpdate 1`] = `
             "id": "newarrivals-womens",
             "name": "Femmes",
           },
+          {
+            "id": "newarrivals",
+            "name": "Nouveaux arrivages",
+          },
         ],
         [
           {
@@ -2393,6 +2473,10 @@ exports[`process partialRecordUpdate 1`] = `
           {
             "id": "newarrivals-womens",
             "name": "Womens",
+          },
+          {
+            "id": "newarrivals",
+            "name": "New Arrivals",
           },
         ],
         [


### PR DESCRIPTION
To be compatible with Category Merchandising, we are introducing a new attribute: `categoryPageId`

It follows the official recommendations described in this doc:
https://www.algolia.com/doc/guides/solutions/ecommerce/browse/tutorials/category-pages/#add-a-category-identifying-attribute-to-each-record

The only difference is that instead of using localized paths ("Womens", "Womens > Clothing"), we will use the categories ids:

```
"categoryPageId": [
    "womens"
    "womens-clothing"
]
```

This permits to keep the same ids across all indices, while still being human readable.

## Changes

- new `categoryPageId`
- added test
- fixed mocks setup: `newarrivals` category was not marked `online` and was missing from the existing snapshots

---
SFCC-401