### PR TITLE
feat: [SFCC-486][SFCC-487] Grouping logic and service file changes

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
@@ -1,5 +1,19 @@
 const logger = require('*/cartridge/scripts/algolia/helper/jobHelper').getAlgoliaLogger();
 
+const INDEXING_APIS = {
+    SEARCH_API: 'search-api',
+    INGESTION_API: 'ingestion-api',
+}
+
+const ANALYTICS_REGIONS = {
+    EU: 'eu',
+    US: 'us',
+}
+
+// TODO: make these into site preferences -- return analyticsRegion programmatically if possible - getIndexSettings?
+const indexingAPI = INDEXING_APIS.INGESTION_API;
+const analyticsRegion = ANALYTICS_REGIONS.EU;
+
 var algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
 var algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
 
@@ -105,16 +119,18 @@ function finishAtomicReindex(indexType, locales, lastIndexingTasks) {
 }
 
 /**
- * Sends an Algolia batch to the multi-indices batch endpoint.
+ * Sends an Algolia batch to either the multi-indices batch endpoint or the Ingestion push endpoint.
  * If records fail to be indexed (because e.g. they are too big), they are removed from the batch and the batch is retried.
  * @param {Object} batch - Algolia multi-indices batch
- * @return {{failedRecords: number}} returns an object with the last call result and the number of failed records.
+ * @param {String} [indexName] Target index -- only used with the Ingestion API
+ * @return {Object} returns an object with the last call result and the number of failed records.
  */
