### PR TITLE
feat: allow partial update for product level

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig.js
@@ -276,6 +276,10 @@ var attributeConfig_v2 = {
         localized: false,
         variantAttribute: true,
     },
+    variants: {
+        localized: true,
+        variantAttribute: false,
+    }
 };
 
 module.exports = {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -530,7 +530,7 @@ function algoliaLocalizedProduct(parameters) {
 
     request.setLocale(parameters.locale || 'default');
 
-    if (empty(product) || empty(attributeList)) {
+    if (empty(product)) {
         this.id = null;
     } else {
         if (parameters.isVariant) {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -104,6 +104,8 @@ exports.beforeStep = function(parameters, stepExecution) {
 
     /* --- attributeListOverride parameter --- */
     if (empty(paramAttributeListOverride)) {
+        variantAttributes = algoliaProductConfig.defaultVariantAttributes_v2.slice();
+        masterAttributes = algoliaProductConfig.defaultMasterAttributes_v2.slice();
         attributesToSend = algoliaProductConfig.defaultAttributes_v2.slice();
         const additionalAttributes = algoliaData.getSetOfArray('AdditionalAttributes');
         additionalAttributes.map(function(attribute) {
@@ -134,8 +136,6 @@ exports.beforeStep = function(parameters, stepExecution) {
 
 
     /* --- categorize attributes (master/variant, non-localized, shared) --- */
-    variantAttributes = algoliaProductConfig.defaultVariantAttributes_v2.slice();
-    masterAttributes = algoliaProductConfig.defaultMasterAttributes_v2.slice();
     attributesToSend.forEach(function(attribute) {
         var attributeConfig = extendedProductAttributesConfig[attribute] ||
             algoliaProductConfig.attributeConfig_v2[attribute] ||

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -90,6 +90,8 @@ exports.beforeStep = function(parameters, stepExecution) {
 
     /* --- attributeListOverride parameter --- */
     if (empty(paramAttributeListOverride)) {
+        variantAttributes = algoliaProductConfig.defaultVariantAttributes_v2.slice();
+        masterAttributes = algoliaProductConfig.defaultMasterAttributes_v2.slice();
         attributesToSend = algoliaProductConfig.defaultAttributes_v2.slice();
         const additionalAttributes = algoliaData.getSetOfArray('AdditionalAttributes');
         additionalAttributes.map(function(attribute) {
@@ -120,8 +122,6 @@ exports.beforeStep = function(parameters, stepExecution) {
     logger.info('Record model: ' + paramRecordModel);
 
     /* --- categorize attributes (master/variant, non-localized, shared) --- */
-    variantAttributes = algoliaProductConfig.defaultVariantAttributes_v2.slice();
-    masterAttributes = algoliaProductConfig.defaultMasterAttributes_v2.slice();
     attributesToSend.forEach(function(attribute) {
         var attributeConfig = extendedProductAttributesConfig[attribute] ||
             algoliaProductConfig.attributeConfig_v2[attribute] ||


### PR DESCRIPTION
The Base product record model stores all variation attributes in a `variants` array.

Algolia doesn't permits to update a specific properties in the objects of an array, so the `variants` array need to be recomputed entirely.
To prevent mistakes, we had initially chosen to block the `partialRecordUpdate` for the base product model.

But there are cases where users need to only update a few top level attributes of product records, for example if the records are updated from multiple indexing pipelines.

This PR removes this safeguard.

It also stop sending the default attributes when `attributeListOverride` is set.