### PR TITLE
feat(sfra): category pages

### DIFF
--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/index.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/index.js
@@ -3,6 +3,7 @@
 document.addEventListener('DOMContentLoaded', function () {
     var $suggestionsWrapper = $('#suggestions-wrapper');
 
+    var categoryId = $suggestionsWrapper.attr('data-category');
     var categoryDisplayNamePath = $suggestionsWrapper.attr('data-category-display-name-path');  // path of the current category
     var categoryDisplayNamePathSeparator = $suggestionsWrapper.attr('data-category-display-name-path-separator'); // separator used to serialize the category path (by default: '>')
     var urlQuery = $suggestionsWrapper.attr('data-q'); // onload search query - for search page - URL param: q
@@ -36,6 +37,7 @@ document.addEventListener('DOMContentLoaded', function () {
         enableInstantSearch({
             searchClient,
             urlQuery,
+            categoryId,
             categoryDisplayNamePath,
             categoryDisplayNamePathSeparator,
         });

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -57,27 +57,62 @@ function enableInstantSearch(config) {
         search.use(insightsMiddleware);
     }
 
-    if (document.querySelector('#algolia-category-title-placeholder')) {
-        search.addWidgets([
-            instantsearch.widgets.breadcrumb({
-                container: '#algolia-category-title-placeholder',
-                attributes: [
-                    '__primary_category.0',
-                    '__primary_category.1',
-                    '__primary_category.2'
-                ],
-                templates: {
-                    home: '',
-                    separator: ''
-                },
-                transformItems: function (items) {
-                    return items.slice(-1); // keep only last item
-                }
-            })
-        ])
-    }
-
     if (document.querySelector('#algolia-searchbox-placeholder')) {
+        if (config.categoryId) {
+            // Category page: filter on categoryPageId
+            // doc: https://www.algolia.com/doc/guides/solutions/ecommerce/browse/tutorials/category-pages/
+            search.addWidgets([
+                instantsearch.widgets.configure({
+                    filters: `categoryPageId: '${config.categoryId}'`,
+                }),
+            ]);
+        } else {
+            // Search results page: display the categories hierarchy and the "Reset" button
+            search.addWidgets([
+                instantsearch.widgets.clearRefinements({
+                    container: '#algolia-clear-refinements-placeholder',
+                    cssClasses: {
+                        root: 'secondary-bar col-12 offset-sm-4 offset-md-0 col-sm-4 col-md-12',
+                        button: 'btn btn-block btn-outline-primary',
+                        disabledButton: 'disabled'
+                    },
+                    templates: {
+                        resetLabel: algoliaData.strings.reset
+                    }
+                }),
+                hierarchicalMenuWithPanel({
+                    container: '#algolia-categories-list-placeholder',
+                    attributes: ['__primary_category.0', '__primary_category.1', '__primary_category.2'],
+                    templates: {
+                        item(data, { html }) {
+                            return html`
+                                <a class="${data.cssClasses.link}" href="${data.url}" style="white-space: nowrap; ${data.isRefined ? 'font-weight: bold;' : ''}">
+                                    <i class="fa ${data.isRefined ? 'fa-check-circle' : 'fa-circle-o'}"></i>
+                                    <span class="${data.cssClasses.label}"> ${data.label}</span>
+                                </a>
+                            `
+                        },
+                    },
+                    panelTitle: algoliaData.strings.categoryPanelTitle
+                }),
+                hierarchicalMenuWithPanel({
+                    container: '#algolia-newarrivals-list-placeholder',
+                    attributes: ['newArrivalsCategory.0', 'newArrivalsCategory.1'],
+                    templates: {
+                        item(data, { html }) {
+                            return html`
+                            <a class="${data.cssClasses.link}" href="${data.url}" style="white-space: nowrap; ${data.isRefined ? 'font-weight: bold;' : ''}">
+                                <i class="fa ${data.isRefined ? 'fa-check-circle' : 'fa-circle-o'}"></i>
+                                <span class="${data.cssClasses.label}"> ${data.label}</span>
+                            </a>
+                        `
+                        },
+                    },
+                    panelTitle: algoliaData.strings.newArrivals
+                }),
+            ]);
+        }
+
         search.addWidgets([
             instantsearch.widgets.configure({
                 distinct: true,
@@ -121,49 +156,6 @@ function enableInstantSearch(config) {
                     {label: algoliaData.strings.priceAsc, value: productsIndexPriceAsc},
                     {label: algoliaData.strings.priceDesc, value: productsIndexPriceDesc}
                 ]
-            }),
-            instantsearch.widgets.clearRefinements({
-                container: '#algolia-clear-refinements-placeholder',
-                cssClasses: {
-                    root: 'secondary-bar col-12 offset-sm-4 offset-md-0 col-sm-4 col-md-12',
-                    button: 'btn btn-block btn-outline-primary',
-                    disabledButton: 'disabled'
-                },
-                templates: {
-                    resetLabel: algoliaData.strings.reset
-                }
-            }),
-
-            hierarchicalMenuWithPanel({
-                container: '#algolia-categories-list-placeholder',
-                attributes: ['__primary_category.0', '__primary_category.1', '__primary_category.2'],
-                templates: {
-                    item(data, { html }) {
-                        return html`
-                            <a class="${data.cssClasses.link}" href="${data.url}" style="white-space: nowrap; ${data.isRefined ? 'font-weight: bold;' : ''}">
-                                <i class="fa ${data.isRefined ? 'fa-check-circle' : 'fa-circle-o'}"></i>
-                                <span class="${data.cssClasses.label}"> ${data.label}</span>
-                            </a>
-                        `
-                    },
-                },
-                panelTitle: algoliaData.strings.categoryPanelTitle
-            }),
-
-            hierarchicalMenuWithPanel({
-                container: '#algolia-newarrivals-list-placeholder',
-                attributes: ['newArrivalsCategory.0', 'newArrivalsCategory.1'],
-                templates: {
-                    item(data, { html }) {
-                        return html`
-                            <a class="${data.cssClasses.link}" href="${data.url}" style="white-space: nowrap; ${data.isRefined ? 'font-weight: bold;' : ''}">
-                                <i class="fa ${data.isRefined ? 'fa-check-circle' : 'fa-circle-o'}"></i>
-                                <span class="${data.cssClasses.label}"> ${data.label}</span>
-                            </a>
-                        `
-                    },
-                },
-                panelTitle: algoliaData.strings.newArrivals
             }),
 
             toggleRefinementWithPanel({

--- a/cartridges/int_algolia_sfra/cartridge/templates/default/components/header/search.isml
+++ b/cartridges/int_algolia_sfra/cartridge/templates/default/components/header/search.isml
@@ -2,7 +2,7 @@
 <isif condition="${algoliaData.getPreference('Enable')}">
     <div class="site-search">
         <div id="suggestions-wrapper"
-            data-category="${pdict.cgid}"
+            data-category="${empty(pdict.cgid) ? '' : pdict.cgid}"
             data-category-display-name-path="${pdict.categoryDisplayNamePath}"
             data-category-display-name-path-separator="${pdict.categoryDisplayNamePathSeparator}"
             data-q="${empty(pdict.q) ? '' : pdict.q}"


### PR DESCRIPTION
Implement [Category Pages](https://www.algolia.com/doc/guides/solutions/ecommerce/browse/tutorials/category-pages/) using the `categoryPageId` added in #206.

This is done by adding a `filters` on the InstantSearch configuration ([doc](https://www.algolia.com/doc/guides/solutions/ecommerce/browse/tutorials/category-pages/#build-a-user-interface-with-instantsearch-js))

For categories pages, the `hierarchicalMenu` are not displayed anymore. This is on purpose, a category page is a standalone page of a single category.

### Changes

- Pass the `categoryId` to the `enableInstantSearch` options
  - add a `filters` on `categoryPageId` when the `categoryId` is present
  - add the hierarchical menus otherwise (if we are on the search results page)
- Remove the `breadcrumb` widget. The category title not be updated by InstantSearch anymore, it will be updated when the user browses another category

### How to test

- Reindex products using the latest version from `develop`, to have the `categoryPageId` in the records
- Browse categories using the top menu

---
SFCC-407