### PR TITLE
feat: newArrival attribute

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js
@@ -93,6 +93,32 @@ function createAlgoliaLocalizedCategoryObject(category) {
     return result;
 }
 
+var NEW_ARRIVALS_CATEGORY_ID = 'newarrivals';
+var specialValueHandlers = {
+    newArrivalsCategory: function(productModel) {
+        if (!empty(productModel.categories)) {
+            for (var i = 0; i < productModel.categories.length; i += 1) {
+                var rootCategoryId = productModel.categories[i][productModel.categories[i].length - 1].id;
+                if (rootCategoryId === NEW_ARRIVALS_CATEGORY_ID) {
+                    return createAlgoliaLocalizedCategoryObject(productModel.categories[i]);
+                }
+            }
+        }
+        return null;
+    },
+    newArrival: function(productModel) {
+        if (!empty(productModel.categories)) {
+            for (var i = 0; i < productModel.categories.length; i += 1) {
+                var rootCategoryId = productModel.categories[i][productModel.categories[i].length - 1].id;
+                if (rootCategoryId === NEW_ARRIVALS_CATEGORY_ID) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}
+
 /**
  * Customize a Localized Algolia Product.
  * Add extra properties to the product model.
@@ -100,22 +126,12 @@ function createAlgoliaLocalizedCategoryObject(category) {
  * @param {Array} algoliaAttributes - The attributes to index
  */
 function customizeLocalizedProductModel(productModel, algoliaAttributes) {
-    var CATEGORY_ATTRIBUTE = 'newArrivalsCategory';
-    var CATEGORY_ID = 'newarrivals';
-
-    if (algoliaAttributes.indexOf(CATEGORY_ATTRIBUTE) >= 0) {
-        productModel[CATEGORY_ATTRIBUTE] = null;
-
-        if (!empty(productModel.categories)) {
-            for (var i = 0; i < productModel.categories.length; i += 1) {
-                var rootCategoryId = productModel.categories[i][productModel.categories[i].length - 1].id;
-                if (rootCategoryId === CATEGORY_ID) {
-                    productModel[CATEGORY_ATTRIBUTE] = createAlgoliaLocalizedCategoryObject(productModel.categories[i]);
-                    break;
-                }
-            }
+    var specialAttributes = ['newArrival', 'newArrivalsCategory'];
+    specialAttributes.forEach(function(attributeName) {
+        if (algoliaAttributes.indexOf(attributeName) >= 0 && specialValueHandlers[attributeName]) {
+            productModel[attributeName] = specialValueHandlers[attributeName](productModel);
         }
-    }
+    })
 }
 
 module.exports = {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/customization/productModelCustomizer.js
@@ -98,8 +98,8 @@ var specialValueHandlers = {
     newArrivalsCategory: function(productModel) {
         if (!empty(productModel.categories)) {
             for (var i = 0; i < productModel.categories.length; i += 1) {
-                var rootCategoryId = productModel.categories[i][productModel.categories[i].length - 1].id;
-                if (rootCategoryId === NEW_ARRIVALS_CATEGORY_ID) {
+                var topLevelCategoryId = productModel.categories[i][productModel.categories[i].length - 1].id;
+                if (topLevelCategoryId === NEW_ARRIVALS_CATEGORY_ID) {
                     return createAlgoliaLocalizedCategoryObject(productModel.categories[i]);
                 }
             }
@@ -109,8 +109,8 @@ var specialValueHandlers = {
     newArrival: function(productModel) {
         if (!empty(productModel.categories)) {
             for (var i = 0; i < productModel.categories.length; i += 1) {
-                var rootCategoryId = productModel.categories[i][productModel.categories[i].length - 1].id;
-                if (rootCategoryId === NEW_ARRIVALS_CATEGORY_ID) {
+                var topLevelCategoryId = productModel.categories[i][productModel.categories[i].length - 1].id;
+                if (topLevelCategoryId === NEW_ARRIVALS_CATEGORY_ID) {
                     return true;
                 }
             }

--- a/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -138,6 +138,17 @@ function enableInstantSearch(config) {
                 panelTitle: algoliaData.strings.newArrivals
             }),
 
+            toggleRefinementWithPanel({
+                container: '#algolia-newarrival-placeholder',
+                attribute: 'newArrival',
+                templates: {
+                    labelText(data, { html }) {
+                        return html`<span> ${algoliaData.strings.newArrivals}</span>`;
+                    },
+                },
+                panelTitle: algoliaData.strings.newArrivals,
+            }),
+
             refinementListWithPanel({
                 container: '#algolia-brand-list-placeholder',
                 attribute: 'brand',
@@ -328,6 +339,15 @@ function enableInstantSearch(config) {
      */
     function refinementListWithPanel(options) {
         return withPanel(options.attribute, options.panelTitle)(instantsearch.widgets.refinementList)(options)
+    }
+
+    /**
+     * Builds a refinement toggle with the Panel widget
+     * @param {Object} options Options object
+     * @returns {Object} The Panel widget
+     */
+    function toggleRefinementWithPanel(options) {
+        return withPanel(options.attribute, options.panelTitle)(instantsearch.widgets.toggleRefinement)(options)
     }
 
     /**

--- a/cartridges/int_algolia_controllers/cartridge/templates/default/algolia/productsearchrefinebar.isml
+++ b/cartridges/int_algolia_controllers/cartridge/templates/default/algolia/productsearchrefinebar.isml
@@ -8,6 +8,7 @@
 	    <div class="refinements">
 	        <div id="algolia-sort-by-placeholder" class="col-6 col-sm-3 order-sm-1"></div>
             <div id="algolia-categories-list-placeholder"></div>
+            <div id="algolia-newarrival-placeholder"></div>
             <div id="algolia-newarrivals-list-placeholder"></div>
 	        <div id="algolia-brand-list-placeholder"></div>
 	        <div id="algolia-size-list-placeholder"></div>
@@ -16,4 +17,3 @@
 	        <div id="algolia-searchbox-placeholder" ></div>
 	    </div>
 	</div>
-

--- a/cartridges/int_algolia_sfra/cartridge/static/default/css/algolia/index.css
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/css/algolia/index.css
@@ -45,6 +45,16 @@
     padding: 0 1em;
 }
 
+.ais-ToggleRefinement-checkbox {
+    position: absolute;
+    opacity: 0;
+    height: 0;
+    width: 0;
+}
+.ais-ToggleRefinement-label {
+    cursor: pointer;
+}
+
 .auc-Recommend-item .col-12 {
     padding: 0;
 }

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -166,6 +166,22 @@ function enableInstantSearch(config) {
                 panelTitle: algoliaData.strings.newArrivals
             }),
 
+            toggleRefinementWithPanel({
+                container: '#algolia-newarrival-placeholder',
+                attribute: 'newArrival',
+                templates: {
+                    labelText(data, { html }) {
+                        return html`
+                            <a style="white-space: nowrap; ${data.isRefined ? 'font-weight: bold;' : ''}">
+                                <i class="fa ${data.isRefined ? 'fa-check-square' : 'fa-square-o'}"></i>
+                                <span> ${algoliaData.strings.newArrivals}</span>
+                            </a>
+                        `;
+                    },
+                },
+                panelTitle: algoliaData.strings.newArrivals
+            }),
+
             refinementListWithPanel({
                 container: '#algolia-brand-list-placeholder',
                 attribute: 'brand',
@@ -303,7 +319,7 @@ function enableInstantSearch(config) {
                                 </div>
                             </div>
                         `;
-                    }, 
+                    },
                 },
                 transformItems: function (items, { results }) {
                     displaySwatches = false;
@@ -557,6 +573,15 @@ function enableInstantSearch(config) {
     }
 
     /**
+     * Builds a refinement toggle with the Panel widget
+     * @param {Object} options Options object
+     * @returns {Object} The Panel widget
+     */
+    function toggleRefinementWithPanel(options) {
+        return withPanel(options.attribute, options.panelTitle)(instantsearch.widgets.toggleRefinement)(options)
+    }
+
+    /**
      * Builds a range input with the Panel widget
      * @param {Object} options Options object
      * @returns {Object} The Panel widget
@@ -663,7 +688,7 @@ function fetchPromoPrices(productIDs) {
 
     // Filter out already fetched product IDs
     const unfetchedProductIDs = productIDs.filter(id => !fetchedPrices.has(id));
-    
+
     if (unfetchedProductIDs.length === 0) return Promise.resolve();
 
     return $.ajax({

--- a/cartridges/int_algolia_sfra/cartridge/templates/default/algolia/search/searchResultsNoDecorator.isml
+++ b/cartridges/int_algolia_sfra/cartridge/templates/default/algolia/search/searchResultsNoDecorator.isml
@@ -67,6 +67,7 @@
 
                         <div class="refinements">
                             <div id="algolia-categories-list-placeholder"></div>
+                            <div id="algolia-newarrival-placeholder"></div>
                             <div id="algolia-newarrivals-list-placeholder"></div>
                             <div id="algolia-brand-list-placeholder"></div>
                             <div id="algolia-size-list-placeholder"></div>

--- a/test/unit/int_algolia/scripts/algolia/customization/productModelCustomizer.test.js
+++ b/test/unit/int_algolia/scripts/algolia/customization/productModelCustomizer.test.js
@@ -75,4 +75,10 @@ describe('customizeLocalizedProductModel (jobs v2)', () => {
         productModelCustomizer.customizeLocalizedProductModel(product, []);
         expect(product).not.toHaveProperty('newArrivalsCategory');
     });
+
+    test('newArrival', () => {
+        productModelCustomizer.customizeLocalizedProductModel(product, ['newArrival']);
+        expect(product).toHaveProperty('newArrival');
+        expect(product.newArrival).toBe(true);
+    });
 });


### PR DESCRIPTION
Today, we have a `newArrivalsCategory` attribute which contains hierarchical facets.
But displaying two hierarchical facets on the UI can create confusion and duplicates the information:

![image](https://github.com/user-attachments/assets/dd5f267c-81d5-40c3-acb7-8a19bf27cf7d)

SFRA default UI uses a "New Arrival" checkbox.
This PR adds a `newArrival` boolean attribute, set to true when a product belongs to the `newarrivals` category, and a [`toggleRefinement`](https://www.algolia.com/doc/api-reference/widgets/toggle-refinement/js/) widget that permits to show a simple refinement checkbox similar to SFRA:

![image](https://github.com/user-attachments/assets/a8065ff2-212d-4789-8ea7-fda272f9696d)

### Changes

- Refactor the `productModelCustomizer` to also handle the `newArrival` attribute
- Add a `toggleRefinement` widget on the UI, and the CSS to have the same look and feel than SFRA
  - Also added to SiteGenesis but with a simpler `labelText` and no custom CSS

### How to test

- Add `newArrival` to the Additional Product Attributes and run the product index job
- Check the search results page

---
SFCC-406
SFCC-407