### PR TITLE
feat: Added Site Preferences/Metadata for real time inventory updates

### DIFF
--- a/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
+++ b/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
@@ -43,6 +43,7 @@ function handleSettings() {
         var algoliaEnableContentSearch = ('EnableContentSearch' in params) && (params.EnableContentSearch.submitted === true);
         var algoliaEnableRecommend = ('EnableRecommend' in params) && (params.EnableRecommend.submitted === true);
         var algoliaEnablePricingLazyLoad = ('EnablePricingLazyLoad' in params) && (params.EnablePricingLazyLoad.submitted === true);
+        var algoliaEnableRealTimeInventory = ('EnableRealTimeInventory' in params) && (params.EnableRealTimeInventory.submitted === true);
 
         // If the user typed an empty prefix, the cartridge logic eventually
         // uses the default <hostname>__<siteID>
@@ -85,6 +86,7 @@ function handleSettings() {
         algoliaData.setPreference('EnableRecommend', algoliaEnableRecommend);
         algoliaData.setPreference('EnablePricingLazyLoad', algoliaEnablePricingLazyLoad);
         algoliaData.setPreference('IndexOutOfStock', params.IndexOutOfStock.submitted);
+        algoliaData.setPreference('EnableRealTimeInventory', algoliaEnableRealTimeInventory);
     } catch (error) {
         Logger.error(error);
         showDashboardWithMessages(adminValidation, error.message);

--- a/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
+++ b/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
@@ -121,6 +121,18 @@
                     </td>
                 </tr>
 
+                <iscomment> Algolia_EnableRealTimeInventory </iscomment>
+                <tr>
+                    <td class="table_detail w s" colspan="1">
+                        <isprint value="${Resource.msg('algolia.label.preference.enablerealetimeinventory', 'algolia', null)}" />
+                        <i class="fa fa-info-circle dw-nc-text-info info-hover"></i>
+                        <div class="tooltip">${Resource.msg('algolia.label.preference.enablerealetimeinventory.help', 'algolia', null)}</div>
+                    </td>
+                    <td class="table_detail w e s">
+                        <input type="checkbox" ${pdict.algoliaData.getPreference('EnableRealTimeInventory') ? "checked": ""} id="EnableRealTimeInventory" name="EnableRealTimeInventory" />
+                    </td>
+                </tr>
+
                 <iscomment> Algolia_AdditionalAttributes </iscomment>
                 <tr>
                     <td class="table_detail w s" colspan="1">

--- a/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
+++ b/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
@@ -124,9 +124,9 @@
                 <iscomment> Algolia_EnableRealTimeInventory </iscomment>
                 <tr>
                     <td class="table_detail w s" colspan="1">
-                        <isprint value="${Resource.msg('algolia.label.preference.enablerealetimeinventory', 'algolia', null)}" />
+                        <isprint value="${Resource.msg('algolia.label.preference.enablerealtimeinventory', 'algolia', null)}" />
                         <i class="fa fa-info-circle dw-nc-text-info info-hover"></i>
-                        <div class="tooltip">${Resource.msg('algolia.label.preference.enablerealetimeinventory.help', 'algolia', null)}</div>
+                        <div class="tooltip">${Resource.msg('algolia.label.preference.enablerealtimeinventory.help', 'algolia', null)}</div>
                     </td>
                     <td class="table_detail w e s">
                         <input type="checkbox" ${pdict.algoliaData.getPreference('EnableRealTimeInventory') ? "checked": ""} id="EnableRealTimeInventory" name="EnableRealTimeInventory" />

--- a/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
+++ b/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
@@ -21,6 +21,7 @@ algolia.label.preference.enablecontentsearch=Enable content search
 algolia.label.preference.enablerecommend=Recommend
 algolia.label.preference.enablePricingLazyLoad=Lazy Loading for prices
 algolia.label.preference.indexoutofstock=Index out of stock products
+algolia.label.preference.enablerealetimeinventory=Enable Real Time Inventory
 algolia.label.preference.clientid=OCAPI Client ID
 algolia.label.preference.clientpassword=OCAPI Client password
 algolia.label.button.apply=Apply
@@ -44,7 +45,8 @@ algolia.label.preference.enablessr.help=Server-side rendering for SFRA's CLP (ca
 algolia.label.preference.enablecontentsearch.help=Enable Content Search on the storefront
 algolia.label.preference.enablerecommend.help=Enable Algolia Recommend on the SFRA storefront cartridge. See the documentation for additional setup steps
 algolia.label.preference.enablePricingLazyLoad.help=When enabled, prices are fetched from SFCC when search results are displayed. Permits to display the most up-to-date promotions without having to index them.
-algolia.label.preference.indexoutofstock.help=Index out of stock products. When disabled, only in-stock (ATS higher than the InStock Threshold) products are indexed. 
+algolia.label.preference.indexoutofstock.help=Index out of stock products. When disabled, only in-stock (ATS higher than the InStock Threshold) products are indexed.
+algolia.label.preference.enablerealetimeinventory.help=Sends inventory updates to Algolia in real-time after each order.
 
 # v2 job report table
 algolia.label.jobtype=job type:

--- a/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
+++ b/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
@@ -21,7 +21,7 @@ algolia.label.preference.enablecontentsearch=Enable content search
 algolia.label.preference.enablerecommend=Recommend
 algolia.label.preference.enablePricingLazyLoad=Lazy Loading for prices
 algolia.label.preference.indexoutofstock=Index out of stock products
-algolia.label.preference.enablerealetimeinventory=Enable Real Time Inventory
+algolia.label.preference.enablerealtimeinventory=Enable Real Time Inventory
 algolia.label.preference.clientid=OCAPI Client ID
 algolia.label.preference.clientpassword=OCAPI Client password
 algolia.label.button.apply=Apply
@@ -46,7 +46,7 @@ algolia.label.preference.enablecontentsearch.help=Enable Content Search on the s
 algolia.label.preference.enablerecommend.help=Enable Algolia Recommend on the SFRA storefront cartridge. See the documentation for additional setup steps
 algolia.label.preference.enablePricingLazyLoad.help=When enabled, prices are fetched from SFCC when search results are displayed. Permits to display the most up-to-date promotions without having to index them.
 algolia.label.preference.indexoutofstock.help=Index out of stock products. When disabled, only in-stock (ATS higher than the InStock Threshold) products are indexed.
-algolia.label.preference.enablerealetimeinventory.help=Sends inventory updates to Algolia in real-time after each order.
+algolia.label.preference.enablerealtimeinventory.help=Sends inventory updates to Algolia in real-time after each order.
 
 # v2 job report table
 algolia.label.jobtype=job type:


### PR DESCRIPTION
# What is Changed

- Added site preference for managing real-time inventory

**Note**: Next PR [here](https://github.com/algolia/algoliasearch-sfcc-b2c/pull/224).

