### PR TITLE
feat!: change default attributes

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var defaultAttributes = ['id', 'primary_category_id', 'in_stock', 'price', 'categories'];
-var defaultAttributes_v2 = ['name', 'primary_category_id', 'categories', 'in_stock', 'price', 'image_groups', 'url'];
+var defaultAttributes_v2 = ['name', 'categoryPageId', '__primary_category', 'in_stock', 'price', 'image_groups', 'url'];
 // Configurations for master-level indexing mode
 var defaultMasterAttributes_v2 = ['variants', 'defaultVariantID', 'colorVariations'];
 var defaultVariantAttributes_v2 = ['in_stock', 'price', 'color', 'size', 'url'];
@@ -214,6 +214,9 @@ var attributeConfig_v2 = {
         localized: true
     },
     categoryPageId: {
+        localized: false,
+    },
+    __primary_category: {
         localized: true,
     },
     color: {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -143,57 +143,6 @@ function getCategoryFlatTree(category) {
 }
 
 /**
- * Compute hierarchical facets from the 'categories' field:
- * If we have the following categories:
- * [
- *   [{ id: 'newarrivals-televisions', name: 'New TVs' } ],
- *   [
- *     { id: 'electronics-televisions-flatscreen', name: 'Flat Screen' },
- *     { id: 'electronics-televisions', name: 'Televisions' },
- *     { id: 'electronics', name: 'Electronics' }
- *   ]
- * ]
- * And the primary category is "electronics-televisions-flatscreen",
- * this method returns the following object:
- * {
- *   0: "Electronics"
- *   1: "Electronics > Televisions"
- *   2: "Electronics > Televisions > Flat Screen"
- * }
- * https://www.algolia.com/doc/guides/managing-results/refine-results/faceting/#hierarchical-facets
- * @param {Array} categories - array containing one array per assigned categories, representing the category hierarchy
- * @param {string} primaryCategoryId - the id primary category
- * @returns {Object} - the primary category's hierarchical facets
- */
-function computePrimaryCategoryHierarchicalFacets(categories, primaryCategoryId) {
-    var res = {};
-
-    // Find the hierarchy that contains the primary category
-    var primaryCategoryHierarchy;
-    for (let i = 0; i < categories.length && !primaryCategoryHierarchy; ++i) {
-        for (let j = 0; j < categories[i].length && !primaryCategoryHierarchy; ++j) {
-            if (categories[i][j].id === primaryCategoryId) {
-                primaryCategoryHierarchy = categories[i];
-            }
-        }
-    }
-    if (!primaryCategoryHierarchy) {
-        return res;
-    }
-
-    // Reverse the hierarchy to have the top category first, and keep only the name
-    var reverseHierarchyNames = [];
-    for (let i = 0; i < primaryCategoryHierarchy.length; ++i) {
-        reverseHierarchyNames.unshift(primaryCategoryHierarchy[i].name);
-    }
-
-    for (let i = 0; i < reverseHierarchyNames.length; ++i) {
-        res[i] = reverseHierarchyNames.slice(0, i + 1).join(' > ');
-    }
-    return res;
-}
-
-/**
  * Compute the hierarchical facets for a given category.
  * Return an array containing the hierarchical facets, ordered from top to bottom.
  * Note: if one of the parent category is 'offline', an empty array is returned.

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -564,12 +564,6 @@ function algoliaLocalizedProduct(parameters) {
                 );
             }
         }
-        if (parameters.fullRecordUpdate) {
-            this._tags = ['id:' + product.ID];
-        }
-        if (this.primary_category_id && this.categories) {
-            this['__primary_category'] = computePrimaryCategoryHierarchicalFacets(this.categories, this.primary_category_id);
-        }
         productModelCustomizer.customizeLocalizedProductModel(this, attributeList);
         if (extendedProductRecordCustomizer) {
             extendedProductRecordCustomizer(this);

--- a/test/unit/int_algolia/scripts/algolia/helper/__snapshots__/jobHelper.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/helper/__snapshots__/jobHelper.test.js.snap
@@ -9,31 +9,12 @@ exports[`generateVariantRecords 1`] = `
         "1": "Femmes > Vêtements",
         "2": "Femmes > Vêtements > Bas",
       },
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Femmes",
-          },
-          {
-            "id": "newarrivals",
-            "name": "Nouveaux arrivages",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bas",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Vêtements",
-          },
-          {
-            "id": "womens",
-            "name": "Femmes",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "colorVariations": [
         {
@@ -98,7 +79,6 @@ exports[`generateVariantRecords 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Product-Show?pid=701644031206M",
     },
     algoliaLocalizedProduct {
@@ -107,31 +87,12 @@ exports[`generateVariantRecords 1`] = `
         "1": "Femmes > Vêtements",
         "2": "Femmes > Vêtements > Bas",
       },
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Femmes",
-          },
-          {
-            "id": "newarrivals",
-            "name": "Nouveaux arrivages",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bas",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Vêtements",
-          },
-          {
-            "id": "womens",
-            "name": "Femmes",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "colorVariations": [
         {
@@ -196,7 +157,6 @@ exports[`generateVariantRecords 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Product-Show?pid=701644031213M",
     },
   ],

--- a/test/unit/int_algolia/scripts/algolia/helper/jobHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/jobHelper.test.js
@@ -24,7 +24,7 @@ test('generateVariantRecords', () => {
     const variantRecords = jobHelper.generateVariantRecords({
         masterProduct,
         locales: collectionHelper.createCollection(['fr']),
-        attributeList: ['name', 'primary_category_id', 'categories', 'in_stock', 'price', 'url', 'colorVariations'],
+        attributeList: ['name', 'categoryPageId', '__primary_category', 'in_stock', 'price', 'url', 'colorVariations'],
         nonLocalizedAttributes: [],
     });
     expect(variantRecords).toMatchSnapshot();

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -67,7 +67,7 @@ jest.mock('*/cartridge/scripts/algolia/customization/productModelCustomizer', ()
 const AlgoliaLocalizedProduct = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct');
 const algoliaProductConfig = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig')
 const attributes = algoliaProductConfig.defaultAttributes_v2.concat(['url', 'UPC', 'searchable', 'variant', 'color', 'refinementColor', 'size', 'refinementSize', 'brand', 'online', 'pageDescription', 'pageKeywords',
-    'pageTitle', 'short_description', 'name', 'long_description', 'image_groups', 'custom.algoliaTest', 'categoryPageId']);
+    'pageTitle', 'short_description', 'name', 'long_description', 'image_groups', 'custom.algoliaTest', 'categoryPageId', 'primary_category_id', 'categories', '_tags']);
 
 function setupMockConfig(customAttributes) {
     jest.resetModules();
@@ -190,14 +190,16 @@ describe('algoliaLocalizedProduct', function () {
             refinementSize: '4',
             custom: {
                 algoliaTest: 'default locale'
-            }
+            },
+            '_tags': ['id:701644031206M']
         };
-        expect(new AlgoliaLocalizedProduct({ product: product, locale: 'default', attributeList: attributes })).toEqual(algoliaProductModel);
-        // Tags are added in case of fullRecordUpdate
-        algoliaProductModel._tags= [
-            'id:701644031206M',
-        ];
-        expect(new AlgoliaLocalizedProduct({ product: product, locale: 'default', attributeList: attributes, fullRecordUpdate: true })).toEqual(algoliaProductModel);
+        expect(
+            new AlgoliaLocalizedProduct({
+                product: product,
+                locale: 'default',
+                attributeList: attributes,
+            })
+        ).toEqual(algoliaProductModel);
     });
 
     test('fr locale', function () {
@@ -304,14 +306,16 @@ describe('algoliaLocalizedProduct', function () {
             refinementSize: '4',
             custom: {
                 algoliaTest: 'fr locale'
-            }
+            },
+            '_tags': ['id:701644031206M']
         };
-        expect(new AlgoliaLocalizedProduct({ product: product, locale: 'fr', attributeList: attributes })).toEqual(algoliaProductModel);
-        // Tags are added in case of fullRecordUpdate
-        algoliaProductModel._tags= [
-            'id:701644031206M',
-        ];
-        expect(new AlgoliaLocalizedProduct({ product: product, locale: 'fr', attributeList: attributes, fullRecordUpdate: true })).toEqual(algoliaProductModel);
+        expect(
+            new AlgoliaLocalizedProduct({
+                product: product,
+                locale: 'fr',
+                attributeList: attributes,
+            })
+        ).toEqual(algoliaProductModel);
     });
 
     test('attributeListOverride', function () {

--- a/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductDeltaIndex.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductDeltaIndex.test.js.snap
@@ -11,35 +11,13 @@ exports[`process default 1`] = `
         "1": "Womens > Clothing",
         "2": "Womens > Clothing > Bottoms",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "color": "Hot Pink Combo",
       "image_groups": [
@@ -92,7 +70,6 @@ exports[`process default 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "refinementColor": "Pink",
       "refinementSize": "4",
       "searchable": true,
@@ -112,35 +89,13 @@ exports[`process default 1`] = `
         "1": "Femmes > Vêtements",
         "2": "Femmes > Vêtements > Bas",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Femmes",
-          },
-          {
-            "id": "newarrivals",
-            "name": "Nouveaux arrivages",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bas",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Vêtements",
-          },
-          {
-            "id": "womens",
-            "name": "Femmes",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "color": "Combo rose vif",
       "image_groups": [
@@ -193,7 +148,6 @@ exports[`process default 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "refinementColor": "Rose",
       "refinementSize": "4",
       "searchable": true,
@@ -213,35 +167,13 @@ exports[`process default 1`] = `
         "1": "Womens > Clothing",
         "2": "Womens > Clothing > Bottoms",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "color": "Hot Pink Combo",
       "image_groups": [
@@ -294,7 +226,6 @@ exports[`process default 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "refinementColor": "Pink",
       "refinementSize": "4",
       "searchable": true,
@@ -320,31 +251,12 @@ exports[`process master-level indexing 1`] = `
         "2": "Womens > Clothing > Bottoms",
       },
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "colorVariations": [
         {
@@ -448,7 +360,6 @@ exports[`process master-level indexing 1`] = `
       "pageDescription": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
       "pageKeywords": null,
       "pageTitle": "Floral Dress",
-      "primary_category_id": "womens-clothing-bottoms",
       "searchable": true,
       "short_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
       "variant": false,
@@ -480,31 +391,12 @@ exports[`process master-level indexing 1`] = `
         "2": "Femmes > Vêtements > Bas",
       },
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Femmes",
-          },
-          {
-            "id": "newarrivals",
-            "name": "Nouveaux arrivages",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bas",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Vêtements",
-          },
-          {
-            "id": "womens",
-            "name": "Femmes",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "colorVariations": [
         {
@@ -608,7 +500,6 @@ exports[`process master-level indexing 1`] = `
       "pageDescription": "Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.",
       "pageKeywords": null,
       "pageTitle": "Robe florale",
-      "primary_category_id": "womens-clothing-bottoms",
       "searchable": true,
       "short_description": "Sentez la brise chaude dans cette robe portefeuille à imprimé floral polyvalent. Complétez ce look avec une superbe paire de sandales à lanières pour une soirée en ville.",
       "variant": false,
@@ -640,31 +531,12 @@ exports[`process master-level indexing 1`] = `
         "2": "Womens > Clothing > Bottoms",
       },
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "colorVariations": [
         {
@@ -768,7 +640,6 @@ exports[`process master-level indexing 1`] = `
       "pageDescription": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
       "pageKeywords": null,
       "pageTitle": "Floral Dress",
-      "primary_category_id": "womens-clothing-bottoms",
       "searchable": true,
       "short_description": "Feel the warm breeze in this versatile printed floral wrap dress. Polish off this look with a great pair of strappy sandals for a night on the town.",
       "variant": false,

--- a/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductIndex.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/steps/__snapshots__/algoliaProductIndex.test.js.snap
@@ -10,34 +10,12 @@ exports[`process colorVariations 1`] = `
         "1": "Womens > Clothing",
         "2": "Womens > Clothing > Bottoms",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "colorVariations": [
         {
@@ -140,7 +118,6 @@ exports[`process colorVariations 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Product-Show?pid=701644031206M",
     },
     "indexName": "test_index___products__default.tmp",
@@ -153,34 +130,12 @@ exports[`process colorVariations 1`] = `
         "1": "Womens > Clothing",
         "2": "Womens > Clothing > Bottoms",
       },
-      "_tags": [
-        "id:701644031213M",
-      ],
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "colorVariations": [
         {
@@ -283,7 +238,6 @@ exports[`process colorVariations 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/default/Product-Show?pid=701644031213M",
     },
     "indexName": "test_index___products__default.tmp",
