### PR TITLE
fix(sfra): prices were not displayed for product-level indexing

### DIFF
--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -755,15 +755,15 @@ function calculateDisplayPrice(item) {
         }
     }
 
-    if (item.promotionalPrice) {
+    if (variant.promotionalPrice) {
         return {
-            price: item.promotionalPrice,
+            price: variant.promotionalPrice[algoliaData.currencyCode] || variant.promotionalPrice,
             calloutMsg: '',
         }
     }
 
     return {
-        price: item.price,
+        price: variant.price[algoliaData.currencyCode] || variant.price,
         calloutMsg: '',
     }
 }


### PR DESCRIPTION
Prices were not displayed in Base product indexing mode with the default attributes, i.e. when there wasn't any other price source such as promotions or pricebooks.

There was two mistakes in the `calculateDisplayPrice` function:
- It was returning the `price` attribute as-is, while it can actually be an object with multiple currencies
- It was using `item` instead of `variant`, so when `item` is the base product, `item.price` is undefined