### PR TITLE
fix: [SFCC-506] failedRecords not being reported properly

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper.js
@@ -7,14 +7,16 @@ const algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
  * Sends an Algolia batch to the Search API `multiple-batch` endpoint
  * https://www.algolia.com/doc/rest-api/search/multiple-batch
  * If records fail to be indexed (because e.g. they are too big), they are removed from the batch and the batch is retried.
- * @param {Object} batch - Algolia multi-indices batch
- * @param {String} [indexName] Target index -- only used with the Ingestion API
- * @return {Object} returns an object with the last call result and the number of failed records.
+ * @param {Object[]} batch - Algolia multi-index batch operations (action, indexName, body)
+ * @return {Object} Last API `result` and `failedRecords`
+ * On success, `failedRecords` is only the count removed during retry (e.g. too big).
+ * On failure, `failedRecords` is the original batch size (no operation from this call completed successfully).
  */
 function sendRetryableBatch(batch) {
     var MAX_ATTEMPTS = 50;
     var attempt = 0;
     var failedRecords = 0;
+    let originalBatchLength = batch.length;
     let result = algoliaIndexingAPI.sendMultiIndexBatch(batch);
 
     while (result.error && attempt < MAX_ATTEMPTS) {
@@ -62,10 +64,11 @@ function sendRetryableBatch(batch) {
     if (attempt === MAX_ATTEMPTS) {
         logger.error('[Retryable batch] Too many products are in error, aborting the batch...');
     }
+
     return {
         result: result,
-        failedRecords: failedRecords,
-    }
+        failedRecords: (!(result && result.ok)) ? originalBatchLength : failedRecords,
+    };
 }
 
 /* --------------------------- Ingestion API methods --------------------------- */
@@ -143,11 +146,12 @@ function groupRecordsForIngestionAPI(recordArray) {
 /**
  * Sends Algolia records to the Ingestion API grouped by indexName and action
  * @param {Object} groupedRecords - Records grouped by `indexName` and `action`.
- * @returns {Object} result object containing status and number of failed records
+ * @returns {Object} result, failedRecords (per failed HTTP call), sentRecords (per successful HTTP call)
  */
 function sendGroupedIngestionAPIRecords(groupedRecords) {
     let indices = Object.keys(groupedRecords);
     let failedRecords = 0;
+    let sentRecords = 0;
     let wasThereAnError = false;
 
     // iterate over the grouped batches by indexName and action, and send them
@@ -168,6 +172,8 @@ function sendGroupedIngestionAPIRecords(groupedRecords) {
             if (!(result.ok)) {
                 wasThereAnError = true;
                 failedRecords += recordToSend.records.length;
+            } else {
+                sentRecords += recordToSend.records.length;
             }
         }
     }
@@ -177,7 +183,8 @@ function sendGroupedIngestionAPIRecords(groupedRecords) {
             ok: !wasThereAnError,
         },
         failedRecords: failedRecords,
-    }
+        sentRecords: sentRecords,
+    };
 }
 
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
@@ -125,7 +125,6 @@ function runCategoryExport(parameters, stepExecution) {
         try {
             var retryableBatchRes = requestHelper.sendRetryableBatch(batch);
             result = retryableBatchRes.result;
-            jobReport.recordsFailed += retryableBatchRes.failedRecords;
         } catch (e) {
             logger.error('Error while sending batch to Algolia: ' + e);
         }
@@ -133,6 +132,7 @@ function runCategoryExport(parameters, stepExecution) {
         if (result && result.ok) {
             jobReport.recordsSent += batch.length;
             jobReport.chunksSent++;
+            jobReport.recordsFailed += retryableBatchRes.failedRecords;
 
             // Store Algolia indexing task IDs
             var taskIDs = result.object.body.taskID;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaCategoryIndex.js
@@ -122,8 +122,9 @@ function runCategoryExport(parameters, stepExecution) {
         logger.info('Sending a batch of ' + batch.length + ' records for locale ' + locale);
 
         var result;
+        var retryableBatchRes;
         try {
-            var retryableBatchRes = requestHelper.sendRetryableBatch(batch);
+            retryableBatchRes = requestHelper.sendRetryableBatch(batch);
             result = retryableBatchRes.result;
         } catch (e) {
             logger.error('Error while sending batch to Algolia: ' + e);
@@ -132,17 +133,23 @@ function runCategoryExport(parameters, stepExecution) {
         if (result && result.ok) {
             jobReport.recordsSent += batch.length;
             jobReport.chunksSent++;
-            jobReport.recordsFailed += retryableBatchRes.failedRecords;
+            jobReport.recordsFailed += retryableBatchRes.failedRecords || 0;
 
             // Store Algolia indexing task IDs
-            var taskIDs = result.object.body.taskID;
-            Object.keys(taskIDs).forEach(function (taskIndexName) {
-                lastIndexingTasks[taskIndexName] = taskIDs[taskIndexName];
-            });
+            if (result.object && result.object.body && result.object.body.taskID) {
+                var taskIDs = result.object.body.taskID;
+                Object.keys(taskIDs).forEach(function (taskIndexName) {
+                    lastIndexingTasks[taskIndexName] = taskIDs[taskIndexName];
+                });
+            }
         } else {
-            let errorMessage = 'Failed to send categories: ' + result.errorMessage + ', stopping job.';
+            let algoliaErrDetail = '';
+            if (result && typeof result.getErrorMessage === 'function') {
+                algoliaErrDetail = result.getErrorMessage();
+            }
+            let errorMessage = 'Failed to send categories: ' + algoliaErrDetail + ', stopping job.';
 
-            jobReport.recordsFailed += batch.length;
+            jobReport.recordsFailed += retryableBatchRes ? retryableBatchRes.failedRecords : batch.length;
             jobReport.chunksFailed++;
             jobReport.error = true;
             jobReport.errorMessage = errorMessage;
@@ -156,12 +163,8 @@ function runCategoryExport(parameters, stepExecution) {
         }
     }
 
-    if (jobReport.recordsFailed === 0) {
-        reindexHelper.finishAtomicReindex('categories', siteLocales.toArray(), lastIndexingTasks);
-    } else {
-        jobReport.error = true;
-        jobReport.errorMessage = 'Some records failed to be indexed (check the logs for details). Not moving temporary indices to production.';
-    }
+    // All locale batches returned OK from Algolia (oversized records are dropped inside sendRetryableBatch; recordsFailed > 0 is OK)
+    reindexHelper.finishAtomicReindex('categories', siteLocales.toArray(), lastIndexingTasks);
 
     jobReport.endTime = new Date();
     jobReport.writeToCustomObject();

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
@@ -223,7 +223,6 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
     try {
         var retryableBatchRes = requestHelper.sendRetryableBatch(batch);
         result = retryableBatchRes.result;
-        jobReport.recordsFailed += retryableBatchRes.failedRecords;
     } catch (e) {
         logger.error('Error while sending batch to Algolia: ' + e);
     }
@@ -231,6 +230,7 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
     if (result && result.ok) {
         jobReport.recordsSent += batch.length;
         jobReport.chunksSent++;
+        jobReport.recordsFailed += retryableBatchRes.failedRecords;
 
         // Store Algolia indexing task IDs.
         // When performing a fullContentReindex, afterStep will wait for the last indexing tasks to complete.

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
@@ -220,8 +220,9 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
     }
 
     var result;
+    var retryableBatchRes;
     try {
-        var retryableBatchRes = requestHelper.sendRetryableBatch(batch);
+        retryableBatchRes = requestHelper.sendRetryableBatch(batch);
         result = retryableBatchRes.result;
     } catch (e) {
         logger.error('Error while sending batch to Algolia: ' + e);
@@ -230,16 +231,18 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
     if (result && result.ok) {
         jobReport.recordsSent += batch.length;
         jobReport.chunksSent++;
-        jobReport.recordsFailed += retryableBatchRes.failedRecords;
+        jobReport.recordsFailed += retryableBatchRes.failedRecords || 0;
 
         // Store Algolia indexing task IDs.
         // When performing a fullContentReindex, afterStep will wait for the last indexing tasks to complete.
-        var taskIDs = result.object.body.taskID;
-        Object.keys(taskIDs).forEach(function (taskIndexName) {
-            lastIndexingTasks[taskIndexName] = taskIDs[taskIndexName];
-        });
+        if (result.object && result.object.body && result.object.body.taskID) {
+            var taskIDs = result.object.body.taskID;
+            Object.keys(taskIDs).forEach(function (taskIndexName) {
+                lastIndexingTasks[taskIndexName] = taskIDs[taskIndexName];
+            });
+        }
     } else {
-        jobReport.recordsFailed += batch.length;
+        jobReport.recordsFailed += retryableBatchRes ? retryableBatchRes.failedRecords : batch.length;
         jobReport.chunksFailed++;
     }
 }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -654,9 +654,14 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
     if (result && result.ok) {
         jobReport.recordsSent += batch.length;
         jobReport.chunksSent++;
-        jobReport.recordsFailed += resultObj.failedRecords;
+        jobReport.recordsFailed += resultObj.failedRecords || 0;
     } else {
-        jobReport.recordsFailed += batch.length;
+        if (indexingAPI === INDEXING_APIS.INGESTION_API && resultObj) {
+            jobReport.recordsSent += resultObj.sentRecords || 0;
+            jobReport.recordsFailed += resultObj.failedRecords || 0;
+        } else {
+            jobReport.recordsFailed += (resultObj && resultObj.failedRecords) ? resultObj.failedRecords : batch.length;
+        }
         jobReport.chunksFailed++;
     }
 }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -650,11 +650,11 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
     // An OK response from a sending call only means that the endpoint received the payload;
     // "record too large" or other indexing-time errors can still happen -- check your Algolia Dashboard for these errors
     let result = resultObj.result;
-    jobReport.recordsFailed += resultObj.failedRecords;
 
-    if (result.ok) {
+    if (result && result.ok) {
         jobReport.recordsSent += batch.length;
         jobReport.chunksSent++;
+        jobReport.recordsFailed += resultObj.failedRecords;
     } else {
         jobReport.recordsFailed += batch.length;
         jobReport.chunksFailed++;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -538,13 +538,16 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
         return;
     }
 
+    // fullCatalogReindex still uses Search API (multiple-batch); must match failure/success accounting below
+    var sendViaSearchAPI = indexingAPI === INDEXING_APIS.SEARCH_API || paramIndexingMethod === 'fullCatalogReindex';
+
     let resultObj, result;
 
     try {
         // TODO: implement full reindexing via the Ingestion API
-        if (indexingAPI === INDEXING_APIS.SEARCH_API || paramIndexingMethod === 'fullCatalogReindex') {
+        if (sendViaSearchAPI) {
             resultObj = requestHelper.sendRetryableBatch(batch);
-        } else { // INDEXING_APIS.INGESTION_API
+        } else {
             let sortedRecords = requestHelper.groupRecordsForIngestionAPI(batch);
             resultObj = requestHelper.sendGroupedIngestionAPIRecords(sortedRecords);
         }
@@ -561,18 +564,25 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
     if (result && result.ok) {
         jobReport.recordsSent += batch.length;
         jobReport.chunksSent++;
-        jobReport.recordsFailed += resultObj.failedRecords;
+        // Search send path: failedRecords = removed-only after a successful final batch; Ingestion path: 0 here
+        jobReport.recordsFailed += resultObj.failedRecords || 0;
 
         // Store Algolia indexing task IDs.
         // When performing a fullCatalogReindex, afterStep will wait for the last indexing tasks to complete.
-        if (indexingAPI === INDEXING_APIS.SEARCH_API || paramIndexingMethod === 'fullCatalogReindex') {
+        if (sendViaSearchAPI && result.object && result.object.body && result.object.body.taskID) {
             var taskIDs = result.object.body.taskID;
             Object.keys(taskIDs).forEach(function (taskIndexName) {
                 lastIndexingTasks[taskIndexName] = taskIDs[taskIndexName];
             });
         }
     } else {
-        jobReport.recordsFailed += batch.length;
+        if (!sendViaSearchAPI && resultObj) {
+            jobReport.recordsSent += resultObj.sentRecords || 0;
+            jobReport.recordsFailed += resultObj.failedRecords || 0;
+        } else {
+            // Search send path (or missing resultObj): sendRetryableBatch.failedRecords is the original batch size when the last call did not succeed
+            jobReport.recordsFailed += (resultObj && resultObj.failedRecords) ? resultObj.failedRecords : batch.length;
+        }
         jobReport.chunksFailed++;
     }
 }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -553,7 +553,7 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
         // An OK response from a sending call only means that the endpoint received the payload;
         // "record too large" or other indexing-time errors can still happen -- check your Algolia Dashboard for these errors
         result = resultObj.result;
-        jobReport.recordsFailed += resultObj.failedRecords;
+
     } catch (e) {
         logger.error('Error while sending batch to Algolia: ' + e);
     }
@@ -561,6 +561,7 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
     if (result && result.ok) {
         jobReport.recordsSent += batch.length;
         jobReport.chunksSent++;
+        jobReport.recordsFailed += resultObj.failedRecords;
 
         // Store Algolia indexing task IDs.
         // When performing a fullCatalogReindex, afterStep will wait for the last indexing tasks to complete.


### PR DESCRIPTION
Fixed failed and successful record counting in all relevant jobs:
- algoliaCategoryIndex
- algoliaContentIndex
- algoliaProductDeltaIndex
- algoliaProductIndex

When indexing with the Search API:
- records removed by `sendRetryableBatch` count towards `failedRecords`, but otherwise call is OK
- if the call fails even after MAX_ATTEMPTS, then the entire batch size is added to `failedRecords`.

Previously, due to the failed records being counted twice, failed records percentage could reach 200% in the logs, this is now fixed.

<img width="814" height="503" alt="image (3)" src="https://github.com/user-attachments/assets/a622c0e3-c25d-4579-8161-acb6e4afe6c0" />

Before:
<img width="1010" height="288" alt="image" src="https://github.com/user-attachments/assets/656ae079-969d-48bb-8294-dd174fe5856f" />

After:
<img width="1017" height="347" alt="image" src="https://github.com/user-attachments/assets/30b2a465-0250-4a62-bfab-d66409a2d700" />

Will revisit the solution once the Ingestion feature is ready.