@@ -296,34 +250,12 @@ exports[`process colorVariations 1`] = `
         "1": "Femmes > Vêtements",
         "2": "Femmes > Vêtements > Bas",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Femmes",
-          },
-          {
-            "id": "newarrivals",
-            "name": "Nouveaux arrivages",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bas",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Vêtements",
-          },
-          {
-            "id": "womens",
-            "name": "Femmes",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "colorVariations": [
         {
@@ -426,7 +358,6 @@ exports[`process colorVariations 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Product-Show?pid=701644031206M",
     },
     "indexName": "test_index___products__fr.tmp",
@@ -439,34 +370,12 @@ exports[`process colorVariations 1`] = `
         "1": "Femmes > Vêtements",
         "2": "Femmes > Vêtements > Bas",
       },
-      "_tags": [
-        "id:701644031213M",
-      ],
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Femmes",
-          },
-          {
-            "id": "newarrivals",
-            "name": "Nouveaux arrivages",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bas",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Vêtements",
-          },
-          {
-            "id": "womens",
-            "name": "Femmes",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "colorVariations": [
         {
@@ -569,7 +478,6 @@ exports[`process colorVariations 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/fr/Product-Show?pid=701644031213M",
     },
     "indexName": "test_index___products__fr.tmp",
@@ -582,34 +490,12 @@ exports[`process colorVariations 1`] = `
         "1": "Womens > Clothing",
         "2": "Womens > Clothing > Bottoms",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "colorVariations": [
         {
@@ -712,7 +598,6 @@ exports[`process colorVariations 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/en/Product-Show?pid=701644031206M",
     },
     "indexName": "test_index___products__en.tmp",
