### PR TITLE
fix: [SFCC-489] Algolia BM site preference error and warning handling fix

### DIFF
--- a/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
+++ b/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
@@ -65,13 +65,12 @@ function handleSettings() {
         );
 
         // validate AdminApiKey
-        if (adminValidation.error) {
+        if (!empty(adminValidation.error)) {
             pdictValues.errors.adminErrorMessage = adminValidation.errorMessage;
-            pdictValues.errors.adminWarningMessage = adminValidation.warning || '';
         }
 
-        if (adminValidation.warning) {
-            pdictValues.errors.adminWarningMessage = adminValidation.warning;
+        if (!empty(adminValidation.warning)) {
+            pdictValues.warnings.adminWarningMessage = adminValidation.warning;
         }
 
         // validate AnalyticsRegion (empty allowed so that it doesn't force a value for initial setup; non-empty must be eu or us)
@@ -79,7 +78,7 @@ function handleSettings() {
             pdictValues.errors.analyticsRegionErrorMessage = Resource.msg('algolia.error.analyticsregion.invalid', 'algolia', null);
         }
 
-        // if any of the errors are set, render the dashboard with the errors before saving the preferences
+        // if any of the errors are set, render the dashboard with the errors and don't save the preferences -- warnings do not block saving the preferences
         let errorKeys = Object.keys(pdictValues.errors);
         for (let i = 0; i < errorKeys.length; i++) {
             let errorKey = errorKeys[i];
@@ -138,10 +137,12 @@ function getDashboardPdict() {
         algoliaData: algoliaData,
         errors: {
             adminErrorMessage: '',
-            adminWarningMessage: '',
             analyticsRegionErrorMessage: '',
             errorMessage: ''
-        }
+        },
+        warnings: {
+            adminWarningMessage: '',
+        },
     };
 }
 

--- a/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
+++ b/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
@@ -77,9 +77,9 @@
                         <div class="tooltip">
                             <isprint value="${Resource.msg('algolia.label.preference.adminkey.help', 'algolia', null)}" />
                         </div>
-                        <isif condition="${pdict.errors.adminWarningMessage}">
+                        <isif condition="${pdict.warnings.adminWarningMessage}">
                             <div class="warning-message yellow narrow">
-                                ${pdict.errors.adminWarningMessage}
+                                ${pdict.warnings.adminWarningMessage}
                             </div>
                         </isif>
                         <isif condition="${pdict.errors.adminErrorMessage}">


### PR DESCRIPTION
The code from previous pull request #262 prevents saving the site preferences not only if there are errors, but also if there are warnings, like this one:
<img width="488" height="139" alt="image" src="https://github.com/user-attachments/assets/0a76692a-00a9-4781-afbe-88aa8fde88ae" />

Warnings should not prevent saving the site preferences, but they should still be displayed after saving them.

This PR conceptually separates errors from warnings and only stops before saving if there are errors.
