### PR TITLE
feat: Implement Hooks for SFRA and Real-Time Inventory Updates for variant level records

### DIFF
--- a/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
+++ b/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
@@ -43,7 +43,7 @@ function handleSettings() {
         var algoliaEnableContentSearch = ('EnableContentSearch' in params) && (params.EnableContentSearch.submitted === true);
         var algoliaEnableRecommend = ('EnableRecommend' in params) && (params.EnableRecommend.submitted === true);
         var algoliaEnablePricingLazyLoad = ('EnablePricingLazyLoad' in params) && (params.EnablePricingLazyLoad.submitted === true);
-        var algoliaEnableRealTimeInventory = ('EnableRealTimeInventory' in params) && (params.EnableRealTimeInventory.submitted === true);
+        var algoliaEnableRealTimeInventoryHook = ('EnableRealTimeInventoryHook' in params) && (params.EnableRealTimeInventoryHook.submitted === true);
 
         // If the user typed an empty prefix, the cartridge logic eventually
         // uses the default <hostname>__<siteID>
@@ -86,7 +86,7 @@ function handleSettings() {
         algoliaData.setPreference('EnableRecommend', algoliaEnableRecommend);
         algoliaData.setPreference('EnablePricingLazyLoad', algoliaEnablePricingLazyLoad);
         algoliaData.setPreference('IndexOutOfStock', params.IndexOutOfStock.submitted);
-        algoliaData.setPreference('EnableRealTimeInventory', algoliaEnableRealTimeInventory);
+        algoliaData.setPreference('EnableRealTimeInventoryHook', algoliaEnableRealTimeInventoryHook);
     } catch (error) {
         Logger.error(error);
         showDashboardWithMessages(adminValidation, error.message);

--- a/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
+++ b/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
@@ -43,6 +43,7 @@ function handleSettings() {
         var algoliaEnableContentSearch = ('EnableContentSearch' in params) && (params.EnableContentSearch.submitted === true);
         var algoliaEnableRecommend = ('EnableRecommend' in params) && (params.EnableRecommend.submitted === true);
         var algoliaEnablePricingLazyLoad = ('EnablePricingLazyLoad' in params) && (params.EnablePricingLazyLoad.submitted === true);
+        var algoliaEnableRealTimeInventory = ('EnableRealTimeInventory' in params) && (params.EnableRealTimeInventory.submitted === true);
 
         // If the user typed an empty prefix, the cartridge logic eventually
         // uses the default <hostname>__<siteID>
@@ -85,6 +86,7 @@ function handleSettings() {
         algoliaData.setPreference('EnableRecommend', algoliaEnableRecommend);
         algoliaData.setPreference('EnablePricingLazyLoad', algoliaEnablePricingLazyLoad);
         algoliaData.setPreference('IndexOutOfStock', params.IndexOutOfStock.submitted);
+        algoliaData.setPreference('EnableRealTimeInventory', algoliaEnableRealTimeInventory);
     } catch (error) {
         Logger.error(error);
         showDashboardWithMessages(adminValidation, error.message);

--- a/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
+++ b/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
@@ -124,9 +124,9 @@
                 <iscomment> Algolia_EnableRealTimeInventoryHook </iscomment>
                 <tr>
                     <td class="table_detail w s" colspan="1">
-                        <isprint value="${Resource.msg('algolia.label.preference.EnableRealTimeInventoryHook', 'algolia', null)}" />
+                        <isprint value="${Resource.msg('algolia.label.preference.enableRealTimeInventoryHook', 'algolia', null)}" />
                         <i class="fa fa-info-circle dw-nc-text-info info-hover"></i>
-                        <div class="tooltip">${Resource.msg('algolia.label.preference.EnableRealTimeInventoryHook.help', 'algolia', null)}</div>
+                        <div class="tooltip">${Resource.msg('algolia.label.preference.enableRealTimeInventoryHook.help', 'algolia', null)}</div>
                     </td>
                     <td class="table_detail w e s">
                         <input type="checkbox" ${pdict.algoliaData.getPreference('EnableRealTimeInventoryHook') ? "checked": ""} id="EnableRealTimeInventoryHook" name="EnableRealTimeInventoryHook" />

--- a/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
+++ b/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
@@ -121,6 +121,18 @@
                     </td>
                 </tr>
 
+                <iscomment> Algolia_EnableRealTimeInventory </iscomment>
+                <tr>
+                    <td class="table_detail w s" colspan="1">
+                        <isprint value="${Resource.msg('algolia.label.preference.enablerealetimeinventory', 'algolia', null)}" />
+                        <i class="fa fa-info-circle dw-nc-text-info info-hover"></i>
+                        <div class="tooltip">${Resource.msg('algolia.label.preference.enablerealetimeinventory.help', 'algolia', null)}</div>
+                    </td>
+                    <td class="table_detail w e s">
+                        <input type="checkbox" ${pdict.algoliaData.getPreference('EnableRealTimeInventory') ? "checked": ""} id="EnableRealTimeInventory" name="EnableRealTimeInventory" />
+                    </td>
+                </tr>
+
                 <iscomment> Algolia_AdditionalAttributes </iscomment>
                 <tr>
                     <td class="table_detail w s" colspan="1">

--- a/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
+++ b/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
@@ -124,9 +124,9 @@
                 <iscomment> Algolia_EnableRealTimeInventory </iscomment>
                 <tr>
                     <td class="table_detail w s" colspan="1">
-                        <isprint value="${Resource.msg('algolia.label.preference.enablerealetimeinventory', 'algolia', null)}" />
+                        <isprint value="${Resource.msg('algolia.label.preference.enablerealtimeinventory', 'algolia', null)}" />
                         <i class="fa fa-info-circle dw-nc-text-info info-hover"></i>
-                        <div class="tooltip">${Resource.msg('algolia.label.preference.enablerealetimeinventory.help', 'algolia', null)}</div>
+                        <div class="tooltip">${Resource.msg('algolia.label.preference.enablerealtimeinventory.help', 'algolia', null)}</div>
                     </td>
                     <td class="table_detail w e s">
                         <input type="checkbox" ${pdict.algoliaData.getPreference('EnableRealTimeInventory') ? "checked": ""} id="EnableRealTimeInventory" name="EnableRealTimeInventory" />

--- a/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
+++ b/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
@@ -121,15 +121,15 @@
                     </td>
                 </tr>
 
-                <iscomment> Algolia_EnableRealTimeInventory </iscomment>
+                <iscomment> Algolia_EnableRealTimeInventoryHook </iscomment>
                 <tr>
                     <td class="table_detail w s" colspan="1">
-                        <isprint value="${Resource.msg('algolia.label.preference.enablerealtimeinventory', 'algolia', null)}" />
+                        <isprint value="${Resource.msg('algolia.label.preference.EnableRealTimeInventoryHook', 'algolia', null)}" />
                         <i class="fa fa-info-circle dw-nc-text-info info-hover"></i>
-                        <div class="tooltip">${Resource.msg('algolia.label.preference.enablerealtimeinventory.help', 'algolia', null)}</div>
+                        <div class="tooltip">${Resource.msg('algolia.label.preference.EnableRealTimeInventoryHook.help', 'algolia', null)}</div>
                     </td>
                     <td class="table_detail w e s">
-                        <input type="checkbox" ${pdict.algoliaData.getPreference('EnableRealTimeInventory') ? "checked": ""} id="EnableRealTimeInventory" name="EnableRealTimeInventory" />
+                        <input type="checkbox" ${pdict.algoliaData.getPreference('EnableRealTimeInventoryHook') ? "checked": ""} id="EnableRealTimeInventoryHook" name="EnableRealTimeInventoryHook" />
                     </td>
                 </tr>
 

--- a/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
+++ b/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
@@ -21,6 +21,7 @@ algolia.label.preference.enablecontentsearch=Enable content search
 algolia.label.preference.enablerecommend=Recommend
 algolia.label.preference.enablePricingLazyLoad=Lazy Loading for prices
 algolia.label.preference.indexoutofstock=Index out of stock products
+algolia.label.preference.enablerealetimeinventory=Enable Real Time Inventory
 algolia.label.preference.clientid=OCAPI Client ID
 algolia.label.preference.clientpassword=OCAPI Client password
 algolia.label.button.apply=Apply
@@ -44,7 +45,8 @@ algolia.label.preference.enablessr.help=Server-side rendering for SFRA's CLP (ca
 algolia.label.preference.enablecontentsearch.help=Enable Content Search on the storefront
 algolia.label.preference.enablerecommend.help=Enable Algolia Recommend on the SFRA storefront cartridge. See the documentation for additional setup steps
 algolia.label.preference.enablePricingLazyLoad.help=When enabled, prices are fetched from SFCC when search results are displayed. Permits to display the most up-to-date promotions without having to index them.
-algolia.label.preference.indexoutofstock.help=Index out of stock products. When disabled, only in-stock (ATS higher than the InStock Threshold) products are indexed. 
+algolia.label.preference.indexoutofstock.help=Index out of stock products. When disabled, only in-stock (ATS higher than the InStock Threshold) products are indexed.
+algolia.label.preference.enablerealetimeinventory.help=Sends inventory updates to Algolia in real-time after each order.
 
 # v2 job report table
 algolia.label.jobtype=job type:

--- a/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
+++ b/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
@@ -21,7 +21,7 @@ algolia.label.preference.enablecontentsearch=Enable content search
 algolia.label.preference.enablerecommend=Recommend
 algolia.label.preference.enablePricingLazyLoad=Lazy Loading for prices
 algolia.label.preference.indexoutofstock=Index out of stock products
-algolia.label.preference.EnableRealTimeInventoryHook=Enable Real Time Inventory
+algolia.label.preference.enableRealTimeInventoryHook=Enable Real Time Inventory
 algolia.label.preference.clientid=OCAPI Client ID
 algolia.label.preference.clientpassword=OCAPI Client password
 algolia.label.button.apply=Apply
@@ -46,7 +46,7 @@ algolia.label.preference.enablecontentsearch.help=Enable Content Search on the s
 algolia.label.preference.enablerecommend.help=Enable Algolia Recommend on the SFRA storefront cartridge. See the documentation for additional setup steps
 algolia.label.preference.enablePricingLazyLoad.help=When enabled, prices are fetched from SFCC when search results are displayed. Permits to display the most up-to-date promotions without having to index them.
 algolia.label.preference.indexoutofstock.help=Index out of stock products. When disabled, only in-stock (ATS higher than the InStock Threshold) products are indexed.
-algolia.label.preference.EnableRealTimeInventoryHook.help=Sends inventory updates to Algolia in real-time after each order.
+algolia.label.preference.enableRealTimeInventoryHook.help=Sends inventory updates to Algolia in real-time after each order.
 
 # v2 job report table
 algolia.label.jobtype=job type:

--- a/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
+++ b/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
@@ -21,7 +21,7 @@ algolia.label.preference.enablecontentsearch=Enable content search
 algolia.label.preference.enablerecommend=Recommend
 algolia.label.preference.enablePricingLazyLoad=Lazy Loading for prices
 algolia.label.preference.indexoutofstock=Index out of stock products
-algolia.label.preference.enablerealetimeinventory=Enable Real Time Inventory
+algolia.label.preference.enablerealtimeinventory=Enable Real Time Inventory
 algolia.label.preference.clientid=OCAPI Client ID
 algolia.label.preference.clientpassword=OCAPI Client password
 algolia.label.button.apply=Apply
@@ -46,7 +46,7 @@ algolia.label.preference.enablecontentsearch.help=Enable Content Search on the s
 algolia.label.preference.enablerecommend.help=Enable Algolia Recommend on the SFRA storefront cartridge. See the documentation for additional setup steps
 algolia.label.preference.enablePricingLazyLoad.help=When enabled, prices are fetched from SFCC when search results are displayed. Permits to display the most up-to-date promotions without having to index them.
 algolia.label.preference.indexoutofstock.help=Index out of stock products. When disabled, only in-stock (ATS higher than the InStock Threshold) products are indexed.
-algolia.label.preference.enablerealetimeinventory.help=Sends inventory updates to Algolia in real-time after each order.
+algolia.label.preference.enablerealtimeinventory.help=Sends inventory updates to Algolia in real-time after each order.
 
 # v2 job report table
 algolia.label.jobtype=job type:

--- a/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
+++ b/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
@@ -21,7 +21,7 @@ algolia.label.preference.enablecontentsearch=Enable content search
 algolia.label.preference.enablerecommend=Recommend
 algolia.label.preference.enablePricingLazyLoad=Lazy Loading for prices
 algolia.label.preference.indexoutofstock=Index out of stock products
-algolia.label.preference.enablerealtimeinventory=Enable Real Time Inventory
+algolia.label.preference.EnableRealTimeInventoryHook=Enable Real Time Inventory
 algolia.label.preference.clientid=OCAPI Client ID
 algolia.label.preference.clientpassword=OCAPI Client password
 algolia.label.button.apply=Apply
@@ -46,7 +46,7 @@ algolia.label.preference.enablecontentsearch.help=Enable Content Search on the s
 algolia.label.preference.enablerecommend.help=Enable Algolia Recommend on the SFRA storefront cartridge. See the documentation for additional setup steps
 algolia.label.preference.enablePricingLazyLoad.help=When enabled, prices are fetched from SFCC when search results are displayed. Permits to display the most up-to-date promotions without having to index them.
 algolia.label.preference.indexoutofstock.help=Index out of stock products. When disabled, only in-stock (ATS higher than the InStock Threshold) products are indexed.
-algolia.label.preference.enablerealtimeinventory.help=Sends inventory updates to Algolia in real-time after each order.
+algolia.label.preference.EnableRealTimeInventoryHook.help=Sends inventory updates to Algolia in real-time after each order.
 
 # v2 job report table
 algolia.label.jobtype=job type:

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -38,9 +38,9 @@ if (ATTRIBUTE_LIST.indexOf('storeAvailability') !== -1) {
     var storesMap = StoreMgr.searchStoresByCoordinates(0, 0, 'mi', 99999999);
 
     if (storesMap && !storesMap.empty) {
-        var storeIds = storesMap.keySet().toArray();
-        for (var l = 0; l < storeIds.length; l++) {
-            var store = storeIds[l];
+        var storeObjects = storesMap.keySet().toArray();
+        for (var l = 0; l < storeObjects.length; l++) {
+            var store = storeObjects[l];
             if (store && store.inventoryList) {
                 stores.push({
                     id: store.ID,

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -32,19 +32,21 @@ const ALGOLIA_IN_STOCK_THRESHOLD = algoliaData.getPreference('InStockThreshold')
 const INDEX_OUT_OF_STOCK = algoliaData.getPreference('IndexOutOfStock');
 const ATTRIBUTE_LIST = algoliaData.getSetOfArray('AdditionalAttributes');
 const stores = [];
-var SystemObjectMgr;
 
 if (ATTRIBUTE_LIST.indexOf('storeAvailability') !== -1) {
-    SystemObjectMgr = require('dw/object/SystemObjectMgr');
-    var storeIt = SystemObjectMgr.getAllSystemObjects('Store');
-    while (storeIt.hasNext()) {
-        var store = storeIt.next();
-        if (store.inventoryList) {
-            var storeObject = {
-                id: store.ID,
-                storeInventory: store.inventoryList
-            };
-            stores.push(storeObject);
+    var StoreMgr = require('dw/catalog/StoreMgr');
+    var storesMap = StoreMgr.searchStoresByCoordinates(0, 0, 'mi', 99999999);
+
+    if (storesMap && !storesMap.empty) {
+        var storeIds = storesMap.keySet().toArray();
+        for (var l = 0; l < storeIds.length; l++) {
+            var store = storeIds[l];
+            if (store && store.inventoryList) {
+                stores.push({
+                    id: store.ID,
+                    storeInventory: store.inventoryList
+                });
+            }
         }
     }
 }
@@ -493,7 +495,7 @@ var aggregatedValueHandlers = {
                 var storeElInventory = storeEl.storeInventory;
                 if (storeElInventory) {
                     var inventoryRecord = storeElInventory.getRecord(product.ID);
-                    if (inventoryRecord && inventoryRecord.ATS.value && inventoryRecord.ATS.value > ALGOLIA_IN_STOCK_THRESHOLD) {
+                    if (inventoryRecord && inventoryRecord.ATS.value && inventoryRecord.ATS.value >= ALGOLIA_IN_STOCK_THRESHOLD) {
                         storeArray.push(storeEl.id);
                     }
                 }

--- a/cartridges/int_algolia_sfra/cartridge/controllers/CheckoutServices.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/CheckoutServices.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var server = require('server');
+var base = module.superModule;
+server.extend(base);
+
+var HookMgr = require('dw/system/HookMgr');
+var OrderMgr = require('dw/order/OrderMgr');
+
+server.append('PlaceOrder', function (req, res, next) {
+
+    var orderId = res.viewData.orderID;
+    if (!orderId) {
+        return next();
+    }
+
+    var order = OrderMgr.getOrder(orderId);
+    if (!order) {
+        return next();
+    }
+
+    HookMgr.callHook('dw.ocapi.shop.order.afterPOST', 'afterPOST', order);
+    next();
+});
+
+module.exports = server.exports();

--- a/cartridges/int_algolia_sfra/cartridge/controllers/CheckoutServices.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/CheckoutServices.js
@@ -6,8 +6,14 @@ server.extend(base);
 
 var HookMgr = require('dw/system/HookMgr');
 var OrderMgr = require('dw/order/OrderMgr');
+var algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
 
 server.append('PlaceOrder', function (req, res, next) {
+    var Algolia_EnableRealTimeInventoryHook = algoliaData.getPreference('EnableRealTimeInventoryHook');
+
+    if (!Algolia_EnableRealTimeInventoryHook) {
+        return next();
+    }
 
     var orderId = res.viewData.orderID;
     if (!orderId) {

--- a/cartridges/int_algolia_sfra/cartridge/scripts/hooks.json
+++ b/cartridges/int_algolia_sfra/cartridge/scripts/hooks.json
@@ -1,0 +1,8 @@
+{
+    "hooks": [
+        {
+            "name": "dw.ocapi.shop.order.afterPOST",
+            "script": "./hooks/order/afterPOST"
+        }
+    ]
+}

--- a/cartridges/int_algolia_sfra/cartridge/scripts/hooks/order/afterPOST.js
+++ b/cartridges/int_algolia_sfra/cartridge/scripts/hooks/order/afterPOST.js
@@ -1,0 +1,92 @@
+'use strict';
+
+var Site = require('dw/system/Site');
+var algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
+var jobHelper = require('*/cartridge/scripts/algolia/helper/jobHelper');
+var Logger = require('dw/system/Logger');
+var Status = require('dw/system/Status');
+
+
+exports.afterPOST = function (order) {
+    var Algolia_EnableRealTimeInventory = algoliaData.getPreference('EnableRealTimeInventory');
+    if (Algolia_EnableRealTimeInventory) {
+        var reindexHelper = require('*/cartridge/scripts/algolia/helper/reindexHelper');
+
+        try {
+            var algoliaOperations = [];
+            var shipments = order.getShipments();
+            for (var i = 0; i < shipments.length; i++) {
+                var shipment = shipments[i];
+                var j;
+                var k;
+                var pli;
+                var product;
+                var productOps;
+                var plis = shipment.getProductLineItems();
+                //check if shipment is a pickup shipment
+                if (shipment.custom.shipmentType === 'instore') {
+                    for (j = 0; j < plis.length; j++) {
+                        pli = plis[j];
+                        product = pli.product;
+                        productOps = getProductData(product, ['storeAvailability']);
+                        for (k = 0; k < productOps.length; k++) {
+                            var productOp = productOps[k];
+                            // If the product is not available in the store anymore
+                            if (productOp.body.storeAvailability.indexOf(shipment.custom.fromStoreId) === -1) {
+                                algoliaOperations.push(productOp);
+                            }
+                        }
+                    }
+                } else {
+                    for (j = 0; j < plis.length; j++) {
+                        pli = plis[j];
+                        product = pli.product;
+                        productOps = getProductData(product, ['in_stock']);
+                        for (k = 0; k < productOps.length; k++) {
+                            productOp = productOps[k];
+                            // If the product is not available in the inventory anymore
+                            if (productOp.body.in_stock === false || productOp.body.in_stock === undefined) {
+                                if (algoliaData.getPreference('IndexOutOfStock')) {
+                                    algoliaOperations.push(productOp);
+                                } else {
+                                    // If the product is not available in the inventory anymore and the IndexOutOfStock preference is disabled, we need to remove the product from Algolia
+                                    algoliaOperations.push(new jobHelper.AlgoliaOperation('deleteObject', { objectID: productOp.body.objectID }, productOp.indexName));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if (algoliaOperations.length > 0) {
+                reindexHelper.sendRetryableBatch(algoliaOperations);
+            }
+        } catch (error) {
+            Logger.error('Error in afterPOST hook for Order: ' + order.orderNo + ', Message: ' + error.message);
+        }
+    }
+
+    return new Status(Status.OK);
+};
+
+
+/**
+ * Get the product data for the product
+ * @param {dw.catalog.Product} product - The product to get the data for
+ * @param {Array} attributes - The attributes to get the data for
+ * @returns {Array} The product data
+ */
+function getProductData(product, attributes) {
+    var algoliaOperations = [];
+    var AlgoliaLocalizedProduct = require('*/cartridge/scripts/algolia/model/algoliaLocalizedProduct');
+    var baseModel = new AlgoliaLocalizedProduct({ product: product, locale: 'default', attributeList: attributes });
+    var siteLocales = Site.getCurrent().getAllowedLocales();
+    for (let l = 0; l < siteLocales.size(); ++l) {
+        let locale = siteLocales[l];
+        let indexName = algoliaData.calculateIndexName('products', locale);
+        let localizedProduct = new AlgoliaLocalizedProduct({ product: product, locale: locale, attributeList: attributes, baseModel: baseModel });
+        algoliaOperations.push(new jobHelper.AlgoliaOperation('partialUpdateObject', localizedProduct, indexName));
+    }
+    return algoliaOperations;
+}
+
+

--- a/cartridges/int_algolia_sfra/package.json
+++ b/cartridges/int_algolia_sfra/package.json
@@ -1,0 +1,3 @@
+{
+    "hooks": "./cartridge/scripts/hooks.json"
+}

--- a/metadata/algolia/meta/system-objecttype-extensions.xml
+++ b/metadata/algolia/meta/system-objecttype-extensions.xml
@@ -264,6 +264,15 @@ Setting this preference replaces the first two segments, the final index name be
                 <externally-managed-flag>false</externally-managed-flag>
             </attribute-definition>
 
+            <attribute-definition attribute-id="Algolia_EnableRealTimeInventory">
+                <display-name xml:lang="x-default">Enable Real Time Inventory</display-name>
+                <description xml:lang="x-default">Sends inventory updates to Algolia in real-time after each order.</description>
+                <type>boolean</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <default-value>false</default-value>
+            </attribute-definition>
+
         </custom-attribute-definitions>
         <group-definitions>
             <attribute-group group-id="Algolia">
@@ -284,6 +293,7 @@ Setting this preference replaces the first two segments, the final index name be
                 <attribute attribute-id="Algolia_EnableRecommend"/>
                 <attribute attribute-id="Algolia_EnablePricingLazyLoad"/>
                 <attribute attribute-id="Algolia_IndexOutOfStock"/>
+                <attribute attribute-id="Algolia_EnableRealTimeInventory"/>
             </attribute-group>
         </group-definitions>
 

--- a/metadata/algolia/meta/system-objecttype-extensions.xml
+++ b/metadata/algolia/meta/system-objecttype-extensions.xml
@@ -264,8 +264,8 @@ Setting this preference replaces the first two segments, the final index name be
                 <externally-managed-flag>false</externally-managed-flag>
             </attribute-definition>
 
-            <attribute-definition attribute-id="Algolia_EnableRealTimeInventory">
-                <display-name xml:lang="x-default">Enable Real Time Inventory</display-name>
+            <attribute-definition attribute-id="Algolia_EnableRealTimeInventoryHook">
+                <display-name xml:lang="x-default">Enable Real Time Inventory Hook</display-name>
                 <description xml:lang="x-default">Sends inventory updates to Algolia in real-time after each order.</description>
                 <type>boolean</type>
                 <mandatory-flag>false</mandatory-flag>
@@ -293,7 +293,7 @@ Setting this preference replaces the first two segments, the final index name be
                 <attribute attribute-id="Algolia_EnableRecommend"/>
                 <attribute attribute-id="Algolia_EnablePricingLazyLoad"/>
                 <attribute attribute-id="Algolia_IndexOutOfStock"/>
-                <attribute attribute-id="Algolia_EnableRealTimeInventory"/>
+                <attribute attribute-id="Algolia_EnableRealTimeInventoryHook"/>
             </attribute-group>
         </group-definitions>
 

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -50,7 +50,7 @@ jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => {
                 : [];
         },
         getPreference: function (id) {
-            return id === 'InStockThreshold' ? 1 : null;
+            return id === 'InStockThreshold' ? 2 : null;
         }
     }
 }, {virtual: true});
@@ -65,59 +65,69 @@ jest.mock('*/cartridge/scripts/algolia/customization/productModelCustomizer', ()
 }, {virtual: true});
 
 // Mock for storeAvailability tests
-jest.mock('dw/object/SystemObjectMgr', () => {
+jest.mock('dw/catalog/StoreMgr', () => {
     const mockCollection = require('../../../../../mocks/dw/util/Collection');
-    return {
-        getAllSystemObjects: jest.fn().mockImplementation((objType) => {
-            if (objType === 'Store') {
-                const stores = [
-                    {
-                        ID: 'store1',
-                        inventoryList: {
-                            getRecord: jest.fn().mockImplementation((productId) => {
-                                if (productId === 'product-in-stock') {
-                                    return {
-                                        ATS: { value: 10 }
-                                    };
-                                } else if (productId === 'product-low-stock') {
-                                    return {
-                                        ATS: { value: 1 }
-                                    };
-                                } else if (productId === 'product-out-of-stock') {
-                                    return {
-                                        ATS: { value: 0 }
-                                    };
-                                }
-                                return null;
-                            })
-                        }
-                    },
-                    {
-                        ID: 'store2',
-                        inventoryList: {
-                            getRecord: jest.fn().mockImplementation((productId) => {
-                                if (productId === 'product-in-stock') {
-                                    return {
-                                        ATS: { value: 15 }
-                                    };
-                                } else if (productId === 'product-store2-only') {
-                                    return {
-                                        ATS: { value: 5 }
-                                    };
-                                }
-                                return null;
-                            })
-                        }
-                    },
-                    {
-                        // Store without inventory list
-                        ID: 'store3',
-                        inventoryList: null
+    const stores = [
+        {
+            ID: 'store1',
+            inventoryList: {
+                getRecord: jest.fn().mockImplementation((productId) => {
+                    if (productId === 'product-in-stock') {
+                        return {
+                            ATS: { value: 10 }
+                        };
+                    } else if (productId === 'product-low-stock') {
+                        return {
+                            ATS: { value: 1 }
+                        };
+                    } else if (productId === 'product-out-of-stock') {
+                        return {
+                            ATS: { value: 0 }
+                        };
                     }
-                ];
-                return new mockCollection(stores).iterator();
+                    return null;
+                })
             }
-            return null;
+        },
+        {
+            ID: 'store2',
+            inventoryList: {
+                getRecord: jest.fn().mockImplementation((productId) => {
+                    if (productId === 'product-in-stock') {
+                        return {
+                            ATS: { value: 15 }
+                        };
+                    } else if (productId === 'product-store2-only') {
+                        return {
+                            ATS: { value: 5 }
+                        };
+                    }
+                    return null;
+                })
+            }
+        },
+        {
+            // Store without inventory list
+            ID: 'store3',
+            inventoryList: null
+        }
+    ];
+    
+    // Create a map-like object with the same stores
+    const storeMap = {
+        empty: false,
+        keySet: function() {
+            return {
+                toArray: function() {
+                    return stores;
+                }
+            };
+        }
+    };
+    
+    return {
+        searchStoresByCoordinates: jest.fn().mockImplementation(() => {
+            return storeMap;
         })
     };
 }, { virtual: true });

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -66,7 +66,6 @@ jest.mock('*/cartridge/scripts/algolia/customization/productModelCustomizer', ()
 
 // Mock for storeAvailability tests
 jest.mock('dw/catalog/StoreMgr', () => {
-    const mockCollection = require('../../../../../mocks/dw/util/Collection');
     const stores = [
         {
             ID: 'store1',


### PR DESCRIPTION
# What is Changed

- Introduced the `afterPOST` hook to send inventory changes to Algolia upon order completion.
- Refactored store availability retrieval to use `StoreMgr` for consistency and storefront logic.
- Adjusted inventory check logic to include products with ATS values meeting the threshold.

# Testing (Only for variant record model)
- Update a product inventory with value 1 (or adjust it according to inventory threshold), Disable Index out-of-stock products, after order this product should be deleted
- Update a product inventory with value 1 (or adjust it according to inventory threshold), Enable Index out of stock products, after order this product `in_stock` value should be false
- Update a product's **store** inventory with value 1 (or adjust it according to inventory threshold), after order this product `storeAvailability` array values should be reflected with changes