@@ -725,34 +610,12 @@ exports[`process colorVariations 1`] = `
         "1": "Womens > Clothing",
         "2": "Womens > Clothing > Bottoms",
       },
-      "_tags": [
-        "id:701644031213M",
-      ],
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "colorVariations": [
         {
@@ -855,7 +718,6 @@ exports[`process colorVariations 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "url": "/on/demandware.store/Sites-Algolia_SFRA-Site/en/Product-Show?pid=701644031213M",
     },
     "indexName": "test_index___products__en.tmp",
@@ -875,31 +737,12 @@ exports[`process default 1`] = `
         "2": "Womens > Clothing > Bottoms",
       },
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "color": "Hot Pink Combo",
       "image_groups": [
@@ -952,7 +795,6 @@ exports[`process default 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "refinementColor": "Pink",
       "refinementSize": "4",
       "searchable": true,
@@ -973,31 +815,12 @@ exports[`process default 1`] = `
         "2": "Femmes > Vêtements > Bas",
       },
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Femmes",
-          },
-          {
-            "id": "newarrivals",
-            "name": "Nouveaux arrivages",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bas",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Vêtements",
-          },
-          {
-            "id": "womens",
-            "name": "Femmes",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "color": "Combo rose vif",
       "image_groups": [
@@ -1050,7 +873,6 @@ exports[`process default 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "refinementColor": "Rose",
       "refinementSize": "4",
       "searchable": true,
