### PR TITLE
fix: Handle variant price display for different currency codes

### DIFF
--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/instantsearch-config.js
@@ -438,7 +438,7 @@ function enableInstantSearch(config) {
                                 item.url = selectedVariant.url;
                                 let { price: variantPrice, calloutMsg: variantCalloutMsg } = calculateDisplayPrice(selectedVariant);
 
-                                item.displayPrice = variantPrice;
+                                item.displayPrice = variantPrice[algoliaData.currencyCode] || variantPrice;
                                 item.calloutMsg = variantCalloutMsg;
                             }
                         }


### PR DESCRIPTION
# What is Changed

- Modify the price display logic in instantsearch-config.js to support variant prices across different currency codes by using the current currency code when available