### PR TITLE
feat: [SFCC-488] retryStrategy updated to be able to handle mixed calls within the same job

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/retryStrategy.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/retryStrategy.js
@@ -19,7 +19,7 @@ const ANALYTICS_REGIONS = {
 // TODO: make these into site preferences -- return analyticsRegion programmatically if possible - getIndexSettings?
 const analyticsRegion = ANALYTICS_REGIONS.EU;
 
-let statefulhosts;
+let statefulhosts = {};
 
 /**
  * Class keeping a host's state
@@ -49,20 +49,25 @@ StatefulHost.prototype.reset = function() {
  * @param {String} indexingAPI the indexing API to use for the call, Search API or Ingestion API
  */
 function initHosts(indexingAPI) {
+    // defaulting to 'search-api'
+    if (typeof indexingAPI === 'undefined') {
+        indexingAPI = INDEXING_APIS.SEARCH_API;
+    }
+
     switch (indexingAPI) {
+        case INDEXING_APIS.INGESTION_API: {
+            statefulhosts[INDEXING_APIS.INGESTION_API] = [
+                new StatefulHost('data.' + analyticsRegion + '.algolia.com'),
+            ];
+            break;
+        }
         case INDEXING_APIS.SEARCH_API: {
-            statefulhosts = [
+            statefulhosts[INDEXING_APIS.SEARCH_API] = [
                 new StatefulHost(appID + '.algolia.net'),
                 new StatefulHost(appID + '-1.algolianet.com'),
                 new StatefulHost(appID + '-2.algolianet.com'),
                 new StatefulHost(appID + '-3.algolianet.com'),
-            ]
-            break;
-        }
-        case INDEXING_APIS.INGESTION_API: {
-            statefulhosts = [
-                new StatefulHost('data.' + analyticsRegion + '.algolia.com'),
-            ]
+            ];
             break;
         }
     }
@@ -74,14 +79,22 @@ function initHosts(indexingAPI) {
  */
 function getAvailableHosts(indexingAPI) {
     const res = [];
-    initHosts(indexingAPI);
 
-    for (let i = 0; i < statefulhosts.length; ++i) {
-        if (statefulhosts[i].isExpired()) {
-            statefulhosts[i].reset();
+    // defaulting to 'search'api'
+    if (typeof indexingAPI === 'undefined') {
+        indexingAPI = INDEXING_APIS.SEARCH_API;
+    }
+
+    if (empty(statefulhosts[indexingAPI])) {
+        initHosts(indexingAPI);
+    }
+
+    for (let i = 0; i < statefulhosts[indexingAPI].length; ++i) {
+        if (statefulhosts[indexingAPI][i].isExpired()) {
+            statefulhosts[indexingAPI][i].reset();
         }
-        if (!statefulhosts[i].isDown) {
-            res.push(statefulhosts[i]);
+        if (!statefulhosts[indexingAPI][i].isDown) {
+            res.push(statefulhosts[indexingAPI][i]);
         }
     }
     if (res.length > 0) {
@@ -89,8 +102,8 @@ function getAvailableHosts(indexingAPI) {
     }
 
     Logger.info('All hosts are down, retrying them...');
-    for (let i = 0; i < statefulhosts.length; ++i) {
-        res.push(statefulhosts[i]);
+    for (let i = 0; i < statefulhosts[indexingAPI].length; ++i) {
+        res.push(statefulhosts[indexingAPI][i]);
     }
     return res;
 }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/retryStrategy.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/retryStrategy.js
@@ -17,7 +17,6 @@ const ANALYTICS_REGIONS = {
 }
 
 // TODO: make these into site preferences -- return analyticsRegion programmatically if possible - getIndexSettings?
-let indexingAPI = INDEXING_APIS.INGESTION_API;
 const analyticsRegion = ANALYTICS_REGIONS.EU;
 
 let statefulhosts;
@@ -46,9 +45,10 @@ StatefulHost.prototype.reset = function() {
 }
 
 /**
- * Initialize the default hosts, based on the 'ApplicationID' custom preference
+ * Initialize the default hosts, based on the 'ApplicationID' custom preference and the selected indexingAPI
+ * @param {String} indexingAPI the indexing API to use for the call, Search API or Ingestion API
  */
-function initHosts() {
+function initHosts(indexingAPI) {
     switch (indexingAPI) {
         case INDEXING_APIS.SEARCH_API: {
             statefulhosts = [
@@ -72,11 +72,10 @@ function initHosts() {
  * Return the currently available hosts
  * @return {StatefulHost[]} The list of available hosts
  */
-function getAvailableHosts() {
+function getAvailableHosts(indexingAPI) {
     const res = [];
-    if (!statefulhosts) {
-        initHosts();
-    }
+    initHosts(indexingAPI);
+
     for (let i = 0; i < statefulhosts.length; ++i) {
         if (statefulhosts[i].isExpired()) {
             statefulhosts[i].reset();
@@ -121,15 +120,19 @@ function isRetryable(result) {
 /**
  * Main logic of the retry strategy.
  * For a given request parameters, sends the request to each available hosts until it gets a valid response.
- * Available hosts are calculated based on the 'ApplicationID' custom property.
+ * Available hosts are calculated based on the 'ApplicationID' custom property and the requestParams.indexingAPI parameter (Search or Ingestion)
  *
  * @param {dw.svc.HTTPService} service The service used to send the request
  * @param {Object} requestParams The request parameters
  * @return {dw.svc.Result} The first non-retryable result
  */
 function retryableCall(service, requestParams) {
+    // even with the Ingestion API selected for indexing globally, there are calls which
+    // need to be made to the Search API, so the hosts need to be defined on a call-by-call basis
+    let indexingAPI = requestParams.indexingAPI === INDEXING_APIS.INGESTION_API ? INDEXING_APIS.INGESTION_API : INDEXING_APIS.SEARCH_API;
+
     let result;
-    let hosts = getAvailableHosts();
+    let hosts = getAvailableHosts(indexingAPI);
     for (let i = 0; i < hosts.length; ++i) {
         let statefulhost = hosts[i];
         result = service.call({
@@ -161,5 +164,3 @@ module.exports.StatefulHost = StatefulHost;
 module.exports.initHosts = initHosts;
 module.exports.getAvailableHosts = getAvailableHosts;
 module.exports.isRetryable = isRetryable;
-module.exports._INDEXING_APIS = INDEXING_APIS;
-module.exports._setIndexingAPI = function(api) { indexingAPI = api; };

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/retryStrategy.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/retryStrategy.js
@@ -49,11 +49,6 @@ StatefulHost.prototype.reset = function() {
  * @param {String} indexingAPI the indexing API to use for the call, Search API or Ingestion API
  */
 function initHosts(indexingAPI) {
-    // defaulting to 'search-api'
-    if (typeof indexingAPI === 'undefined') {
-        indexingAPI = INDEXING_APIS.SEARCH_API;
-    }
-
     switch (indexingAPI) {
         case INDEXING_APIS.INGESTION_API: {
             statefulhosts[INDEXING_APIS.INGESTION_API] = [
@@ -61,6 +56,7 @@ function initHosts(indexingAPI) {
             ];
             break;
         }
+        default:
         case INDEXING_APIS.SEARCH_API: {
             statefulhosts[INDEXING_APIS.SEARCH_API] = [
                 new StatefulHost(appID + '.algolia.net'),

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -617,13 +617,14 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
 
     let resultObj;
     switch (indexingAPI) {
-        case INDEXING_APIS.SEARCH_API: {
-            resultObj = requestHelper.sendRetryableBatch(batch);
-            break;
-        }
         case INDEXING_APIS.INGESTION_API: {
             let sortedRecords = requestHelper.groupRecordsForIngestionAPI(batch);
             resultObj = requestHelper.sendGroupedIngestionAPIRecords(sortedRecords);
+            break;
+        }
+        case INDEXING_APIS.SEARCH_API:
+        default: {
+            resultObj = requestHelper.sendRetryableBatch(batch);
             break;
         }
     }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -525,8 +525,7 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
     let resultObj, result;
 
     try {
-        // fullCatalogReindex should still use Search API due to there being no task associated with the temporary index created during atomic reindexing
-        // atomic reindexing clears the _collection arrays anyway, this is a known caveat which needs to be taken in to account when using atomic reindexing
+        // TODO: implement full reindexing via the Ingestion API
         if (indexingAPI === INDEXING_APIS.SEARCH_API || paramIndexingMethod === 'fullCatalogReindex') {
             resultObj = requestHelper.sendRetryableBatch(batch);
         } else { // INDEXING_APIS.INGESTION_API

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -32,6 +32,14 @@ const RECORD_MODEL_TYPE = {
     ATTRIBUTE_SLICED: 'attribute-sliced',
 }
 
+const INDEXING_APIS = {
+    SEARCH_API: 'search-api',
+    INGESTION_API: 'ingestion-api',
+}
+
+// TODO: make these into site preferences -- return analyticsRegion programmatically if possible - getIndexSettings?
+let indexingAPI = INDEXING_APIS.INGESTION_API;
+
 // Algolia preferences
 var ALGOLIA_IN_STOCK_THRESHOLD;
 var INDEX_OUT_OF_STOCK;
@@ -514,11 +522,23 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
         return;
     }
 
-    var result;
+    let resultObj, result;
+
     try {
-        var retryableBatchRes = requestHelper.sendRetryableBatch(batch);
-        result = retryableBatchRes.result;
-        jobReport.recordsFailed += retryableBatchRes.failedRecords;
+        // fullCatalogReindex should still use Search API due to there being no task associated with the temporary index created during atomic reindexing
+        // atomic reindexing clears the _collection arrays anyway, this is a known caveat which needs to be taken in to account when using atomic reindexing
+        if (indexingAPI === INDEXING_APIS.SEARCH_API || paramIndexingMethod === 'fullCatalogReindex') {
+            resultObj = requestHelper.sendRetryableBatch(batch);
+        } else { // INDEXING_APIS.INGESTION_API
+            let sortedRecords = requestHelper.groupRecordsForIngestionAPI(batch);
+            resultObj = requestHelper.sendGroupedIngestionAPIRecords(sortedRecords);
+        }
+
+        // recordsFailed count is not necessarily accurate when using the Ingestion API
+        // An OK response from a sending call only means that the endpoint received the payload;
+        // "record too large" or other indexing-time errors can still happen -- check your Algolia Dashboard for these errors
+        result = resultObj.result;
+        jobReport.recordsFailed += resultObj.failedRecords;
     } catch (e) {
         logger.error('Error while sending batch to Algolia: ' + e);
     }
@@ -529,10 +549,12 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
 
         // Store Algolia indexing task IDs.
         // When performing a fullCatalogReindex, afterStep will wait for the last indexing tasks to complete.
-        var taskIDs = result.object.body.taskID;
-        Object.keys(taskIDs).forEach(function (taskIndexName) {
-            lastIndexingTasks[taskIndexName] = taskIDs[taskIndexName];
-        });
+        if (indexingAPI === INDEXING_APIS.SEARCH_API || paramIndexingMethod === 'fullCatalogReindex') {
+            var taskIDs = result.object.body.taskID;
+            Object.keys(taskIDs).forEach(function (taskIndexName) {
+                lastIndexingTasks[taskIndexName] = taskIDs[taskIndexName];
+            });
+        }
     } else {
         jobReport.recordsFailed += batch.length;
         jobReport.chunksFailed++;
@@ -621,3 +643,5 @@ exports.__getLocalesForIndexing = function() {
 exports.__getJobReport = function() {
     return jobReport;
 }
+exports.__INDEXING_APIS = INDEXING_APIS;
+exports.__setIndexingAPI = function(api) { indexingAPI = api; }

--- a/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
+++ b/cartridges/int_algolia/cartridge/scripts/algoliaIndexingAPI.js
@@ -10,6 +10,11 @@ const logger = require('*/cartridge/scripts/algolia/helper/jobHelper').getAlgoli
 
 var __jobInfo = {};
 
+const INDEXING_APIS = {
+    SEARCH_API: 'search-api',
+    INGESTION_API: 'ingestion-api',
+}
+
 const ANALYTICS_REGIONS = {
     EU: 'eu',
     US: 'us',
@@ -269,6 +274,7 @@ function pushByIndexName(requestPayload, indexName) {
         url: 'https://data.' + analyticsRegion + '.algolia.com',
         path: '/1/push/' + indexName,
         body: requestPayload,
+        indexingAPI: INDEXING_APIS.INGESTION_API,
     }
 
     var result = retryableCall(indexingService, retryableCallParameters);

--- a/test/unit/int_algolia/scripts/algolia/helper/retryStrategy.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/retryStrategy.test.js
@@ -26,8 +26,6 @@ beforeEach(() => {
 })
 
 test('StatefulHost', () => {
-    retryStrategy._setIndexingAPI(retryStrategy._INDEXING_APIS.SEARCH_API);
-
     const statefulhost = new retryStrategy.StatefulHost('http://test.com');
     expect(statefulhost.hostname).toBe('http://test.com');
     expect(statefulhost.isDown).toBe(false);
@@ -46,9 +44,7 @@ test('StatefulHost', () => {
 });
 
 test('defaultHosts', () => {
-    retryStrategy._setIndexingAPI(retryStrategy._INDEXING_APIS.SEARCH_API);
-
-    expect(retryStrategy.getAvailableHosts()
+    expect(retryStrategy.getAvailableHosts('search-api')
         .map(statefulhost => statefulhost.hostname)).toEqual([
         `${appID}.algolia.net`,
         `${appID}-1.algolianet.com`,
@@ -58,7 +54,6 @@ test('defaultHosts', () => {
 });
 
 test('isRetryable', () => {
-    retryStrategy._setIndexingAPI(retryStrategy._INDEXING_APIS.SEARCH_API);
     const getUnavailableReasonMock = jest.fn();
     const getErrorMock = jest.fn().mockReturnValue(0);
 
@@ -85,7 +80,6 @@ test('isRetryable', () => {
 });
 
 test('retryableCall - success on 3rd server', () => {
-    retryStrategy._setIndexingAPI(retryStrategy._INDEXING_APIS.SEARCH_API);
     const serverErrorResult = {
         ok: false,
         getUnavailableReason: jest.fn(),
@@ -115,7 +109,6 @@ test('retryableCall - success on 3rd server', () => {
 });
 
 test('retryableCall - error', () => {
-    retryStrategy._setIndexingAPI(retryStrategy._INDEXING_APIS.SEARCH_API);
     const serverErrorResult = {
         ok: false,
         getUnavailableReason: jest.fn(),

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -280,6 +280,7 @@ describe('process', () => {
 describe('send', () => {
     test('normal batch', () => {
         job.beforeStep({}, stepExecution);
+        job.__setIndexingAPI(job.__INDEXING_APIS.SEARCH_API);
 
         const algoliaOperationsChunk = [];
         for (let i = 0; i < 3; ++i) {


### PR DESCRIPTION
`retryStrategy` was made backwards-compatible by equipping it to be able to handle calls to both the Ingestion API and the Search API within the same job.

#255 made the assumption that once the API is switched over to the Ingestion API, all calls within the same job run will be made through the Ingestion API. This proved not to be the case as not all Search API calls the cartridge uses have an Ingestion API equivalent. These are calls related to index manipulation (methods `deleteIndex`, `getIndexSettings`, `setIndexSettings`, `copyIndexSettings`, `moveIndex` and `waitTask` in `algoliaIndexingAPI.js`). These methods need to make requests to the Search API even if indexing is globally configured to happen through the Ingestion API.

In order to fix this, `retryStrategy.retryableCall()` now takes an extra parameter that tells it which API is the intended target and initializes `statefulHosts` accordingly, which means that a job can now make calls to both the Search API and the Ingestion API within the same job run.

Instead of overwriting the cached `statefulHosts` when an API switch happens (from Search API to Ingestion API and vice versa), the code now keeps track of both sets of hosts. The internal `statefulhosts` structure was changed from holding a single array of objects containing host data for one API
```
statefulHosts = [{hostObject1}, {hostObject2}, ...]
```
to the following:
```
statefulHosts = {
  'search-api': [{hostObject1}, {hostObject2}, ...],
  'ingestion-api': [{hostObject1}, ...]
}
```
...holding the host data for both APIs. The hosts for each API are initialized only when they're actually needed, they are not populated automatically.

For now the `fullCatalogReindex` mode is forced to index via the Search API regardless of the selected API because creating a temporary index via the Ingestion API would require creating a temporary task as well, changes which are not in scope for the current pull request. Doing atomic reindexing properly via the Ingestion API shall be revisited in a subsequent task if decided.