@@ -1071,31 +893,12 @@ exports[`process default 1`] = `
         "2": "Womens > Clothing > Bottoms",
       },
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "color": "Hot Pink Combo",
       "image_groups": [
@@ -1148,7 +951,6 @@ exports[`process default 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "refinementColor": "Pink",
       "refinementSize": "4",
       "searchable": true,
@@ -1173,35 +975,13 @@ exports[`process fullCatalogReindex 1`] = `
         "1": "Womens > Clothing",
         "2": "Womens > Clothing > Bottoms",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "color": "Hot Pink Combo",
       "image_groups": [
@@ -1254,7 +1034,6 @@ exports[`process fullCatalogReindex 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "refinementColor": "Pink",
       "refinementSize": "4",
       "searchable": true,
@@ -1274,35 +1053,13 @@ exports[`process fullCatalogReindex 1`] = `
         "1": "Femmes > Vêtements",
         "2": "Femmes > Vêtements > Bas",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Femmes",
-          },
-          {
-            "id": "newarrivals",
-            "name": "Nouveaux arrivages",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bas",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Vêtements",
-          },
-          {
-            "id": "womens",
-            "name": "Femmes",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "color": "Combo rose vif",
       "image_groups": [
@@ -1355,7 +1112,6 @@ exports[`process fullCatalogReindex 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "refinementColor": "Rose",
       "refinementSize": "4",
       "searchable": true,
