### PR TITLE
fix(tests): e2e UI tests

### DIFF
--- a/cypress/e2e/inventory-update.cy.js
+++ b/cypress/e2e/inventory-update.cy.js
@@ -11,8 +11,6 @@ let productName;
  */
 context('Inventory real-time update', () => {
     before(() => {
-        cy.closeCookieConsent();
-
         email = Cypress.env('TEST_SHOPPER_EMAIL');
         password = Cypress.env('TEST_SHOPPER_PASSWORD');
 
@@ -25,6 +23,10 @@ context('Inventory real-time update', () => {
             // Login after we have the product name
             cy.loginSFRA(email, password);
         });
+    });
+
+    beforeEach(() => {
+        cy.closeCookieConsent();
     });
 
     it('Places order and ensures product removed from Algolia (out of stock)', () => {

--- a/cypress/e2e/inventory-update.cy.js
+++ b/cypress/e2e/inventory-update.cy.js
@@ -11,6 +11,8 @@ let productName;
  */
 context('Inventory real-time update', () => {
     before(() => {
+        cy.closeCookieConsent();
+
         email = Cypress.env('TEST_SHOPPER_EMAIL');
         password = Cypress.env('TEST_SHOPPER_PASSWORD');
 
@@ -31,13 +33,13 @@ context('Inventory real-time update', () => {
 
     it('Places order and ensures product removed from Algolia (out of stock)', () => {
         const host = Cypress.env('SANDBOX_HOST');
-        
+
         // Navigate to homepage first
         cy.visit(`https://${host}/s/RefArch/home`);
-        
+
         // Wait for page to load and search input to be available
         cy.get('#autocomplete-0-input', { timeout: 20000 }).should('be.visible');
-        
+
         // Arrange: Search and open PDP
         cy.get('#autocomplete-0-input').clear()
         cy.get('#autocomplete-0-input').type(productName);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,7 +24,17 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
-// Close cookie consent pop-up
+// Dismiss the cookie consent modal if it's present on the current page
+Cypress.Commands.add('dismissConsentModal', () => {
+    cy.get('body').then(($body) => {
+        if ($body.find('#consent-tracking.show').length) {
+            cy.get('#consent-tracking .affirm').click();
+            cy.get('#consent-tracking', { timeout: 10000 }).should('not.be.visible');
+        }
+    });
+});
+
+// Close cookie consent pop-up (visits a page and dismisses the modal)
 Cypress.Commands.add('closeCookieConsent', () => {
     const host = Cypress.env('SANDBOX_HOST');
     // Visit your website's homepage or search page

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -27,12 +27,16 @@
 // Close cookie consent pop-up
 Cypress.Commands.add('closeCookieConsent', () => {
     const host = Cypress.env('SANDBOX_HOST');
+    cy.intercept('**/ConsentTracking-SetSession*').as('consentTracking');
     // Visit your website's homepage or search page
     cy.visit(`https://${host}/on/demandware.store/Sites-RefArch-Site`);
-    // Wait for the tracking consent modal to appear
+    // Wait for the tracking consent modal to appear (may be slow on CI)
     cy.get('#consent-tracking .affirm', { timeout: 10000 }).then(($affirm) => {
         if ($affirm.length) {
             cy.wrap($affirm).click();
+            // Wait for the consent to be persisted in the session
+            // before navigating away
+            cy.wait('@consentTracking');
         } else {
             cy.log('No cookie consent pop-up found.');
         }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,29 +24,15 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
-// Automatically dismiss the cookie consent modal after every cy.visit()
-Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
-    return originalFn(url, options).then(() => {
-        cy.get('body').then(($body) => {
-            if ($body.find('#consent-tracking.show').length) {
-                cy.get('#consent-tracking .affirm').click();
-                cy.get('#consent-tracking', { timeout: 10000 }).should('not.be.visible');
-            }
-        });
-    });
-});
-
 // Close cookie consent pop-up (visits a page and dismisses the modal)
 Cypress.Commands.add('closeCookieConsent', () => {
-    cy.session('consent-tracking', () => {
-        const host = Cypress.env('SANDBOX_HOST');
-        cy.visit(`https://${host}/on/demandware.store/Sites-RefArch-Site`);
-        cy.get('body').then(($body) => {
-            if ($body.find('#consent-tracking.show').length) {
-                cy.get('#consent-tracking .affirm').click();
-                cy.get('#consent-tracking', { timeout: 10000 }).should('not.be.visible');
-            }
-        });
+    const host = Cypress.env('SANDBOX_HOST');
+    cy.visit(`https://${host}/on/demandware.store/Sites-RefArch-Site`);
+    cy.get('body').then(($body) => {
+        if ($body.find('#consent-tracking.show').length) {
+            cy.get('#consent-tracking .affirm').click();
+            cy.get('#consent-tracking', { timeout: 10000 }).should('not.be.visible');
+        }
     });
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -41,8 +41,12 @@ Cypress.Commands.add('closeCookieConsent', () => {
     cy.session('consent-tracking', () => {
         const host = Cypress.env('SANDBOX_HOST');
         cy.visit(`https://${host}/on/demandware.store/Sites-RefArch-Site`);
-        cy.get('#consent-tracking .affirm', { timeout: 10000 }).click();
-        cy.get('#consent-tracking', { timeout: 10000 }).should('not.be.visible');
+        cy.get('body').then(($body) => {
+            if ($body.find('#consent-tracking.show').length) {
+                cy.get('#consent-tracking .affirm').click();
+                cy.get('#consent-tracking', { timeout: 10000 }).should('not.be.visible');
+            }
+        });
     });
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,7 +24,19 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
-// Close cookie consent pop-up using cy.session() to persist cookies across retries
+// Automatically dismiss the cookie consent modal after every cy.visit()
+Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+    return originalFn(url, options).then(() => {
+        cy.get('body').then(($body) => {
+            if ($body.find('#consent-tracking.show').length) {
+                cy.get('#consent-tracking .affirm').click();
+                cy.get('#consent-tracking', { timeout: 10000 }).should('not.be.visible');
+            }
+        });
+    });
+});
+
+// Close cookie consent pop-up (visits a page and dismisses the modal)
 Cypress.Commands.add('closeCookieConsent', () => {
     cy.session('consent-tracking', () => {
         const host = Cypress.env('SANDBOX_HOST');

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -27,16 +27,15 @@
 // Close cookie consent pop-up
 Cypress.Commands.add('closeCookieConsent', () => {
     const host = Cypress.env('SANDBOX_HOST');
-    cy.intercept('**/ConsentTracking-SetSession*').as('consentTracking');
     // Visit your website's homepage or search page
     cy.visit(`https://${host}/on/demandware.store/Sites-RefArch-Site`);
     // Wait for the tracking consent modal to appear (may be slow on CI)
     cy.get('#consent-tracking .affirm', { timeout: 10000 }).then(($affirm) => {
         if ($affirm.length) {
             cy.wrap($affirm).click();
-            // Wait for the consent to be persisted in the session
-            // before navigating away
-            cy.wait('@consentTracking');
+            // Wait for the modal to fully disappear before navigating away,
+            // ensuring the consent has been persisted in the session
+            cy.get('#consent-tracking', { timeout: 10000 }).should('not.be.visible');
         } else {
             cy.log('No cookie consent pop-up found.');
         }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,31 +24,13 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
-// Dismiss the cookie consent modal if it's present on the current page
-Cypress.Commands.add('dismissConsentModal', () => {
-    cy.get('body').then(($body) => {
-        if ($body.find('#consent-tracking.show').length) {
-            cy.get('#consent-tracking .affirm').click();
-            cy.get('#consent-tracking', { timeout: 10000 }).should('not.be.visible');
-        }
-    });
-});
-
-// Close cookie consent pop-up (visits a page and dismisses the modal)
+// Close cookie consent pop-up using cy.session() to persist cookies across retries
 Cypress.Commands.add('closeCookieConsent', () => {
-    const host = Cypress.env('SANDBOX_HOST');
-    // Visit your website's homepage or search page
-    cy.visit(`https://${host}/on/demandware.store/Sites-RefArch-Site`);
-    // Wait for the tracking consent modal to appear (may be slow on CI)
-    cy.get('#consent-tracking .affirm', { timeout: 10000 }).then(($affirm) => {
-        if ($affirm.length) {
-            cy.wrap($affirm).click();
-            // Wait for the modal to fully disappear before navigating away,
-            // ensuring the consent has been persisted in the session
-            cy.get('#consent-tracking', { timeout: 10000 }).should('not.be.visible');
-        } else {
-            cy.log('No cookie consent pop-up found.');
-        }
+    cy.session('consent-tracking', () => {
+        const host = Cypress.env('SANDBOX_HOST');
+        cy.visit(`https://${host}/on/demandware.store/Sites-RefArch-Site`);
+        cy.get('#consent-tracking .affirm', { timeout: 10000 }).click();
+        cy.get('#consent-tracking', { timeout: 10000 }).should('not.be.visible');
     });
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,15 +29,11 @@ Cypress.Commands.add('closeCookieConsent', () => {
     const host = Cypress.env('SANDBOX_HOST');
     // Visit your website's homepage or search page
     cy.visit(`https://${host}/on/demandware.store/Sites-RefArch-Site`);
-    // Wait for the page to load
-    cy.get('body', { timeout: 20000 }).should('be.visible');
-    // Handle the cookie consent pop-up
-    cy.get('body').then(($body) => {
-        if ($body.find('.affirm').length) {
-            // If the affirm button exists, click it
-            cy.get('.affirm').click();
+    // Wait for the tracking consent modal to appear
+    cy.get('#consent-tracking .affirm', { timeout: 10000 }).then(($affirm) => {
+        if ($affirm.length) {
+            cy.wrap($affirm).click();
         } else {
-            // If the affirm button does not exist, log a message
             cy.log('No cookie consent pop-up found.');
         }
     });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,7 +29,7 @@ Cypress.Commands.add('closeCookieConsent', () => {
     const host = Cypress.env('SANDBOX_HOST');
     cy.visit(`https://${host}/on/demandware.store/Sites-RefArch-Site`);
     cy.get('body').then(($body) => {
-        if ($body.find('#consent-tracking.show').length) {
+        if ($body.find('#consent-tracking').length) {
             cy.get('#consent-tracking .affirm').click();
             cy.get('#consent-tracking', { timeout: 10000 }).should('not.be.visible');
         }


### PR DESCRIPTION
UI tests started to fail consistently, often with the following error:

```
`<input class="aa-Input" aria-autocomplete="both" aria-labelledby="autocomplete-0-label" id="autocomplete-0-input" autocomplete="off" autocorrect="off" autocapitalize="off" enterkeyhint="search" spellcheck="false" placeholder="Search (keywords,etc)" maxlength="512" type="search">`

is being covered by another element:

`<div class="modal show" id="consent-tracking" aria-modal="true" role="dialog" style="display: block; padding-right: 15px;">...</div>`
```

I'm not sure why it was working more reliably locally, but what is sure is that tests are isolated on Cypress by default ([doc](https://docs.cypress.io/app/core-concepts/test-isolation))
This means that each test starts with a fresh browser, so the SFRA consent popup is indeed shown.
Closing it in the `beforeAll` hook is not enough.

### Changes

- Call `closeCookieConsent` before each test
- Improve a bit the popup selector

---
SFCC-503