### PR TITLE
fix(frontend): hidding logic wasn't working for hierachicalFacets panel

### DIFF
--- a/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_controllers/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -305,13 +305,6 @@ function enableInstantSearch(config) {
 
     search.start();
 
-    search.on('render', function () {
-        var emptyFacetSelector = '.ais-HierarchicalMenu--noRefinement';
-        $(emptyFacetSelector).each(function () {
-            $(this).parents().eq(2).hide();
-        });
-    });
-
     /**
      * Generates a menu with the Panel widget
      * @param {Object} options Options object
@@ -349,8 +342,8 @@ function enableInstantSearch(config) {
         return instantsearch.widgets.panel({
             hidden: function(options) {
                 var facets = [].concat(options.results.disjunctiveFacets, options.results.hierarchicalFacets)
-                var facet = facets.find(function(facet) { return facet.name === attribute }); // eslint-disable-line no-shadow
-                var facetExists = !!facet;
+                var attributeFacet = facets.find(function(facet) { return facet.name === attribute });
+                var facetExists = attributeFacet && attributeFacet.data;
                 return !facetExists; // hides panel if not facets selectable
             },
             templates: {

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -303,7 +303,7 @@ function enableInstantSearch(config) {
                                 </div>
                             </div>
                         `;
-                    }, 
+                    },
                 },
                 transformItems: function (items, { results }) {
                     displaySwatches = false;
@@ -531,11 +531,6 @@ function enableInstantSearch(config) {
                 updateAllProductPrices();
             });
         }
-
-        var emptyFacetSelector = '.ais-HierarchicalMenu--noRefinement';
-        $(emptyFacetSelector).each(function () {
-            $(this).parents().eq(2).hide();
-        });
     });
 
     /**
@@ -575,8 +570,8 @@ function enableInstantSearch(config) {
         return instantsearch.widgets.panel({
             hidden: function(options) {
                 var facets = [].concat(options.results.disjunctiveFacets, options.results.hierarchicalFacets)
-                var facet = facets.find(function(facet) { return facet.name === attribute }); // eslint-disable-line no-shadow
-                var facetExists = !!facet;
+                var attributeFacet = facets.find(function(facet) { return facet.name === attribute });
+                var facetExists = attributeFacet && attributeFacet.data;
                 return !facetExists; // hides panel if not facets selectable
             },
             templates: {
@@ -663,7 +658,7 @@ function fetchPromoPrices(productIDs) {
 
     // Filter out already fetched product IDs
     const unfetchedProductIDs = productIDs.filter(id => !fetchedPrices.has(id));
-    
+
     if (unfetchedProductIDs.length === 0) return Promise.resolve();
 
     return $.ajax({


### PR DESCRIPTION
InstantSearch panel permits to implement a `hidden` function to determine if the panel should be hidden ([doc](https://www.algolia.com/doc/api-reference/widgets/panel/js/#widget-param-hidden)).

It wasn't working for hierarchicalFacets, and a workaround had been done in  https://github.com/algolia/algoliasearch-sfcc-b2c/pull/146 to try to replicate the logic.
The problem is that when the panel is hidden by this hack, if the selected filters are reset, **it's not becoming visible anymore**.

### Changes

- fix the `hidden` function: the hierarchicalFacets are always present in `options.results.hierarchicalFacets`. But when there are no results matching, the `data` field is `null`. Checking the presence of `data` fixes the behaviour
- remove the buggy workaround

### How to test

- Index records with the `newArrivalsCategory` attribute
- Select a category without new arrivals: `Men > Accessories > Gloves`. The New Arrivals panel disappears
- Select a category with new arrivals: The panel reappears

---
SFCC-410