@@ -1375,35 +1131,13 @@ exports[`process fullCatalogReindex 1`] = `
         "1": "Womens > Clothing",
         "2": "Womens > Clothing > Bottoms",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "color": "Hot Pink Combo",
       "image_groups": [
@@ -1456,7 +1190,6 @@ exports[`process fullCatalogReindex 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "refinementColor": "Pink",
       "refinementSize": "4",
       "searchable": true,
@@ -1481,35 +1214,13 @@ exports[`process fullRecordUpdate 1`] = `
         "1": "Womens > Clothing",
         "2": "Womens > Clothing > Bottoms",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "color": "Hot Pink Combo",
       "image_groups": [
@@ -1562,7 +1273,6 @@ exports[`process fullRecordUpdate 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "refinementColor": "Pink",
       "refinementSize": "4",
       "searchable": true,
@@ -1582,35 +1292,13 @@ exports[`process fullRecordUpdate 1`] = `
         "1": "Femmes > Vêtements",
         "2": "Femmes > Vêtements > Bas",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Femmes",
-          },
-          {
-            "id": "newarrivals",
-            "name": "Nouveaux arrivages",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bas",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Vêtements",
-          },
-          {
-            "id": "womens",
-            "name": "Femmes",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "color": "Combo rose vif",
       "image_groups": [
@@ -1663,7 +1351,6 @@ exports[`process fullRecordUpdate 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "refinementColor": "Rose",
       "refinementSize": "4",
       "searchable": true,
@@ -1683,35 +1370,13 @@ exports[`process fullRecordUpdate 1`] = `
         "1": "Womens > Clothing",
         "2": "Womens > Clothing > Bottoms",
       },
-      "_tags": [
-        "id:701644031206M",
-      ],
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "color": "Hot Pink Combo",
       "image_groups": [
@@ -1764,7 +1429,6 @@ exports[`process fullRecordUpdate 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "refinementColor": "Pink",
       "refinementSize": "4",
       "searchable": true,
@@ -1788,31 +1452,12 @@ exports[`process master-level indexing 1`] = `
         "1": "Womens > Clothing",
         "2": "Womens > Clothing > Bottoms",
       },
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "colorVariations": [
         {
@@ -1911,7 +1556,6 @@ exports[`process master-level indexing 1`] = `
       ],
       "name": "Floral Dress",
       "objectID": "25592581M",