-function sendRetryableBatch(batch) {
+function sendRetryableBatch(batch, indexName) {
     var MAX_ATTEMPTS = 50;
     var attempt = 0;
     var failedRecords = 0;
-    var result = algoliaIndexingAPI.sendMultiIndexBatch(batch);
+    var result = algoliaIndexingAPI.sendPayload(batch, indexName);
+
     while (result.error && attempt < MAX_ATTEMPTS) {
         ++attempt;
         try {
@@ -122,7 +138,7 @@ function sendRetryableBatch(batch) {
             // When records are failing, Algolia returns the following (those are examples for records too big):
             // - For Classic: {"message":"Record at the position 6 objectID=008884303996M is too big size=11072/10000 bytes. Please have a look at [...]", "position":6,"objectID":"008884303996M","status":400}
             // - For Current: {"message":"Record 008884303996M is too big: size: 11072 byte(s), maximum allowed: 100000 byte(s). Please have a look at [...]","status":400}
-            if (!apiResponse.objectID && (!apiResponse.message || !apiResponse.message.indexOf('is too big') > 0)) {
+            if (!apiResponse.objectID && (!apiResponse.message || !(apiResponse.message.indexOf('is too big') > 0))) {
                 // No identified objectID, and not an "is too big" error. Nothing else to do
                 break;
             }
@@ -137,6 +153,9 @@ function sendRetryableBatch(batch) {
             }
             logger.info('[Retryable batch] Removing records for product "' + objectIdToRemove + '"');
             var removedRecords = 0;
+
+            // TODO: adapt this logic to be able to work with Ingestion payloads as well
+
             for (var i = batch.length - 1; i >= 0; --i) {
                 if (batch[i].body.objectID === objectIdToRemove) {
                     batch.splice(i, 1);
@@ -149,7 +168,7 @@ function sendRetryableBatch(batch) {
                 break;
             }
             logger.info('[Retryable batch] Removed ' + removedRecords + ' records. Retrying batch...');
-            result = algoliaIndexingAPI.sendMultiIndexBatch(batch);
+            result = algoliaIndexingAPI.sendPayload(batch, indexName);
         } catch(e) {
             // Error message is not JSON, ignoring
             logger.error('[Retryable batch] Error while parsing response: ' + e.message);
@@ -165,10 +184,82 @@ function sendRetryableBatch(batch) {
     }
 }
 
+/**
+ * Groups payload records by index name and action to build ingestion API batches.
+ * Example sortedPayloads:
+ * sortedPayloads = {
+ *     'indexName1': {
+ *         'addObject': [
+ *             { <recordBody10> }, { <recordBody11> }, ...
+ *         ],
+ *         'deleteObject': [
+ *             { <recordBody20> }, { <recordBody21> }, ...
+ *         ],
+ *         ...
+ *     },
+ *     'indexName2': { ... },
+ *     ...
+ * }
+ * @param {Object[]} payloadArray - Payload entries with `action` and `records`.
+ * @returns {Object} Result from the batch send operation.
+ */
+function groupPayloadsForIngestionAPI(payloadArray) {
+
+    let sortedPayloads = {};
+    let result;
+    let failedRecords = 0;
+
+    // sort records by indexName and action
+    for (let i = 0; i < payloadArray.length; i ++) {
+        let currentObject = payloadArray[i];
+        let indexName = currentObject.indexName;
+        let action = currentObject.action;
+
+        if (empty(sortedPayloads[indexName])) {
+            sortedPayloads[indexName] = {};
+        }
+
+        if (empty(sortedPayloads[indexName][action])) {
+            sortedPayloads[indexName][action] = [];
+        }
+
+        sortedPayloads[indexName][action].push(currentObject.body);
+    }
+
+   let indices = Object.keys(sortedPayloads);
+
+    // iterate over the sorted batches by indexName and action, and send them
+    for (let i = 0; i < indices.length; i++) {
+        let indexName = indices[i];
+        let index = sortedPayloads[indexName];
+        let actions = Object.keys(index);
+
+        for (let j = 0; j < actions.length; j++) {
+            let action = actions[j];
+            let records = index[action];
+
+            let payloadToSend = {
+                action: action,
+                records: records,
+            }
+
+            result = sendRetryableBatch(payloadToSend, indexName);
+            failedRecords += result.failedRecords;
+            if (!(result.ok)) {
+                break;
+            }
+        }
+    }
+
+    // returns the last OK result or the first failed one -- since we only need the OK/NOK from it, it's representative of the entire batch
+    return result;
+}
+
 module.exports.deleteTemporaryIndices = deleteTemporaryIndices;
 module.exports.finishAtomicReindex = finishAtomicReindex;
 module.exports.waitForTasks = waitForTasks;
 module.exports.sendRetryableBatch = sendRetryableBatch;
+module.exports.groupPayloadsForIngestionAPI = groupPayloadsForIngestionAPI;
 
 // For unit testing
 module.exports.copySettingsFromProdIndices = copySettingsFromProdIndices;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
@@ -1,19 +1,5 @@
 const logger = require('*/cartridge/scripts/algolia/helper/jobHelper').getAlgoliaLogger();
 
-const INDEXING_APIS = {
-    SEARCH_API: 'search-api',
-    INGESTION_API: 'ingestion-api',
-}
-
-const ANALYTICS_REGIONS = {
-    EU: 'eu',
-    US: 'us',
-}
-
-// TODO: make these into site preferences -- return analyticsRegion programmatically if possible - getIndexSettings?
-const indexingAPI = INDEXING_APIS.INGESTION_API;
-const analyticsRegion = ANALYTICS_REGIONS.EU;
-
 var algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
 var algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
 
@@ -119,7 +105,7 @@ function finishAtomicReindex(indexType, locales, lastIndexingTasks) {
 }
 
 /**
- * Sends an Algolia batch to either the multi-indices batch endpoint or the Ingestion push endpoint.
+ * Sends an Algolia batch to either the Search API `multiple-batch` endpoint or the Ingestion API `push by indexName` endpoint.
  * If records fail to be indexed (because e.g. they are too big), they are removed from the batch and the batch is retried.
  * @param {Object} batch - Algolia multi-indices batch
  * @param {String} [indexName] Target index -- only used with the Ingestion API
@@ -226,7 +212,7 @@ function groupPayloadsForIngestionAPI(payloadArray) {
         sortedPayloads[indexName][action].push(currentObject.body);
     }
 
-   let indices = Object.keys(sortedPayloads);
+    let indices = Object.keys(sortedPayloads);
 
     // iterate over the sorted batches by indexName and action, and send them
     for (let i = 0; i < indices.length; i++) {
@@ -252,6 +238,7 @@ function groupPayloadsForIngestionAPI(payloadArray) {
     }
 
     // returns the last OK result or the first failed one -- since we only need the OK/NOK from it, it's representative of the entire batch
+    result.failedRecords = failedRecords;
     return result;
 }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper.js
@@ -1,7 +1,7 @@
 const logger = require('*/cartridge/scripts/algolia/helper/jobHelper').getAlgoliaLogger();
 
-var algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
-var algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
+const algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
+const algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
 
 /**
  * Delete the temporary indices corresponding to the given type and locales
@@ -104,149 +104,9 @@ function finishAtomicReindex(indexType, locales, lastIndexingTasks) {
     moveTemporaryIndices(indexType, locales);
 }
 
-/**
- * Sends an Algolia batch to either the Search API `multiple-batch` endpoint or the Ingestion API `push by indexName` endpoint.
- * If records fail to be indexed (because e.g. they are too big), they are removed from the batch and the batch is retried.
- * @param {Object} batch - Algolia multi-indices batch
- * @param {String} [indexName] Target index -- only used with the Ingestion API
- * @return {Object} returns an object with the last call result and the number of failed records.
- */
-function sendRetryableBatch(batch, indexName) {
-    var MAX_ATTEMPTS = 50;
-    var attempt = 0;
-    var failedRecords = 0;
-    var result = algoliaIndexingAPI.sendPayload(batch, indexName);
-
-    while (result.error && attempt < MAX_ATTEMPTS) {
-        ++attempt;
-        try {
-            var apiResponse = JSON.parse(result.getErrorMessage());
-            // When records are failing, Algolia returns the following (those are examples for records too big):
-            // - For Classic: {"message":"Record at the position 6 objectID=008884303996M is too big size=11072/10000 bytes. Please have a look at [...]", "position":6,"objectID":"008884303996M","status":400}
-            // - For Current: {"message":"Record 008884303996M is too big: size: 11072 byte(s), maximum allowed: 100000 byte(s). Please have a look at [...]","status":400}
-            if (!apiResponse.objectID && (!apiResponse.message || !(apiResponse.message.indexOf('is too big') > 0))) {
-                // No identified objectID, and not an "is too big" error. Nothing else to do
-                break;
-            }
-            var objectIdToRemove;
-            if (apiResponse.objectID) {
-                objectIdToRemove = apiResponse.objectID
-            } else {
-                var match = apiResponse.message.match(/^Record (.*) is too big/);
-                if (match) {
-                    objectIdToRemove = match[1];
-                }
-            }
-            logger.info('[Retryable batch] Removing records for product "' + objectIdToRemove + '"');
-            var removedRecords = 0;
-
-            // TODO: adapt this logic to be able to work with Ingestion payloads as well
-
-            for (var i = batch.length - 1; i >= 0; --i) {
-                if (batch[i].body.objectID === objectIdToRemove) {
-                    batch.splice(i, 1);
-                    failedRecords++;
-                    removedRecords++;
-                }
-            }
-            if (removedRecords === 0) {
-                logger.warn('[Retryable batch] could not remove any record. Not retrying the batch.');
-                break;
-            }
-            logger.info('[Retryable batch] Removed ' + removedRecords + ' records. Retrying batch...');
-            result = algoliaIndexingAPI.sendPayload(batch, indexName);
-        } catch(e) {
-            // Error message is not JSON, ignoring
-            logger.error('[Retryable batch] Error while parsing response: ' + e.message);
-            break;
-        }
-    }
-    if (attempt === MAX_ATTEMPTS) {
-        logger.error('[Retryable batch] Too many products are in error, aborting the batch...');
-    }
-    return {
-        result: result,
-        failedRecords: failedRecords,
-    }
-}
-
-/**
- * Groups payload records by index name and action to build ingestion API batches.
- * Example sortedPayloads:
- * sortedPayloads = {
- *     'indexName1': {
- *         'addObject': [
- *             { <recordBody10> }, { <recordBody11> }, ...
- *         ],
- *         'deleteObject': [
- *             { <recordBody20> }, { <recordBody21> }, ...
- *         ],
- *         ...
- *     },
- *     'indexName2': { ... },
- *     ...
- * }
- * @param {Object[]} payloadArray - Payload entries with `action` and `records`.
- * @returns {Object} Result from the batch send operation.
- */
-function groupPayloadsForIngestionAPI(payloadArray) {
-
-    let sortedPayloads = {};
-    let result;
-    let failedRecords = 0;
-
-    // sort records by indexName and action
-    for (let i = 0; i < payloadArray.length; i ++) {
-        let currentObject = payloadArray[i];
-        let indexName = currentObject.indexName;
-        let action = currentObject.action;
-
-        if (empty(sortedPayloads[indexName])) {
-            sortedPayloads[indexName] = {};
-        }
-
-        if (empty(sortedPayloads[indexName][action])) {
-            sortedPayloads[indexName][action] = [];
-        }
-
-        sortedPayloads[indexName][action].push(currentObject.body);
-    }
-
-    let indices = Object.keys(sortedPayloads);
-
-    // iterate over the sorted batches by indexName and action, and send them
-    for (let i = 0; i < indices.length; i++) {
-        let indexName = indices[i];
-        let index = sortedPayloads[indexName];
-        let actions = Object.keys(index);
-
-        for (let j = 0; j < actions.length; j++) {
-            let action = actions[j];
-            let records = index[action];
-
-            let payloadToSend = {
-                action: action,
-                records: records,
-            }
-
-            result = sendRetryableBatch(payloadToSend, indexName);
-            failedRecords += result.failedRecords;
-            if (!(result.ok)) {
-                break;
-            }
-        }
-    }
-
-    // returns the last OK result or the first failed one -- since we only need the OK/NOK from it, it's representative of the entire batch
-    result.failedRecords = failedRecords;
-    return result;
-}
-
 module.exports.deleteTemporaryIndices = deleteTemporaryIndices;
 module.exports.finishAtomicReindex = finishAtomicReindex;
 module.exports.waitForTasks = waitForTasks;
-module.exports.sendRetryableBatch = sendRetryableBatch;
-module.exports.groupPayloadsForIngestionAPI = groupPayloadsForIngestionAPI;
 
 // For unit testing
 module.exports.copySettingsFromProdIndices = copySettingsFromProdIndices;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper.js
@@ -4,7 +4,8 @@ const algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
 /* --------------------------- Search API methods --------------------------- */
 
 /**
- * Sends an Algolia batch to either the Search API `multiple-batch` endpoint or the Ingestion API `push by indexName` endpoint.
+ * Sends an Algolia batch to the Search API `multiple-batch` endpoint
+ * https://www.algolia.com/doc/rest-api/search/multiple-batch
  * If records fail to be indexed (because e.g. they are too big), they are removed from the batch and the batch is retried.
  * @param {Object} batch - Algolia multi-indices batch
  * @param {String} [indexName] Target index -- only used with the Ingestion API
@@ -70,9 +71,36 @@ function sendRetryableBatch(batch) {
 /* --------------------------- Ingestion API methods --------------------------- */
 
 /**
- * Groups payload records by index name and action to build ingestion API batches.
+ * Groups records to be sent by index name and action to build ingestion API batches.
+ * The "deleteObject" action is currently only used with the algoliaProductDeltaIndex job
+ * and the real-time inventory update feature.
+ * Example input:
+ *  recordArray = [
+ *      {
+ *          action: "addObject",
+ *          body: {
+ *              defaultVariantID: "...",
+ *              image_groups: "[{ ... }, { ... }]",
+ *              masterID: "...",
+ *              name: "...",
+ *              objectID: "...",
+ *              short_description: "..."
+ *              variants: [{ ... }, { ... }],
+ *              ... any other record properties configured in BM ...
+ *          },
+ *          indexName: "...",
+ *      },
+ *      {
+ *          action: "deleteObject",
+ *          body: {
+ *              objectID: "..."
+ *          },
+ *          indexName: "...",
+ *      },
+ *      ...
+ *  ]
  * Example return object:
- * groupedPayloads = {
+ *  groupedRecords = {
  *     'indexName1': {
  *         'addObject': [
  *             { <recordBody10> }, { <recordBody11> }, ...
@@ -84,62 +112,62 @@ function sendRetryableBatch(batch) {
  *     },
  *     'indexName2': { ... },
  *     ...
- * }
- * @param {Object[]} payloadArray - Payload entries with `action` and `records`.
+ *  }
+ * @param {Object[]} recordArray - record entries with `action` and `records`.
  * @returns {Object} object containing records grouped by target index and action
  */
-function groupPayloadsForIngestionAPI(payloadArray) {
+function groupRecordsForIngestionAPI(recordArray) {
 
-    let groupedPayloads = {};
+    let groupedRecords = {};
 
     // group records by indexName and action
-    for (let i = 0; i < payloadArray.length; i ++) {
-        let currentObject = payloadArray[i];
+    for (let i = 0; i < recordArray.length; i ++) {
+        let currentObject = recordArray[i];
         let indexName = currentObject.indexName;
         let action = currentObject.action;
 
-        if (empty(groupedPayloads[indexName])) {
-            groupedPayloads[indexName] = {};
+        if (empty(groupedRecords[indexName])) {
+            groupedRecords[indexName] = {};
         }
 
-        if (empty(groupedPayloads[indexName][action])) {
-            groupedPayloads[indexName][action] = [];
+        if (empty(groupedRecords[indexName][action])) {
+            groupedRecords[indexName][action] = [];
         }
 
-        groupedPayloads[indexName][action].push(currentObject.body);
+        groupedRecords[indexName][action].push(currentObject.body);
     }
 
-    return groupedPayloads;
+    return groupedRecords;
 }
 
 /**
- * Sends Ingestion API payloads grouped by indexName and action
- * @param {Object} groupedPayloads - Records grouped by `indexName` and `action`.
+ * Sends Algolia records to the Ingestion API grouped by indexName and action
+ * @param {Object} groupedRecords - Records grouped by `indexName` and `action`.
  * @returns {Object} result object containing status and number of failed records
  */
-function sendGroupedIngestionAPIPayloads(groupedPayloads) {
-    let indices = Object.keys(groupedPayloads);
+function sendGroupedIngestionAPIRecords(groupedRecords) {
+    let indices = Object.keys(groupedRecords);
     let failedRecords = 0;
     let wasThereAnError = false;
 
     // iterate over the grouped batches by indexName and action, and send them
     for (let i = 0; i < indices.length; i++) {
         let indexName = indices[i];
-        let index = groupedPayloads[indexName];
+        let index = groupedRecords[indexName];
         let actions = Object.keys(index);
 
         for (let j = 0; j < actions.length; j++) {
             let action = actions[j];
 
-            let payloadToSend = {
+            let recordToSend = {
                 action: action,
                 records: index[action],
             }
 
-            let result = algoliaIndexingAPI.pushByIndexName(payloadToSend, indexName);
+            let result = algoliaIndexingAPI.pushByIndexName(recordToSend, indexName);
             if (!(result.ok)) {
                 wasThereAnError = true;
-                failedRecords += payloadToSend.records.length;
+                failedRecords += recordToSend.records.length;
             }
         }
     }
@@ -154,5 +182,5 @@ function sendGroupedIngestionAPIPayloads(groupedPayloads) {
 
 
 module.exports.sendRetryableBatch = sendRetryableBatch;
-module.exports.groupPayloadsForIngestionAPI = groupPayloadsForIngestionAPI;
-module.exports.sendGroupedIngestionAPIPayloads = sendGroupedIngestionAPIPayloads;
+module.exports.groupRecordsForIngestionAPI = groupRecordsForIngestionAPI;
+module.exports.sendGroupedIngestionAPIRecords = sendGroupedIngestionAPIRecords;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper.js
@@ -1,0 +1,158 @@
+const logger = require('*/cartridge/scripts/algolia/helper/jobHelper').getAlgoliaLogger();
+const algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
+
+/* --------------------------- Search API methods --------------------------- */
+
+/**
+ * Sends an Algolia batch to either the Search API `multiple-batch` endpoint or the Ingestion API `push by indexName` endpoint.
+ * If records fail to be indexed (because e.g. they are too big), they are removed from the batch and the batch is retried.
+ * @param {Object} batch - Algolia multi-indices batch
+ * @param {String} [indexName] Target index -- only used with the Ingestion API
+ * @return {Object} returns an object with the last call result and the number of failed records.
+ */
+function sendRetryableBatch(batch) {
+    var MAX_ATTEMPTS = 50;
+    var attempt = 0;
+    var failedRecords = 0;
+    let result = algoliaIndexingAPI.sendMultiIndexBatch(batch);
+
+    while (result.error && attempt < MAX_ATTEMPTS) {
+        ++attempt;
+        try {
+            var apiResponse = JSON.parse(result.getErrorMessage());
+            // When records are failing, Algolia returns the following (those are examples for records too big):
+            // - For Classic: {"message":"Record at the position 6 objectID=008884303996M is too big size=11072/10000 bytes. Please have a look at [...]", "position":6,"objectID":"008884303996M","status":400}
+            // - For Current: {"message":"Record 008884303996M is too big: size: 11072 byte(s), maximum allowed: 100000 byte(s). Please have a look at [...]","status":400}
+            if (!apiResponse.objectID && (!apiResponse.message || !(apiResponse.message.indexOf('is too big') > 0))) {
+                // No identified objectID, and not an "is too big" error. Nothing else to do
+                break;
+            }
+            var objectIdToRemove;
+            if (apiResponse.objectID) {
+                objectIdToRemove = apiResponse.objectID
+            } else {
+                var match = apiResponse.message.match(/^Record (.*) is too big/);
+                if (match) {
+                    objectIdToRemove = match[1];
+                }
+            }
+            logger.info('[Retryable batch] Removing records for product "' + objectIdToRemove + '"');
+            var removedRecords = 0;
+
+            for (var i = batch.length - 1; i >= 0; --i) {
+                if (batch[i].body.objectID === objectIdToRemove) {
+                    batch.splice(i, 1);
+                    failedRecords++;
+                    removedRecords++;
+                }
+            }
+            if (removedRecords === 0) {
+                logger.warn('[Retryable batch] could not remove any record. Not retrying the batch.');
+                break;
+            }
+            logger.info('[Retryable batch] Removed ' + removedRecords + ' records. Retrying batch...');
+            result = algoliaIndexingAPI.sendMultiIndexBatch(batch);
+        } catch(e) {
+            // Error message is not JSON, ignoring
+            logger.error('[Retryable batch] Error while parsing response: ' + e.message);
+            break;
+        }
+    }
+    if (attempt === MAX_ATTEMPTS) {
+        logger.error('[Retryable batch] Too many products are in error, aborting the batch...');
+    }
+    return {
+        result: result,
+        failedRecords: failedRecords,
+    }
+}
+
+/* --------------------------- Ingestion API methods --------------------------- */
+
+/**
+ * Groups payload records by index name and action to build ingestion API batches.
+ * Example return object:
+ * groupedPayloads = {
+ *     'indexName1': {
+ *         'addObject': [
+ *             { <recordBody10> }, { <recordBody11> }, ...
+ *         ],
+ *         'deleteObject': [
+ *             { <recordBody20> }, { <recordBody21> }, ...
+ *         ],
+ *         ...
+ *     },
+ *     'indexName2': { ... },
+ *     ...
+ * }
+ * @param {Object[]} payloadArray - Payload entries with `action` and `records`.
+ * @returns {Object} object containing records grouped by target index and action
+ */
+function groupPayloadsForIngestionAPI(payloadArray) {
+
+    let groupedPayloads = {};
+
+    // group records by indexName and action
+    for (let i = 0; i < payloadArray.length; i ++) {
+        let currentObject = payloadArray[i];
+        let indexName = currentObject.indexName;
+        let action = currentObject.action;
+
+        if (empty(groupedPayloads[indexName])) {
+            groupedPayloads[indexName] = {};
+        }
+
+        if (empty(groupedPayloads[indexName][action])) {
+            groupedPayloads[indexName][action] = [];
+        }
+
+        groupedPayloads[indexName][action].push(currentObject.body);
+    }
+
+    return groupedPayloads;
+}
+
+/**
+ * Sends Ingestion API payloads grouped by indexName and action
+ * @param {Object} groupedPayloads - Records grouped by `indexName` and `action`.
+ * @returns {Object} result object containing status and number of failed records
+ */
+function sendGroupedIngestionAPIPayloads(groupedPayloads) {
+    let indices = Object.keys(groupedPayloads);
+    let failedRecords = 0;
+    let wasThereAnError = false;
+
+    // iterate over the grouped batches by indexName and action, and send them
+    for (let i = 0; i < indices.length; i++) {
+        let indexName = indices[i];
+        let index = groupedPayloads[indexName];
+        let actions = Object.keys(index);
+
+        for (let j = 0; j < actions.length; j++) {
+            let action = actions[j];
+
+            let payloadToSend = {
+                action: action,
+                records: index[action],
+            }
+
+            let result = algoliaIndexingAPI.pushByIndexName(payloadToSend, indexName);
+            if (!(result.ok)) {
+                wasThereAnError = true;
+                failedRecords += payloadToSend.records.length;
+            }
+        }
+    }
+
+    return {
+        result: {
+            ok: !wasThereAnError,
+        },
+        failedRecords: failedRecords,
+    }
+}
+
+
+module.exports.sendRetryableBatch = sendRetryableBatch;
+module.exports.groupPayloadsForIngestionAPI = groupPayloadsForIngestionAPI;
+module.exports.sendGroupedIngestionAPIPayloads = sendGroupedIngestionAPIPayloads;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/retryStrategy.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/retryStrategy.js
@@ -49,7 +49,7 @@ StatefulHost.prototype.reset = function() {
  */
 function initHosts() {
     switch (indexingAPI) {
-        case INDEXING_APIS.SEARCH_API:
+        case INDEXING_APIS.SEARCH_API: {
             const appID = algoliaData.getPreference('ApplicationID');
             statefulhosts = [
                 new StatefulHost(appID + '.algolia.net'),
@@ -58,15 +58,14 @@ function initHosts() {
                 new StatefulHost(appID + '-3.algolianet.com'),
             ]
             break;
-
-        case INDEXING_APIS.INGESTION_API:
+        }
+        case INDEXING_APIS.INGESTION_API: {
             statefulhosts = [
                 new StatefulHost('data.' + analyticsRegion + '.algolia.com'),
             ]
             break;
+        }
     }
-
-
 }
 
 /**

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/retryStrategy.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/retryStrategy.js
@@ -2,6 +2,7 @@ const Result = require('dw/svc/Result')
 const Logger = require('dw/system/Logger');
 
 const algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
+const appID = algoliaData.getPreference('ApplicationID');
 
 const EXPIRATION_DELAY = 5 * 60 * 1000;
 
@@ -16,7 +17,7 @@ const ANALYTICS_REGIONS = {
 }
 
 // TODO: make these into site preferences -- return analyticsRegion programmatically if possible - getIndexSettings?
-const indexingAPI = INDEXING_APIS.INGESTION_API;
+let indexingAPI = INDEXING_APIS.INGESTION_API;
 const analyticsRegion = ANALYTICS_REGIONS.EU;
 
 let statefulhosts;
@@ -50,7 +51,6 @@ StatefulHost.prototype.reset = function() {
 function initHosts() {
     switch (indexingAPI) {
         case INDEXING_APIS.SEARCH_API: {
-            const appID = algoliaData.getPreference('ApplicationID');
             statefulhosts = [
                 new StatefulHost(appID + '.algolia.net'),
                 new StatefulHost(appID + '-1.algolianet.com'),
@@ -161,3 +161,5 @@ module.exports.StatefulHost = StatefulHost;
 module.exports.initHosts = initHosts;
 module.exports.getAvailableHosts = getAvailableHosts;
 module.exports.isRetryable = isRetryable;
+module.exports._INDEXING_APIS = INDEXING_APIS;
+module.exports._setIndexingAPI = function(api) { indexingAPI = api; };

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/retryStrategy.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/retryStrategy.js
@@ -5,6 +5,20 @@ const algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
 
 const EXPIRATION_DELAY = 5 * 60 * 1000;
 
+const INDEXING_APIS = {
+    SEARCH_API: 'search-api',
+    INGESTION_API: 'ingestion-api',
+}
+
+const ANALYTICS_REGIONS = {
+    EU: 'eu',
+    US: 'us',
+}
+
+// TODO: make these into site preferences -- return analyticsRegion programmatically if possible - getIndexSettings?
+const indexingAPI = INDEXING_APIS.INGESTION_API;
+const analyticsRegion = ANALYTICS_REGIONS.EU;
+
 let statefulhosts;
 
 /**
@@ -34,13 +48,25 @@ StatefulHost.prototype.reset = function() {
  * Initialize the default hosts, based on the 'ApplicationID' custom preference
  */
 function initHosts() {
-    const appID = algoliaData.getPreference('ApplicationID')
-    statefulhosts = [
-        new StatefulHost(appID + '.algolia.net'),
-        new StatefulHost(appID + '-1.algolianet.com'),
-        new StatefulHost(appID + '-2.algolianet.com'),
-        new StatefulHost(appID + '-3.algolianet.com'),
-    ]
+    switch (indexingAPI) {
+        case INDEXING_APIS.SEARCH_API:
+            const appID = algoliaData.getPreference('ApplicationID');
+            statefulhosts = [
+                new StatefulHost(appID + '.algolia.net'),
+                new StatefulHost(appID + '-1.algolianet.com'),
+                new StatefulHost(appID + '-2.algolianet.com'),
+                new StatefulHost(appID + '-3.algolianet.com'),
+            ]
+            break;
+
+        case INDEXING_APIS.INGESTION_API:
+            statefulhosts = [
+                new StatefulHost('data.' + analyticsRegion + '.algolia.com'),
+            ]
+            break;
+    }
+
+
 }
 
 /**
@@ -118,7 +144,7 @@ function retryableCall(service, requestParams) {
         }
 
         Logger.error('Request error on ' + statefulhost.hostname + ': ' +
-          result.getError() + ' - ' + result.getErrorMessage());
+            result.getError() + ' - ' + result.getErrorMessage());
         if (!isTimeoutError(result)) {
             Logger.info('Marking host ' + statefulhost.hostname + ' down.');
             statefulhost.markDown();

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
@@ -41,6 +41,7 @@ function runCategoryExport(parameters, stepExecution) {
     const algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
     const jobHelper = require('*/cartridge/scripts/algolia/helper/jobHelper');
     const reindexHelper = require('*/cartridge/scripts/algolia/helper/reindexHelper');
+    const requestHelper = require('*/cartridge/scripts/algolia/helper/requestHelper');
     const algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
     const AlgoliaJobReport = require('*/cartridge/scripts/algolia/helper/AlgoliaJobReport');
     const logger = jobHelper.getAlgoliaLogger();
@@ -122,7 +123,7 @@ function runCategoryExport(parameters, stepExecution) {
 
         var result;
         try {
-            var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
+            var retryableBatchRes = requestHelper.sendRetryableBatch(batch);
             result = retryableBatchRes.result;
             jobReport.recordsFailed += retryableBatchRes.failedRecords;
         } catch (e) {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
@@ -9,7 +9,7 @@ var logger;
 var paramAttributeList, paramFailureThresholdPercentage, includedContent, paramLocalesForIndexing;
 
 // Algolia requires
-var algoliaData, AlgoliaLocalizedContent, jobHelper, reindexHelper, algoliaIndexingAPI, AlgoliaJobReport, algoliaSplitter, algoliaContentConfig, ContentUtil;
+var algoliaData, AlgoliaLocalizedContent, jobHelper, reindexHelper, requestHelper, algoliaIndexingAPI, AlgoliaJobReport, algoliaSplitter, algoliaContentConfig, ContentUtil;
 var indexingOperation;
 
 // logging-related variables
@@ -29,6 +29,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     AlgoliaLocalizedContent = require('*/cartridge/scripts/algolia/model/algoliaLocalizedContent');
     jobHelper = require('*/cartridge/scripts/algolia/helper/jobHelper');
     reindexHelper = require('*/cartridge/scripts/algolia/helper/reindexHelper');
+    requestHelper = require('*/cartridge/scripts/algolia/helper/requestHelper');
     algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
     logger = jobHelper.getAlgoliaLogger();
     algoliaContentConfig = require('*/cartridge/scripts/algolia/lib/algoliaContentConfig');
@@ -220,7 +221,7 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
 
     var result;
     try {
-        var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
+        var retryableBatchRes = requestHelper.sendRetryableBatch(batch);
         result = retryableBatchRes.result;
         jobReport.recordsFailed += retryableBatchRes.failedRecords;
     } catch (e) {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -12,7 +12,7 @@ var recordModel;
 
 // Algolia requires
 var algoliaData, AlgoliaLocalizedProduct, algoliaProductConfig, algoliaIndexingAPI, productFilter, CPObjectIterator, AlgoliaJobReport;
-var fileHelper, jobHelper, reindexHelper;
+var fileHelper, jobHelper, requestHelper;
 
 // logging-related variables and constants
 var jobReport;
@@ -42,7 +42,7 @@ const INDEXING_APIS = {
 }
 
 // TODO: make these into site preferences -- return analyticsRegion programmatically if possible - getIndexSettings?
-const indexingAPI = INDEXING_APIS.INGESTION_API;
+let indexingAPI = INDEXING_APIS.INGESTION_API;
 
 // Algolia preferences
 var ALGOLIA_IN_STOCK_THRESHOLD;
@@ -80,7 +80,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     algoliaProductConfig = require('*/cartridge/scripts/algolia/lib/algoliaProductConfig');
     jobHelper = require('*/cartridge/scripts/algolia/helper/jobHelper');
     fileHelper = require('*/cartridge/scripts/algolia/helper/fileHelper');
-    reindexHelper = require('*/cartridge/scripts/algolia/helper/reindexHelper');
+    requestHelper = require('*/cartridge/scripts/algolia/helper/requestHelper');
     algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
     logger = jobHelper.getAlgoliaLogger();
     productFilter = require('*/cartridge/scripts/algolia/filters/productFilter');
@@ -617,22 +617,27 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
 
     let resultObj;
     switch (indexingAPI) {
-        case INDEXING_APIS.SEARCH_API:
-            resultObj = reindexHelper.sendRetryableBatch(batch);
+        case INDEXING_APIS.SEARCH_API: {
+            resultObj = requestHelper.sendRetryableBatch(batch);
             break;
-        case INDEXING_APIS.INGESTION_API:
-            resultObj = reindexHelper.groupPayloadsForIngestionAPI(batch);
+        }
+        case INDEXING_APIS.INGESTION_API: {
+            let sortedPayloads = requestHelper.groupPayloadsForIngestionAPI(batch);
+            resultObj = requestHelper.sendGroupedIngestionAPIPayloads(sortedPayloads);
             break;
+        }
     }
 
-    var result = resultObj.result;
+    // recordsFailed count is not necessarily accurate when using the Ingestion API
+    // An OK response from a sending call only means that the endpoint received the payload;
+    // "record too large" or other indexing-time errors can still happen -- check your Algolia Dashboard for these errors
+    let result = resultObj.result;
     jobReport.recordsFailed += resultObj.failedRecords;
 
     if (result.ok) {
         jobReport.recordsSent += batch.length;
         jobReport.chunksSent++;
     } else {
-        jobReport.recordsFailed += batch.length;
         jobReport.chunksFailed++;
     }
 }
@@ -699,3 +704,5 @@ exports.__getJobReport = function() {
 exports.__getLocalesForIndexing = function() {
     return siteLocales.toArray();
 }
+exports.__INDEXING_APIS = INDEXING_APIS;
+exports.__setIndexingAPI = function(api) { indexingAPI = api; }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -622,8 +622,8 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
             break;
         }
         case INDEXING_APIS.INGESTION_API: {
-            let sortedPayloads = requestHelper.groupPayloadsForIngestionAPI(batch);
-            resultObj = requestHelper.sendGroupedIngestionAPIPayloads(sortedPayloads);
+            let sortedRecords = requestHelper.groupRecordsForIngestionAPI(batch);
+            resultObj = requestHelper.sendGroupedIngestionAPIRecords(sortedRecords);
             break;
         }
     }
@@ -638,6 +638,7 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
         jobReport.recordsSent += batch.length;
         jobReport.chunksSent++;
     } else {
+        jobReport.recordsFailed += batch.length;
         jobReport.chunksFailed++;
     }
 }
@@ -671,7 +672,7 @@ exports.afterStep = function(success, parameters, stepExecution) {
 
             // cleanup: after the products have successfully been sent, move the delta zips from which the productIDs have successfully been extracted and the corresponding products sent to "_completed"
             if (!empty(deltaExportZips)) {
-                logger.info('Moving the Delta export files to the "_completed" directory...')
+                logger.info('Moving the Delta export files to the "_completed" directory...');
                 fileHelper.moveDeltaExportFiles(deltaExportZips, l0_deltaExportDir, l1_completedDir);
             }
         } else {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -41,14 +41,8 @@ const INDEXING_APIS = {
     INGESTION_API: 'ingestion-api',
 }
 
-const ANALYTICS_REGIONS = {
-    EU: 'eu',
-    US: 'us',
-}
-
 // TODO: make these into site preferences -- return analyticsRegion programmatically if possible - getIndexSettings?
 const indexingAPI = INDEXING_APIS.INGESTION_API;
-const analyticsRegion = ANALYTICS_REGIONS.EU;
 
 // Algolia preferences
 var ALGOLIA_IN_STOCK_THRESHOLD;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -36,6 +36,20 @@ const RECORD_MODEL_TYPE = {
     ATTRIBUTE_SLICED: 'attribute-sliced',
 }
 
+const INDEXING_APIS = {
+    SEARCH_API: 'search-api',
+    INGESTION_API: 'ingestion-api',
+}
+
+const ANALYTICS_REGIONS = {
+    EU: 'eu',
+    US: 'us',
+}
+
+// TODO: make these into site preferences -- return analyticsRegion programmatically if possible - getIndexSettings?
+const indexingAPI = INDEXING_APIS.INGESTION_API;
+const analyticsRegion = ANALYTICS_REGIONS.EU;
+
 // Algolia preferences
 var ALGOLIA_IN_STOCK_THRESHOLD;
 var INDEX_OUT_OF_STOCK;
@@ -607,9 +621,18 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
         batch = batch.concat(algoliaOperationsArray[i].toArray());
     }
 
-    var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
-    var result = retryableBatchRes.result;
-    jobReport.recordsFailed += retryableBatchRes.failedRecords;
+    let resultObj;
+    switch (indexingAPI) {
+        case INDEXING_APIS.SEARCH_API:
+            resultObj = reindexHelper.sendRetryableBatch(batch);
+            break;
+        case INDEXING_APIS.INGESTION_API:
+            resultObj = reindexHelper.groupPayloadsForIngestionAPI(batch);
+            break;
+    }
+
+    var result = resultObj.result;
+    jobReport.recordsFailed += resultObj.failedRecords;
 
     if (result.ok) {
         jobReport.recordsSent += batch.length;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -11,7 +11,7 @@ var recordModel;
 
 // Algolia requires
 var algoliaData, AlgoliaLocalizedProduct, algoliaProductConfig, algoliaIndexingAPI, productFilter, AlgoliaJobReport;
-var jobHelper, reindexHelper;
+var jobHelper, reindexHelper, requestHelper;
 var indexingOperation;
 var fullRecordUpdate = false;
 
@@ -67,6 +67,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     AlgoliaLocalizedProduct = require('*/cartridge/scripts/algolia/model/algoliaLocalizedProduct');
     jobHelper = require('*/cartridge/scripts/algolia/helper/jobHelper');
     reindexHelper = require('*/cartridge/scripts/algolia/helper/reindexHelper');
+    requestHelper = require('*/cartridge/scripts/algolia/helper/requestHelper');
     algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
     logger = jobHelper.getAlgoliaLogger();
     productFilter = require('*/cartridge/scripts/algolia/filters/productFilter');
@@ -515,7 +516,7 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
 
     var result;
     try {
-        var retryableBatchRes = reindexHelper.sendRetryableBatch(batch);
+        var retryableBatchRes = requestHelper.sendRetryableBatch(batch);
         result = retryableBatchRes.result;
         jobReport.recordsFailed += retryableBatchRes.failedRecords;
     } catch (e) {

--- a/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
@@ -280,8 +280,6 @@ function pushByIndexName(requestPayload, indexName) {
     return result;
 }
 
-
-
 module.exports.setJobInfo = setJobInfo;
 module.exports.sendBatch = sendBatch;
 module.exports.sendMultiIndexBatch = sendMultiIndexBatch;

--- a/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
@@ -10,19 +10,14 @@ const logger = require('*/cartridge/scripts/algolia/helper/jobHelper').getAlgoli
 
 var __jobInfo = {};
 
-const INDEXING_APIS = {
-    SEARCH_API: 'search-api',
-    INGESTION_API: 'ingestion-api',
-}
-
 const ANALYTICS_REGIONS = {
     EU: 'eu',
     US: 'us',
 }
 
-// TODO: make these into site preferences -- return analyticsRegion programmatically if possible - getIndexSettings?
-const indexingAPI = INDEXING_APIS.INGESTION_API;
+// TODO: make into site preference / retrieve programmatically
 const analyticsRegion = ANALYTICS_REGIONS.EU;
+
 
 /**
  * Set information about the job using the API Client
@@ -31,6 +26,8 @@ const analyticsRegion = ANALYTICS_REGIONS.EU;
 function setJobInfo(jobInfo) {
     __jobInfo = jobInfo;
 }
+
+/* --------------------------- Search API methods --------------------------- */
 
 /**
  * Send a batch of objects to Algolia Indexing API: https://www.algolia.com/doc/rest-api/search/#batch-write-operations
@@ -60,44 +57,24 @@ function sendBatch(indexName, requestsArray) {
 }
 
 /**
- * Sends a request to either
- * - the Search API's `multiple-batch` endpoint (https://www.algolia.com/doc/rest-api/search/multiple-batch) or
- * - the Ingestion API's `push` endpoint (https://www.algolia.com/doc/rest-api/ingestion/push)
- * based on the indexing API used.
- * For the Ingestion API, the `push` endpoint can only accept single-index and single-action requests.
- * When using the Ingestion API, requests have already been grouped by indexName and action by this point.
-* @param {Array | Object} requestPayload Array of requests when using the Search API or payload object for the Ingestion API. For the search API, each operation must contain the `indexName` to target, for the Ingestion API, indexName is part of the reuqest URL
-* @param {String} [indexName] Name of the target index (for Ingestion only)
-* @returns {dw.svc.Result} - result of the call
-*/
-function sendPayload(requestPayload, indexName) {
+ * Send a batch of objects to Algolia Search API's `multiple-batch` endpoint
+ * https://www.algolia.com/doc/rest-api/search/multiple-batch
+ * @param {Array} requestsArray - array of requests to send to Algolia. Each operation must contain the `indexName` to target.
+ * @returns {dw.svc.Result} - result of the call
+ */
+function sendMultiIndexBatch(requestsArray) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
-    let retryableCallParameters = {};
 
-    switch (indexingAPI) {
-        case INDEXING_APIS.SEARCH_API:
-
-            retryableCallParameters = {
-                method: 'POST',
-                path: '/1/indexes/*/batch',
-                body: {
-                    requests: requestPayload,
-                }
+    var result = retryableCall(
+        indexingService,
+        {
+            method: 'POST',
+            path: '/1/indexes/*/batch',
+            body: {
+                requests: requestsArray,
             }
-            break;
-
-        case INDEXING_APIS.INGESTION_API:
-            indexingService.setURL('https://data.' + analyticsRegion + '.algolia.com/');
-            retryableCallParameters = {
-                method: 'POST',
-                path: '/1/push/' + indexName,
-                body: requestPayload,
-            }
-
-            break;
-    }
-
-    var result = retryableCall(indexingService, retryableCallParameters);
+        }
+    );
 
     if (!result.ok) {
         logger.error(result.getErrorMessage());
@@ -274,12 +251,44 @@ function waitTask(indexName, taskID) {
     throw new Error('Max wait time reached. TaskID: ' + taskID + '; index: ' + indexName);
 }
 
+/* --------------------------- Ingestion API methods --------------------------- */
+
+/**
+ * Sends a request to the Ingestion API's `push` endpoint (https://www.algolia.com/doc/rest-api/ingestion/push)
+ * The `push` endpoint can only accept single-index and single-action requests.
+ * When using the Ingestion API, requests have already been grouped by indexName and action by this point.
+* @param {Object} requestPayload payload object to be sent to the Ingestion API
+* @param {String} indexName name of the target index (for Ingestion only), used in the endpoint URL
+* @returns {dw.svc.Result} - result of the call
+*/
+function pushByIndexName(requestPayload, indexName) {
+    var indexingService = algoliaIndexingService.getService(__jobInfo);
+
+    let retryableCallParameters = {
+        method: 'POST',
+        url: 'https://data.' + analyticsRegion + '.algolia.com',
+        path: '/1/push/' + indexName,
+        body: requestPayload,
+    }
+
+    var result = retryableCall(indexingService, retryableCallParameters);
+
+    if (!result.ok) {
+        logger.error(result.getErrorMessage());
+    }
+
+    return result;
+}
+
+
+
 module.exports.setJobInfo = setJobInfo;
 module.exports.sendBatch = sendBatch;
-module.exports.sendPayload = sendPayload;
+module.exports.sendMultiIndexBatch = sendMultiIndexBatch;
 module.exports.deleteIndex = deleteIndex;
 module.exports.getIndexSettings = getIndexSettings;
 module.exports.setIndexSettings = setIndexSettings;
 module.exports.copyIndexSettings = copyIndexSettings;
 module.exports.moveIndex = moveIndex;
 module.exports.waitTask = waitTask;
+module.exports.pushByIndexName = pushByIndexName;

--- a/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
@@ -1,7 +1,7 @@
 /**
-*  Client to communicate with Algolia's indexing API:
-*  https://www.algolia.com/doc/rest-api/search/#objects-endpoints
-**/
+ *  Client to communicate with Algolia's indexing API:
+ *  https://www.algolia.com/doc/rest-api/search/#objects-endpoints
+ **/
 
 const waitTaskTimeout = require('*/algoliaconfig').waitTaskTimeout;
 const algoliaIndexingService = require('*/cartridge/scripts/services/algoliaIndexingService');
@@ -25,19 +25,19 @@ const indexingAPI = INDEXING_APIS.INGESTION_API;
 const analyticsRegion = ANALYTICS_REGIONS.EU;
 
 /**
-* Set information about the job using the API Client
-* @param {Object} jobInfo - object with the following structure: { "jobID": "", "stepID": "", "indexingMethod": "" }
-*/
+ * Set information about the job using the API Client
+ * @param {Object} jobInfo - object with the following structure: { "jobID": "", "stepID": "", "indexingMethod": "" }
+ */
 function setJobInfo(jobInfo) {
     __jobInfo = jobInfo;
 }
 
 /**
-* Send a batch of objects to Algolia Indexing API: https://www.algolia.com/doc/rest-api/search/#batch-write-operations
-* @param {string} indexName - name of the index to target
-* @param {Array} requestsArray - array of requests to send to Algolia
-* @returns {dw.svc.Result} - result of the call
-*/
+ * Send a batch of objects to Algolia Indexing API: https://www.algolia.com/doc/rest-api/search/#batch-write-operations
+ * @param {string} indexName - name of the index to target
+ * @param {Array} requestsArray - array of requests to send to Algolia
+ * @returns {dw.svc.Result} - result of the call
+ */
 function sendBatch(indexName, requestsArray) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
 
@@ -107,10 +107,10 @@ function sendPayload(requestPayload, indexName) {
 }
 
 /**
-* Delete index
-* @param {string} indexName - index to delete
-* @returns {dw.svc.Result} - result of the call
-*/
+ * Delete index
+ * @param {string} indexName - index to delete
+ * @returns {dw.svc.Result} - result of the call
+ */
 function deleteIndex(indexName) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
 
@@ -130,10 +130,10 @@ function deleteIndex(indexName) {
 }
 
 /**
-* Get index settings. https://www.algolia.com/doc/rest-api/search/#get-settings
-* @param {string} indexName - index to get the settings from
-* @returns {dw.svc.Result} - result of the call
-*/
+ * Get index settings. https://www.algolia.com/doc/rest-api/search/#get-settings
+ * @param {string} indexName - index to get the settings from
+ * @returns {dw.svc.Result} - result of the call
+ */
 function getIndexSettings(indexName) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
 
@@ -157,11 +157,11 @@ function getIndexSettings(indexName) {
 }
 
 /**
-* Set index settings. https://www.algolia.com/doc/rest-api/search/#set-settings
-* @param {string} indexName - targeted index
-* @param {string} indexSettings - index settings to set
-* @returns {dw.svc.Result} - result of the call
-*/
+ * Set index settings. https://www.algolia.com/doc/rest-api/search/#set-settings
+ * @param {string} indexName - targeted index
+ * @param {string} indexSettings - index settings to set
+ * @returns {dw.svc.Result} - result of the call
+ */
 function setIndexSettings(indexName, indexSettings) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
 
@@ -182,11 +182,11 @@ function setIndexSettings(indexName, indexSettings) {
 }
 
 /**
-* Copy the settings of an index to another. https://www.algolia.com/doc/rest-api/search/#copymove-index
-* @param {string} indexNameSrc - index to copy
-* @param {string} indexNameDest - name of the destination index
-* @returns {dw.svc.Result} - result of the call
-*/
+ * Copy the settings of an index to another. https://www.algolia.com/doc/rest-api/search/#copymove-index
+ * @param {string} indexNameSrc - index to copy
+ * @param {string} indexNameDest - name of the destination index
+ * @returns {dw.svc.Result} - result of the call
+ */
 function copyIndexSettings(indexNameSrc, indexNameDest) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
 
@@ -211,11 +211,11 @@ function copyIndexSettings(indexNameSrc, indexNameDest) {
 }
 
 /**
-* Move an index. https://www.algolia.com/doc/rest-api/search/#copymove-index
-* @param {string} indexNameSrc - index to move
-* @param {string} indexNameDest - new name of the index
-* @returns {dw.svc.Result} - result of the call
-*/
+ * Move an index. https://www.algolia.com/doc/rest-api/search/#copymove-index
+ * @param {string} indexNameSrc - index to move
+ * @param {string} indexNameDest - new name of the index
+ * @returns {dw.svc.Result} - result of the call
+ */
 function moveIndex(indexNameSrc, indexNameDest) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
 
@@ -239,12 +239,12 @@ function moveIndex(indexNameSrc, indexNameDest) {
 }
 
 /**
-* Wait for an Algolia task to complete.
-* This method will call the /task endpoint until its status become 'published'
-* https://www.algolia.com/doc/rest-api/search/#get-a-tasks-status
-* @param {string} indexName - index name where the task was executed
-* @param {number} taskID - id of the task
-*/
+ * Wait for an Algolia task to complete.
+ * This method will call the /task endpoint until its status become 'published'
+ * https://www.algolia.com/doc/rest-api/search/#get-a-tasks-status
+ * @param {string} indexName - index name where the task was executed
+ * @param {number} taskID - id of the task
+ */
 function waitTask(indexName, taskID) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
     var maxWait = waitTaskTimeout || 10 * 60 * 1000;

--- a/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
@@ -1,7 +1,7 @@
 /**
- *  Client to communicate with Algolia's indexing API:
- *  https://www.algolia.com/doc/rest-api/search/#objects-endpoints
- **/
+*  Client to communicate with Algolia's indexing API:
+*  https://www.algolia.com/doc/rest-api/search/#objects-endpoints
+**/
 
 const waitTaskTimeout = require('*/algoliaconfig').waitTaskTimeout;
 const algoliaIndexingService = require('*/cartridge/scripts/services/algoliaIndexingService');
@@ -10,20 +10,34 @@ const logger = require('*/cartridge/scripts/algolia/helper/jobHelper').getAlgoli
 
 var __jobInfo = {};
 
+const INDEXING_APIS = {
+    SEARCH_API: 'search-api',
+    INGESTION_API: 'ingestion-api',
+}
+
+const ANALYTICS_REGIONS = {
+    EU: 'eu',
+    US: 'us',
+}
+
+// TODO: make these into site preferences -- return analyticsRegion programmatically if possible - getIndexSettings?
+const indexingAPI = INDEXING_APIS.INGESTION_API;
+const analyticsRegion = ANALYTICS_REGIONS.EU;
+
 /**
- * Set information about the job using the API Client
- * @param {Object} jobInfo - object with the following structure: { "jobID": "", "stepID": "", "indexingMethod": "" }
- */
+* Set information about the job using the API Client
+* @param {Object} jobInfo - object with the following structure: { "jobID": "", "stepID": "", "indexingMethod": "" }
+*/
 function setJobInfo(jobInfo) {
     __jobInfo = jobInfo;
 }
 
 /**
- * Send a batch of objects to Algolia Indexing API: https://www.algolia.com/doc/rest-api/search/#batch-write-operations
- * @param {string} indexName - name of the index to target
- * @param {Array} requestsArray - array of requests to send to Algolia
- * @returns {dw.svc.Result} - result of the call
- */
+* Send a batch of objects to Algolia Indexing API: https://www.algolia.com/doc/rest-api/search/#batch-write-operations
+* @param {string} indexName - name of the index to target
+* @param {Array} requestsArray - array of requests to send to Algolia
+* @returns {dw.svc.Result} - result of the call
+*/
 function sendBatch(indexName, requestsArray) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
 
@@ -46,24 +60,44 @@ function sendBatch(indexName, requestsArray) {
 }
 
 /**
- * Send a batch of objects to Algolia Indexing API (multiple indices):
- * https://www.algolia.com/doc/rest-api/search/#batch-write-operations-multiple-indices
- * @param {AlgoliaOperation[]} requestsArray - array of requests to send to Algolia. Each operation must contain the `indexName` to target.
- * @returns {dw.svc.Result} - result of the call
- */
-function sendMultiIndexBatch(requestsArray) {
+ * Sends a request to either
+ * - the Search API's `multiple-batch` endpoint (https://www.algolia.com/doc/rest-api/search/multiple-batch) or
+ * - the Ingestion API's `push` endpoint (https://www.algolia.com/doc/rest-api/ingestion/push)
+ * based on the indexing API used.
+ * For the Ingestion API, the `push` endpoint can only accept single-index and single-action requests.
+ * When using the Ingestion API, requests have already been grouped by indexName and action by this point.
+* @param {Array | Object} requestPayload Array of requests when using the Search API or payload object for the Ingestion API. For the search API, each operation must contain the `indexName` to target, for the Ingestion API, indexName is part of the reuqest URL
+* @param {String} [indexName] Name of the target index (for Ingestion only)
+* @returns {dw.svc.Result} - result of the call
+*/
+function sendPayload(requestPayload, indexName) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
+    let retryableCallParameters = {};
 
-    var result = retryableCall(
-        indexingService,
-        {
-            method: 'POST',
-            path: '/1/indexes/*/batch',
-            body: {
-                requests: requestsArray,
+    switch (indexingAPI) {
+        case INDEXING_APIS.SEARCH_API:
+
+            retryableCallParameters = {
+                method: 'POST',
+                path: '/1/indexes/*/batch',
+                body: {
+                    requests: requestPayload,
+                }
             }
-        }
-    );
+            break;
+
+        case INDEXING_APIS.INGESTION_API:
+            indexingService.setURL('https://data.' + analyticsRegion + '.algolia.com/');
+            retryableCallParameters = {
+                method: 'POST',
+                path: '/1/push/' + indexName,
+                body: requestPayload,
+            }
+
+            break;
+    }
+
+    var result = retryableCall(indexingService, retryableCallParameters);
 
     if (!result.ok) {
         logger.error(result.getErrorMessage());
@@ -73,10 +107,10 @@ function sendMultiIndexBatch(requestsArray) {
 }
 
 /**
- * Delete index
- * @param {string} indexName - index to delete
- * @returns {dw.svc.Result} - result of the call
- */
+* Delete index
+* @param {string} indexName - index to delete
+* @returns {dw.svc.Result} - result of the call
+*/
 function deleteIndex(indexName) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
 
@@ -96,10 +130,10 @@ function deleteIndex(indexName) {
 }
 
 /**
- * Get index settings. https://www.algolia.com/doc/rest-api/search/#get-settings
- * @param {string} indexName - index to get the settings from
- * @returns {dw.svc.Result} - result of the call
- */
+* Get index settings. https://www.algolia.com/doc/rest-api/search/#get-settings
+* @param {string} indexName - index to get the settings from
+* @returns {dw.svc.Result} - result of the call
+*/
 function getIndexSettings(indexName) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
 
@@ -123,11 +157,11 @@ function getIndexSettings(indexName) {
 }
 
 /**
- * Set index settings. https://www.algolia.com/doc/rest-api/search/#set-settings
- * @param {string} indexName - targeted index
- * @param {string} indexSettings - index settings to set
- * @returns {dw.svc.Result} - result of the call
- */
+* Set index settings. https://www.algolia.com/doc/rest-api/search/#set-settings
+* @param {string} indexName - targeted index
+* @param {string} indexSettings - index settings to set
+* @returns {dw.svc.Result} - result of the call
+*/
 function setIndexSettings(indexName, indexSettings) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
 
@@ -148,11 +182,11 @@ function setIndexSettings(indexName, indexSettings) {
 }
 
 /**
- * Copy the settings of an index to another. https://www.algolia.com/doc/rest-api/search/#copymove-index
- * @param {string} indexNameSrc - index to copy
- * @param {string} indexNameDest - name of the destination index
- * @returns {dw.svc.Result} - result of the call
- */
+* Copy the settings of an index to another. https://www.algolia.com/doc/rest-api/search/#copymove-index
+* @param {string} indexNameSrc - index to copy
+* @param {string} indexNameDest - name of the destination index
+* @returns {dw.svc.Result} - result of the call
+*/
 function copyIndexSettings(indexNameSrc, indexNameDest) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
 
@@ -177,11 +211,11 @@ function copyIndexSettings(indexNameSrc, indexNameDest) {
 }
 
 /**
- * Move an index. https://www.algolia.com/doc/rest-api/search/#copymove-index
- * @param {string} indexNameSrc - index to move
- * @param {string} indexNameDest - new name of the index
- * @returns {dw.svc.Result} - result of the call
- */
+* Move an index. https://www.algolia.com/doc/rest-api/search/#copymove-index
+* @param {string} indexNameSrc - index to move
+* @param {string} indexNameDest - new name of the index
+* @returns {dw.svc.Result} - result of the call
+*/
 function moveIndex(indexNameSrc, indexNameDest) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
 
@@ -205,12 +239,12 @@ function moveIndex(indexNameSrc, indexNameDest) {
 }
 
 /**
- * Wait for an Algolia task to complete.
- * This method will call the /task endpoint until its status become 'published'
- * https://www.algolia.com/doc/rest-api/search/#get-a-tasks-status
- * @param {string} indexName - index name where the task was executed
- * @param {number} taskID - id of the task
- */
+* Wait for an Algolia task to complete.
+* This method will call the /task endpoint until its status become 'published'
+* https://www.algolia.com/doc/rest-api/search/#get-a-tasks-status
+* @param {string} indexName - index name where the task was executed
+* @param {number} taskID - id of the task
+*/
 function waitTask(indexName, taskID) {
     var indexingService = algoliaIndexingService.getService(__jobInfo);
     var maxWait = waitTaskTimeout || 10 * 60 * 1000;
@@ -242,7 +276,7 @@ function waitTask(indexName, taskID) {
 
 module.exports.setJobInfo = setJobInfo;
 module.exports.sendBatch = sendBatch;
-module.exports.sendMultiIndexBatch = sendMultiIndexBatch;
+module.exports.sendPayload = sendPayload;
 module.exports.deleteIndex = deleteIndex;
 module.exports.getIndexSettings = getIndexSettings;
 module.exports.setIndexSettings = setIndexSettings;

--- a/cartridges/int_algolia_sfra/cartridge/scripts/hooks/order/algoliaHooks.js
+++ b/cartridges/int_algolia_sfra/cartridge/scripts/hooks/order/algoliaHooks.js
@@ -5,7 +5,7 @@ let Status = require('dw/system/Status');
 
 let jobHelper = require('*/cartridge/scripts/algolia/helper/jobHelper');
 let algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
-let reindexHelper = require('*/cartridge/scripts/algolia/helper/reindexHelper');
+let requestHelper = require('*/cartridge/scripts/algolia/helper/requestHelper');
 let productFilter = require('*/cartridge/scripts/algolia/filters/productFilter');
 let AlgoliaLocalizedProduct = require('*/cartridge/scripts/algolia/model/algoliaLocalizedProduct');
 
@@ -131,7 +131,7 @@ exports.inventoryUpdate = function (order) {
         }
 
         if (algoliaOperations.length > 0) {
-            reindexHelper.sendRetryableBatch(algoliaOperations);
+            requestHelper.sendRetryableBatch(algoliaOperations);
         }
     } catch (error) {
         Logger.error(

--- a/test/unit/int_algolia/scripts/algolia/helper/reindexHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/reindexHelper.test.js
@@ -38,6 +38,7 @@ jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
         moveIndex: mockMoveIndex,
         waitTask: mockWaitTask,
         sendMultiIndexBatch: mockSendMultiIndexBatch,
+        pushByIndexName: jest.fn(),
     }
 }, {virtual: true});
 
@@ -93,54 +94,4 @@ test('waitForTasks', () => {
     expect(mockWaitTask).toHaveBeenCalledTimes(2);
     expect(mockWaitTask).toHaveBeenCalledWith('testIndex', 33);
     expect(mockWaitTask).toHaveBeenCalledWith('testIndex2', 51);
-});
-
-test('sendRetryableBatch', () => {
-    const batch = [
-        {
-            action: 'addObject',
-            indexName: 'test_index_fr_FR',
-            body: { objectID: 'record1', name: 'record1' },
-        },
-        {
-            action: 'addObject',
-            indexName: 'test_index_en_US',
-            body: { objectID: 'record1', name: 'record1' },
-        },
-        {
-            action: 'addObject',
-            indexName: 'test_index_fr_FR',
-            body: { objectID: 'record2', name: 'record2' },
-        },
-        {
-            action: 'addObject',
-            indexName: 'test_index_en_US',
-            body: { objectID: 'record2', name: 'record2' },
-        }
-        ,
-        {
-            action: 'addObject',
-            indexName: 'test_index_fr_FR',
-            body: { objectID: 'record3', name: 'record3' },
-        },
-        {
-            action: 'addObject',
-            indexName: 'test_index_en_US',
-            body: { objectID: 'record3', name: 'record3' },
-        }
-    ];
-    mockSendMultiIndexBatch.mockReturnValueOnce({
-        error: true,
-        getErrorMessage: () => '{"message":"Record at the position 0 objectID=record1 is too big size=11072/10000 bytes. Please have a look at https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/in-depth/index-and-records-size-and-usage-limitations/#record-size-limits","position":2,"objectID":"record2","status":400}'
-    });
-    mockSendMultiIndexBatch.mockReturnValue({
-        ok: true,
-    });
-
-    const res = reindexHelper.sendRetryableBatch(batch);
-
-    expect(mockSendMultiIndexBatch).toHaveBeenCalledTimes(2);
-    expect(res.result.ok).toBe(true);
-    expect(res.failedRecords).toBe(2);
-    expect(batch.length).toBe(4); // 2 records have been removed
 });

--- a/test/unit/int_algolia/scripts/algolia/helper/requestHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/requestHelper.test.js
@@ -64,10 +64,10 @@ test('sendRetryableBatch', () => {
     expect(batch.length).toBe(4); // 2 records have been removed
 });
 
-test('groupPayloadsForIngestionAPI', () => {
-    // TODO: write test
+test('groupRecordsForIngestionAPI', () => {
+    // TODO: add test
 });
 
-test('sendGroupedIngestionAPIPayloads', () => {
-    // TODO: write test
+test('sendGroupedIngestionAPIRecords', () => {
+    // TODO: add test
 });

--- a/test/unit/int_algolia/scripts/algolia/helper/requestHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/requestHelper.test.js
@@ -1,0 +1,73 @@
+const mockSendMultiIndexBatch = jest.fn();
+jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
+    return {
+        deleteIndex: jest.fn(),
+        getIndexSettings: jest.fn(),
+        setIndexSettings: jest.fn(),
+        copyIndexSettings: jest.fn(),
+        moveIndex: jest.fn(),
+        waitTask: jest.fn(),
+        sendMultiIndexBatch: mockSendMultiIndexBatch,
+        pushByIndexName: jest.fn(),
+    }
+}, {virtual: true});
+
+const requestHelper = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper');
+
+test('sendRetryableBatch', () => {
+    const batch = [
+        {
+            action: 'addObject',
+            indexName: 'test_index_fr_FR',
+            body: { objectID: 'record1', name: 'record1' },
+        },
+        {
+            action: 'addObject',
+            indexName: 'test_index_en_US',
+            body: { objectID: 'record1', name: 'record1' },
+        },
+        {
+            action: 'addObject',
+            indexName: 'test_index_fr_FR',
+            body: { objectID: 'record2', name: 'record2' },
+        },
+        {
+            action: 'addObject',
+            indexName: 'test_index_en_US',
+            body: { objectID: 'record2', name: 'record2' },
+        }
+        ,
+        {
+            action: 'addObject',
+            indexName: 'test_index_fr_FR',
+            body: { objectID: 'record3', name: 'record3' },
+        },
+        {
+            action: 'addObject',
+            indexName: 'test_index_en_US',
+            body: { objectID: 'record3', name: 'record3' },
+        }
+    ];
+    mockSendMultiIndexBatch.mockReturnValueOnce({
+        error: true,
+        getErrorMessage: () => '{"message":"Record at the position 0 objectID=record1 is too big size=11072/10000 bytes. Please have a look at https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/in-depth/index-and-records-size-and-usage-limitations/#record-size-limits","position":2,"objectID":"record2","status":400}'
+    });
+    mockSendMultiIndexBatch.mockReturnValue({
+        ok: true,
+    });
+
+    const res = requestHelper.sendRetryableBatch(batch);
+
+    expect(mockSendMultiIndexBatch).toHaveBeenCalledTimes(2);
+    expect(res.result.ok).toBe(true);
+    expect(res.failedRecords).toBe(2);
+    expect(batch.length).toBe(4); // 2 records have been removed
+});
+
+test('groupPayloadsForIngestionAPI', () => {
+    // TODO: write test
+});
+
+test('sendGroupedIngestionAPIPayloads', () => {
+    // TODO: write test
+});

--- a/test/unit/int_algolia/scripts/algolia/helper/retryStrategy.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/retryStrategy.test.js
@@ -26,6 +26,8 @@ beforeEach(() => {
 })
 
 test('StatefulHost', () => {
+    retryStrategy._setIndexingAPI(retryStrategy._INDEXING_APIS.SEARCH_API);
+
     const statefulhost = new retryStrategy.StatefulHost('http://test.com');
     expect(statefulhost.hostname).toBe('http://test.com');
     expect(statefulhost.isDown).toBe(false);
@@ -44,6 +46,8 @@ test('StatefulHost', () => {
 });
 
 test('defaultHosts', () => {
+    retryStrategy._setIndexingAPI(retryStrategy._INDEXING_APIS.SEARCH_API);
+
     expect(retryStrategy.getAvailableHosts()
         .map(statefulhost => statefulhost.hostname)).toEqual([
         `${appID}.algolia.net`,
@@ -54,6 +58,7 @@ test('defaultHosts', () => {
 });
 
 test('isRetryable', () => {
+    retryStrategy._setIndexingAPI(retryStrategy._INDEXING_APIS.SEARCH_API);
     const getUnavailableReasonMock = jest.fn();
     const getErrorMock = jest.fn().mockReturnValue(0);
 
@@ -80,6 +85,7 @@ test('isRetryable', () => {
 });
 
 test('retryableCall - success on 3rd server', () => {
+    retryStrategy._setIndexingAPI(retryStrategy._INDEXING_APIS.SEARCH_API);
     const serverErrorResult = {
         ok: false,
         getUnavailableReason: jest.fn(),
@@ -109,6 +115,7 @@ test('retryableCall - success on 3rd server', () => {
 });
 
 test('retryableCall - error', () => {
+    retryStrategy._setIndexingAPI(retryStrategy._INDEXING_APIS.SEARCH_API);
     const serverErrorResult = {
         ok: false,
         getUnavailableReason: jest.fn(),

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaCategoryIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaCategoryIndex.test.js
@@ -87,13 +87,17 @@ const mockCopySettingsFromProdIndices = jest.fn();
 const mockDeleteTemporaryIndices = jest.fn();
 const mockFinishAtomicReindex = jest.fn();
 jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
-    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper');
     return {
-        sendRetryableBatch: originalModule.sendRetryableBatch,
         deleteTemporaryIndices: mockDeleteTemporaryIndices,
         copySettingsFromProdIndices: mockCopySettingsFromProdIndices,
         finishAtomicReindex: mockFinishAtomicReindex,
         waitForTasks: jest.fn(),
+    };
+}, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/helper/requestHelper', () => {
+    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper');
+    return {
+        sendRetryableBatch: originalModule.sendRetryableBatch,
     };
 }, {virtual: true});
 

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaContentIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaContentIndex.test.js
@@ -34,7 +34,6 @@ jest.mock('*/cartridge/scripts/algolia/lib/algoliaContentConfig', () => {
 jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
     const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper');
     return {
-        sendRetryableBatch: originalModule.sendRetryableBatch,
         deleteRetryableBatch: originalModule.deleteRetryableBatch,
         deleteTemporaryIndices: originalModule.deleteTemporaryIndices,
         waitForTasks: originalModule.waitForTasks,
@@ -44,6 +43,16 @@ jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
 }, {
     virtual: true
 });
+
+jest.mock('*/cartridge/scripts/algolia/helper/requestHelper', () => {
+    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper');
+    return {
+        sendRetryableBatch: originalModule.sendRetryableBatch,
+    }
+}, {
+    virtual: true
+});
+
 
 jest.mock('dw/util/Bytes', () => {
     class BytesMock {

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
@@ -15,8 +15,8 @@ jest.mock('*/cartridge/scripts/algolia/helper/requestHelper', () => {
     const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper');
     return {
         sendRetryableBatch: originalModule.sendRetryableBatch,
-        groupPayloadsForIngestionAPI: originalModule.groupPayloadsForIngestionAPI,
-        sendGroupedIngestionAPIPayloads: originalModule.sendGroupedIngestionAPIPayloads,
+        groupRecordsForIngestionAPI: originalModule.groupRecordsForIngestionAPI,
+        sendGroupedIngestionAPIRecords: originalModule.sendGroupedIngestionAPIRecords,
     }
 }, {virtual: true});
 

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
@@ -8,12 +8,15 @@ jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
     return {
         setJobInfo: mockSetJobInfo,
         sendMultiIndexBatch: mockSendMultiIndexBatch,
+        pushByIndexName: jest.fn(),
     }
 }, {virtual: true});
-jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
-    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper');
+jest.mock('*/cartridge/scripts/algolia/helper/requestHelper', () => {
+    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper');
     return {
         sendRetryableBatch: originalModule.sendRetryableBatch,
+        groupPayloadsForIngestionAPI: originalModule.groupPayloadsForIngestionAPI,
+        sendGroupedIngestionAPIPayloads: originalModule.sendGroupedIngestionAPIPayloads,
     }
 }, {virtual: true});
 
@@ -133,6 +136,7 @@ describe('process', () => {
 
 test('send', () => {
     job.beforeStep(parameters, stepExecution);
+    job.__setIndexingAPI(job.__INDEXING_APIS.SEARCH_API);
 
     const algoliaOperationsChunk = [];
     for (let i = 0; i < 3; ++i) {

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -14,9 +14,7 @@ const mockCopySettingsFromProdIndices = jest.fn();
 const mockMoveTemporaryIndices = jest.fn();
 const mockFinishAtomicReindex = jest.fn();
 jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
-    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/reindexHelper');
     return {
-        sendRetryableBatch: originalModule.sendRetryableBatch,
         deleteTemporaryIndices: mockDeleteTemporaryIndices,
         copySettingsFromProdIndices: mockCopySettingsFromProdIndices,
         moveTemporaryIndices: mockMoveTemporaryIndices,
@@ -24,6 +22,14 @@ jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
         waitForTasks: jest.fn(),
     };
 }, {virtual: true});
+
+jest.mock('*/cartridge/scripts/algolia/helper/requestHelper', () => {
+    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper');
+    return {
+        sendRetryableBatch: originalModule.sendRetryableBatch,
+    };
+}, {virtual: true});
+
 
 jest.mock('*/cartridge/scripts/services/algoliaIndexingService', () => {}, {virtual: true});
 

--- a/test/unit/int_algolia/scripts/hooks/order/algoliaHooks.test.js
+++ b/test/unit/int_algolia/scripts/hooks/order/algoliaHooks.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => ({
+jest.mock('*/cartridge/scripts/algolia/helper/requestHelper', () => ({
     sendRetryableBatch: jest.fn().mockReturnValue({ ok: true })
 }), { virtual: true });
 


### PR DESCRIPTION
The current call chain is the following for Search API calls:
- job file calls `reindexHelper.sendRetryableBatch()`
- `sendRetryableBatch()` calls `algoliaIndexingAPI.sendMultiIndexBatch()`
- `sendMultiIndexBatch()` calls `retryStrategy.retryableCall()`
- `retryableCall()` sends the request, employing stateful hosts logic

Since the payloads to be sent to the Ingestion API are different from those to be sent to the Search API (and also there are more of them), the grouping/sorting needs to happen before sending the payloads.

In order to achieve that, a new layer between the job and `reindexHelper.sendRetryableBatch` called `groupPayloadsForIngestionAPI()` was created that handles the grouping/sorting, passes the ready-to-send payloads along in the chain, and then collects the request results together so that monitoring keeps working (how many records / requests failed, for example).

Created new helper script `requestHelper.js` which includes the grouping and sending methods for the Ingestion API. Also moved `sendRetryableBatch()` here from `reindexHelper.js`.

Since an OK result from the Ingestion API endpoint only means that the payload was received, it doesn't indicate any errors with the payload itself (like if a record exceeds the Algolia size limit), `sendRetryableBatch` is now bypassed for Ingestion calls (this is the method that removes the records that were found to be too large from the payload and then retries the call). Not having an immediate feedback that something was wrong with the payload also means that `failedRecords` count is not accurate with the Ingestion API, this is a caveat and will need to be added to the documentation (a call to the "Retrieve task run event" endpoint could be made after the indexing call, but with the current synchronous approach waiting for the result of each of these calls would slow down execution significantly since it's not guaranteed that they'll be processed right away). Added a note on this in the code.

Even though the Ingestion API doesn't have backup URLs like the Search API does, we're keeping the `statefulHosts` mechanism since the API client libraries also use it, even with the one target, and also because more URLs may be added later.

Here's the call chain for Ingestion API calls:
- job file calls `requestHelper.groupPayloadsForIngestionAPI()` (NEW)
- job file calls `requestHelper.sendGroupedIngestionAPIPayloads()` with the payloads returned by the above (NEW)
- `sendGroupedIngestionAPIPayloads()` calls `algoliaIndexingAPI.pushByIndexName()` for each payload group (NEW)
- `pushByIndexName()` calls `retryableCall()` to send the payloads, employing the retry mechanism that is also used with Search API calls.

### Notes:
- indexing API choice (Search or Ingestion) is hardcoded for now, will move it to a site preference in a subsequent pull request.
- analytics region is hardcoded for now, will move it to a site preference in a subsequent pull request or retrieve it programmatically if possible.
- service target URL (Ingestion API endpoint) is also hardcoded for now, will create a new service if needed
- fixed current (Search API) unit tests for now, tests for Ingestion will be added at a later date in another PR once the code is finalized.