### PR TITLE
fix: improve HTML content handling in algoliaSplitter.js

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaSplitter.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaSplitter.js
@@ -33,13 +33,15 @@ function splitHtmlContent(htmlContent, maxByteSize, splitterElement) {
     sections.forEach(function(section) {
         section = StringUtils.trim(splitterBegin + section) || '';
 
-        if (!section.trim()) {
+        if (!section) {
             return;
         }
 
+        section = removeHtmlTagsAndFormat(section).trim();
 
-        //remove all HTML tags
-        section = removeHtmlTagsAndFormat(section);
+        if (!section) {
+            return;
+        }
 
         var sectionSize = new Bytes(section).getLength();
         if (sectionSize > maxByteSize) {
@@ -61,11 +63,18 @@ function splitHtmlContent(htmlContent, maxByteSize, splitterElement) {
  * @returns {string} Sanitized content
  */
 function removeIgnoredContent(content) {
-    //remove restricted tags and their content
     IGNORED_TAGS.forEach(function(tag) {
-        content = content.replace(new RegExp('<' + tag + '.*?' + tag + '>', 'g'), '');
+        // Remove entire <tag ...>...</tag> blocks (multiline)
+        content = content.replace(
+            new RegExp('<' + tag + '[^>]*>[\\s\\S]*?<\\/' + tag + '>', 'gi'),
+            ''
+        );
+        // Remove self-closing tags <tag ... />
+        content = content.replace(
+            new RegExp('<' + tag + '[^>]*?\\/?>', 'gi'),
+            ''
+        );
     });
-
     return content;
 }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaSplitter.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaSplitter.js
@@ -33,10 +33,6 @@ function splitHtmlContent(htmlContent, maxByteSize, splitterElement) {
     sections.forEach(function(section) {
         section = StringUtils.trim(splitterBegin + section) || '';
 
-        if (!section) {
-            return;
-        }
-
         section = removeHtmlTagsAndFormat(section).trim();
 
         if (!section) {
@@ -140,5 +136,6 @@ function getMaxBodySize(content) {
 module.exports = {
     splitHtmlContent: splitHtmlContent,
     getMaxBodySize: getMaxBodySize,
-    removeHtmlTagsAndFormat: removeHtmlTagsAndFormat
+    removeHtmlTagsAndFormat: removeHtmlTagsAndFormat,
+    removeIgnoredContent: removeIgnoredContent
 };

--- a/test/unit/int_algolia/scripts/algolia/lib/algoliaSplitter.test.js
+++ b/test/unit/int_algolia/scripts/algolia/lib/algoliaSplitter.test.js
@@ -1,4 +1,4 @@
-const { splitHtmlContent, getMaxBodySize, removeHtmlTagsAndFormat } = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaSplitter');
+const { splitHtmlContent, getMaxBodySize, removeHtmlTagsAndFormat, removeIgnoredContent } = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaSplitter');
 
 jest.mock('dw/util/Bytes', () => {
     class BytesMock {
@@ -108,6 +108,47 @@ describe('Extreme Content Manipulation', () => {
         </div>`;
         const result = splitHtmlContent(htmlContent, 1000, 'div');
         expect(result).toEqual(['Test 3']);
+    });
+});
+
+describe('removeIgnoredContent', () => {
+    test('removes content within regular tags', () => {
+        const input = '<div>Keep this<script>Remove this</script>Keep this too</div>';
+        expect(removeIgnoredContent(input)).toBe('<div>Keep thisKeep this too</div>');
+    });
+
+    test('removes content within multiline tags', () => {
+        const input = `<div>Keep this<script>
+            Remove
+            this
+            content
+        </script>Keep this too</div>`;
+        expect(removeIgnoredContent(input)).toBe('<div>Keep thisKeep this too</div>');
+    });
+
+    test('removes self-closing tags', () => {
+        const input = '<div>Keep this<input type="text" />Keep this too</div>';
+        expect(removeIgnoredContent(input)).toBe('<div>Keep thisKeep this too</div>');
+    });
+
+    test('removes multiple instances of ignored tags', () => {
+        const input = '<div>Text<script>JS1</script>Middle<script>JS2</script>End</div>';
+        expect(removeIgnoredContent(input)).toBe('<div>TextMiddleEnd</div>');
+    });
+
+    test('handles multiple self-closing tags', () => {
+        const input = '<div>Start<input /><input/>End</div>';
+        expect(removeIgnoredContent(input)).toBe('<div>StartEnd</div>');
+    });
+
+    test('handles mixed regular and self-closing ignored tags', () => {
+        const input = '<div>Start<script>Remove</script><input />Middle<style>Remove</style><input/>End</div>';
+        expect(removeIgnoredContent(input)).toBe('<div>StartMiddleEnd</div>');
+    });
+
+    test('preserves content not in ignored tags', () => {
+        const input = '<div><span>Keep</span><script>Remove</script><p>Also Keep</p></div>';
+        expect(removeIgnoredContent(input)).toBe('<div><span>Keep</span><p>Also Keep</p></div>');
     });
 });
 

--- a/test/unit/int_algolia/scripts/algolia/lib/algoliaSplitter.test.js
+++ b/test/unit/int_algolia/scripts/algolia/lib/algoliaSplitter.test.js
@@ -94,6 +94,21 @@ describe('Extreme Content Manipulation', () => {
             expect(removeHtmlTagsAndFormat(input)).toBe(expectedOutput);
         });
     });
+
+    test('should remove content inside an <area> tag even if multiline', () => {
+        const htmlContent = `<div>
+            <area>Test 1
+                <div>
+                    <button>Test 2</button>
+                </div>
+            </area>
+            <div>
+                <span>Test 3</span>
+            </div>
+        </div>`;
+        const result = splitHtmlContent(htmlContent, 1000, 'div');
+        expect(result).toEqual(['Test 3']);
+    });
 });
 
 


### PR DESCRIPTION
## What is Changed

- Refactored `splitHtmlContent` to enhance section trimming and ensure empty sections are properly handled.
- Updated `removeIgnoredContent` to correctly remove multiline content within ignored tags and self-closing tags.
- Added a new test case to verify removal of content inside multiline  tags.