-      "primary_category_id": "womens-clothing-bottoms",
       "variants": [
         algoliaLocalizedProduct {
           "color": "Hot Pink Combo",
@@ -1947,31 +1591,12 @@ exports[`process master-level indexing 1`] = `
         "1": "Femmes > Vêtements",
         "2": "Femmes > Vêtements > Bas",
       },
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Femmes",
-          },
-          {
-            "id": "newarrivals",
-            "name": "Nouveaux arrivages",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bas",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Vêtements",
-          },
-          {
-            "id": "womens",
-            "name": "Femmes",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "colorVariations": [
         {
@@ -2070,7 +1695,6 @@ exports[`process master-level indexing 1`] = `
       ],
       "name": "Robe florale",
       "objectID": "25592581M",
-      "primary_category_id": "womens-clothing-bottoms",
       "variants": [
         algoliaLocalizedProduct {
           "color": "Combo rose vif",
@@ -2106,31 +1730,12 @@ exports[`process master-level indexing 1`] = `
         "1": "Womens > Clothing",
         "2": "Womens > Clothing > Bottoms",
       },
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "colorVariations": [
         {
@@ -2229,7 +1834,6 @@ exports[`process master-level indexing 1`] = `
       ],
       "name": "Floral Dress",
       "objectID": "25592581M",
-      "primary_category_id": "womens-clothing-bottoms",
       "variants": [
         algoliaLocalizedProduct {
           "color": "Hot Pink Combo",
@@ -2272,31 +1876,12 @@ exports[`process partialRecordUpdate 1`] = `
         "2": "Womens > Clothing > Bottoms",
       },
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "color": "Hot Pink Combo",
       "image_groups": [
@@ -2349,7 +1934,6 @@ exports[`process partialRecordUpdate 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "refinementColor": "Pink",
       "refinementSize": "4",
       "searchable": true,
@@ -2370,31 +1954,12 @@ exports[`process partialRecordUpdate 1`] = `
         "2": "Femmes > Vêtements > Bas",
       },
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Femmes",
-          },
-          {
-            "id": "newarrivals",
-            "name": "Nouveaux arrivages",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bas",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Vêtements",
-          },
-          {
-            "id": "womens",
-            "name": "Femmes",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "color": "Combo rose vif",
       "image_groups": [
@@ -2447,7 +2012,6 @@ exports[`process partialRecordUpdate 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "refinementColor": "Rose",
       "refinementSize": "4",
       "searchable": true,
@@ -2468,31 +2032,12 @@ exports[`process partialRecordUpdate 1`] = `
         "2": "Womens > Clothing > Bottoms",
       },
       "brand": null,
-      "categories": [
-        [
-          {
-            "id": "newarrivals-womens",
-            "name": "Womens",
-          },
-          {
-            "id": "newarrivals",
-            "name": "New Arrivals",
-          },
-        ],
-        [
-          {
-            "id": "womens-clothing-bottoms",
-            "name": "Bottoms",
-          },
-          {
-            "id": "womens-clothing",
-            "name": "Clothing",
-          },
-          {
-            "id": "womens",
-            "name": "Womens",
-          },
-        ],
+      "categoryPageId": [
+        "newarrivals",
+        "newarrivals-womens",
+        "womens",
+        "womens-clothing",
+        "womens-clothing-bottoms",
       ],
       "color": "Hot Pink Combo",
       "image_groups": [
@@ -2545,7 +2090,6 @@ exports[`process partialRecordUpdate 1`] = `
         "EUR": 92.88,
         "USD": 129,
       },
-      "primary_category_id": "womens-clothing-bottoms",
       "refinementColor": "Pink",
       "refinementSize": "4",
       "searchable": true,

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -86,14 +86,14 @@ describe('beforeStep', () => {
     test('defaultAttributes', () => {
         mockAdditionalAttributes = [];
         job.beforeStep({}, stepExecution);
-        expect(job.__getAttributesToSend()).toStrictEqual(['name', 'primary_category_id',
-            'categories', 'in_stock', 'price', 'image_groups', 'url']);
+        expect(job.__getAttributesToSend()).toStrictEqual(['name', 'categoryPageId',
+            '__primary_category', 'in_stock', 'price', 'image_groups', 'url']);
     });
     test('no duplicated attributes', () => {
         mockAdditionalAttributes = ['name'];
         job.beforeStep({}, stepExecution);
-        expect(job.__getAttributesToSend()).toStrictEqual(['name', 'primary_category_id',
-            'categories', 'in_stock', 'price', 'image_groups', 'url']);
+        expect(job.__getAttributesToSend()).toStrictEqual(['name', 'categoryPageId',
+            '__primary_category', 'in_stock', 'price', 'image_groups', 'url']);
     });
     test('locales for indexing', () => {
         job.beforeStep({}, stepExecution);


### PR DESCRIPTION
Today we have the following list of default attributes:
`'name', 'categories', 'primary_category_id', '__primary_category', 'in_stock', 'price', 'image_groups', 'url'`

Some of them are not used by our default UI and are not following Algolia latest guidelines.
We want to replace of remove them:
- replace `categories` by the new `categoryPageId` attribute introduced in #206 
- remove the `primary_category_id` attribute
- remove the undocumented `_tags` attribute: `_tags` are a built-in way to do filtering in Algolia, but ours only contains the product id and are not used

After this PR, the default list of attributes will be:
`'name', 'categoryPageId', '__primary_category', 'in_stock', 'price', 'image_groups', 'url'`

The attribute definitions are kept, so if clients rely on them, they can add them to their Additional Product Attributes and their records will stay unchanged.

### Changes

- added proper attribute handler for `__primary_category`. Before, it was hardcoded in the `algoliaLocalizedProduct` function and computed from the `categories` attribute. Now it's directly computed from the SFCC product.
  - -> `computePrimaryCategoryHierarchicalFacets()` has been replaced by `getHierarchicalCategories()`
- updated the `defaultAttributes_v2` list
- updated tests

## To put in the release notes

**BREAKING CHANGE**: the list of default attributes has changed:
- `categories` replaced by `categoryPageId`, which is permits to create [Category Pages](https://www.algolia.com/doc/guides/solutions/ecommerce/browse/tutorials/category-pages/)
- `primary_category_id` removed
- `_tags` removed

If you rely on one of those attribute: add it to the `Additional Product Attributes` list before upgrading.

---
SFCC-402