### PR TITLE
feat: Optimizing Browser Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         run: npm run lint:js
 
   e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     env:
       CODE_VERSION: ${{ vars.CODE_VERSION }}
       ALGOLIA_APP_ID: ${{ vars.ALGOLIA_APP_ID }}
@@ -97,8 +97,6 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y zip
           npm ci
 
       - name: Run E2E Tests


### PR DESCRIPTION
## What is Changed?
- Changed CI flow resource from Ubuntu to MacOS.

## Why do we need this?
- Currently, because of the Linux structure, browser tests are failing many times and are not stabil, and by changing it to MacOS, we increased resources and made the infrastructure more stable.
