### PR TITLE
fix: Attribute-sliced guard fix and increased attempt count for E2E job runs

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -87,7 +87,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     variationAttributeForAttributeSlicedRecordModel = algoliaData.getPreference('AttributeSlicedRecordModel_GroupingAttribute');
 
     // throw an error if no "Grouping attribute for the Attribute-sliced record model" is defined when using the "Attribute-sliced" record model
-    if (recordModel === RECORD_MODEL_TYPE.ATTRIBUTE_SLICED_MASTER_LEVEL && empty(variationAttributeForAttributeSlicedRecordModel)) {
+    if (recordModel === RECORD_MODEL_TYPE.ATTRIBUTE_SLICED && empty(variationAttributeForAttributeSlicedRecordModel)) {
         throw new Error('You need to define a grouping attribute for the Attribute-sliced record model in the Algolia BM module!');
     }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -80,7 +80,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     variationAttributeForAttributeSlicedRecordModel = algoliaData.getPreference('AttributeSlicedRecordModel_GroupingAttribute');
 
     // throw an error if no "Grouping attribute for the Attribute-sliced record model" is defined when using the "Attribute-sliced" record model
-    if (recordModel === RECORD_MODEL_TYPE.ATTRIBUTE_SLICED_MASTER_LEVEL && empty(variationAttributeForAttributeSlicedRecordModel)) {
+    if (recordModel === RECORD_MODEL_TYPE.ATTRIBUTE_SLICED && empty(variationAttributeForAttributeSlicedRecordModel)) {
         throw new Error('You need to define a grouping attribute for the Attribute-sliced record model in the Algolia BM module!');
     }
 

--- a/scripts/runSFCCJob.js
+++ b/scripts/runSFCCJob.js
@@ -36,9 +36,9 @@ async function runSFCCJob() {
                             console.log('Current jobs:', JSON.stringify(result, null, 2));
                             // The result might be wrapped in a body property
                             const jobs = result.body || result;
-                            const runningJob = jobs.find(job => 
-                                job.job_id === jobId && 
-                                job.status !== 'finished' && 
+                            const runningJob = jobs.find(job =>
+                                job.job_id === jobId &&
+                                job.status !== 'finished' &&
                                 job.status !== 'failed'
                             );
                             if (runningJob) {
@@ -62,7 +62,7 @@ async function runSFCCJob() {
 
         // Poll for Job Completion
         let attempts = 0;
-        const maxAttempts = 15;
+        const maxAttempts = 25;
         const delay = 15000; // 15 seconds
 
         while (attempts < maxAttempts) {


### PR DESCRIPTION
- fixed guard that forces user to defined a grouping attribute when the Attribute-sliced model is used
- increased attempt count for job runs in end-to-end tests