### PR TITLE
feat: [SFCC-500] Unit tests and snapshots for Ingestion

### DIFF
--- a/test/unit/int_algolia/scripts/algolia/__snapshots__/algoliaIndexingAPI.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/__snapshots__/algoliaIndexingAPI.test.js.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pushByIndexName - HTTP request snapshots addObject push for fullCatalogReindex with realistic payload: fullCatalogReindex push request params 1`] = `
+{
+  "body": {
+    "action": "addObject",
+    "records": [
+      {
+        "in_stock": true,
+        "name": "Fitted Shirt",
+        "objectID": "M-25592581",
+        "price": {
+          "EUR": 24.99,
+          "USD": 29.99,
+        },
+        "variants": [
+          {
+            "color": "JJB52A0",
+            "objectID": "701644031206M",
+            "size": "004",
+          },
+        ],
+      },
+      {
+        "in_stock": true,
+        "name": "Classic Jeans",
+        "objectID": "M-25604524",
+        "price": {
+          "EUR": 39.99,
+          "USD": 49.99,
+        },
+        "variants": [
+          {
+            "color": "BLK",
+            "objectID": "701644031300M",
+            "size": "032",
+          },
+        ],
+      },
+    ],
+  },
+  "indexingAPI": "ingestion-api",
+  "method": "POST",
+  "path": "/1/push/test_products_en.tmp?referenceIndexName=test_products_en",
+}
+`;
+
+exports[`pushByIndexName - HTTP request snapshots deleteObject push for delta index: delta deleteObject push request params 1`] = `
+{
+  "body": {
+    "action": "deleteObject",
+    "records": [
+      {
+        "objectID": "701644031206M",
+      },
+      {
+        "objectID": "701644031300M",
+      },
+    ],
+  },
+  "indexingAPI": "ingestion-api",
+  "method": "POST",
+  "path": "/1/push/test_products_en",
+}
+`;
+
+exports[`pushByIndexName - HTTP request snapshots partialUpdateObject push for inventory update: inventory update push request params 1`] = `
+{
+  "body": {
+    "action": "partialUpdateObject",
+    "records": [
+      {
+        "objectID": "M-25592581",
+        "variants": [
+          {
+            "in_stock": false,
+            "objectID": "701644031206M",
+          },
+        ],
+      },
+    ],
+  },
+  "indexingAPI": "ingestion-api",
+  "method": "POST",
+  "path": "/1/push/test_products_en",
+}
+`;

--- a/test/unit/int_algolia/scripts/algolia/algoliaIndexingAPI.test.js
+++ b/test/unit/int_algolia/scripts/algolia/algoliaIndexingAPI.test.js
@@ -223,4 +223,82 @@ describe('waitForRunEvent', () => {
 
         expect(mockRetryableCall).toHaveBeenCalledTimes(1);
     });
+
+    test('continues polling on non-404 error', () => {
+        mockRetryableCall
+            .mockReturnValueOnce({
+                ok: false,
+                error: 500,
+                getErrorMessage: () => 'Internal Server Error',
+            })
+            .mockReturnValueOnce({
+                ok: false,
+                error: 404,
+                getErrorMessage: () => 'Not found',
+            })
+            .mockReturnValue({
+                ok: true,
+                object: { body: { eventID: 'evt-abc', runID: 'run-uuid-123' }}
+            });
+
+        indexingAPI.waitForRunEvent('run-uuid-123', 'evt-abc');
+
+        expect(mockRetryableCall).toHaveBeenCalledTimes(3);
+    });
+
+    test('throws on timeout when event never becomes available', () => {
+        const originalDateNow = Date.now;
+        let callCount = 0;
+        Date.now = jest.fn(() => {
+            callCount++;
+            if (callCount <= 2) return 0;
+            return 999999999;
+        });
+
+        mockRetryableCall.mockReturnValue({
+            ok: false,
+            error: 404,
+            getErrorMessage: () => 'Not found',
+        });
+
+        expect(() => {
+            indexingAPI.waitForRunEvent('run-timeout', 'evt-timeout');
+        }).toThrow('Max wait time reached. Run: run-timeout; event: evt-timeout');
+
+        Date.now = originalDateNow;
+    });
+});
+
+describe('pushByIndexName - failure', () => {
+    test('returns failed result when retryableCall fails', () => {
+        mockRetryableCall.mockReturnValue({
+            ok: false,
+            getErrorMessage: () => 'Service unavailable',
+        });
+
+        const payload = { action: 'addObject', records: [{ objectID: '1' }] };
+        const result = indexingAPI.pushByIndexName(payload, 'my_index');
+
+        expect(result.ok).toBe(false);
+        expect(mockRetryableCall).toHaveBeenCalledWith(mockService, expect.objectContaining({
+            method: 'POST',
+            path: '/1/push/my_index',
+            indexingAPI: 'ingestion-api',
+        }));
+    });
+
+    test('returns failed result for fullCatalogReindex path', () => {
+        mockRetryableCall.mockReturnValue({
+            ok: false,
+            getErrorMessage: () => 'Bad request',
+        });
+
+        const payload = { action: 'addObject', records: [{ objectID: '1' }] };
+        const result = indexingAPI.pushByIndexName(payload, 'my_index.tmp', 'fullCatalogReindex');
+
+        expect(result.ok).toBe(false);
+        expect(mockRetryableCall).toHaveBeenCalledWith(mockService, expect.objectContaining({
+            path: '/1/push/my_index.tmp?referenceIndexName=my_index',
+        }));
+    });
 });

--- a/test/unit/int_algolia/scripts/algolia/algoliaIndexingAPI.test.js
+++ b/test/unit/int_algolia/scripts/algolia/algoliaIndexingAPI.test.js
@@ -148,6 +148,44 @@ test('waitForTask', () => {
     });
 });
 
+describe('pushByIndexName', () => {
+    test('sends to Ingestion API without referenceIndexName for non-tmp index', () => {
+        const payload = { action: 'addObject', records: [{ objectID: '1' }] };
+        indexingAPI.pushByIndexName(payload, 'my_index');
+
+        expect(mockRetryableCall).toHaveBeenCalledWith(mockService, {
+            method: 'POST',
+            path: '/1/push/my_index',
+            body: payload,
+            indexingAPI: 'ingestion-api',
+        });
+    });
+
+    test('appends referenceIndexName query param for fullCatalogReindex', () => {
+        const payload = { action: 'addObject', records: [{ objectID: '1' }] };
+        indexingAPI.pushByIndexName(payload, 'my_index.tmp', 'fullCatalogReindex');
+
+        expect(mockRetryableCall).toHaveBeenCalledWith(mockService, {
+            method: 'POST',
+            path: '/1/push/my_index.tmp?referenceIndexName=my_index',
+            body: payload,
+            indexingAPI: 'ingestion-api',
+        });
+    });
+
+    test('does not append referenceIndexName without fullCatalogReindex even for .tmp index', () => {
+        const payload = { action: 'addObject', records: [{ objectID: '1' }] };
+        indexingAPI.pushByIndexName(payload, 'my_index.tmp');
+
+        expect(mockRetryableCall).toHaveBeenCalledWith(mockService, {
+            method: 'POST',
+            path: '/1/push/my_index.tmp',
+            body: payload,
+            indexingAPI: 'ingestion-api',
+        });
+    });
+});
+
 describe('waitForRunEvent', () => {
     test('polls event endpoint until non-404', () => {
         mockRetryableCall

--- a/test/unit/int_algolia/scripts/algolia/algoliaIndexingAPI.test.js
+++ b/test/unit/int_algolia/scripts/algolia/algoliaIndexingAPI.test.js
@@ -186,6 +186,49 @@ describe('pushByIndexName', () => {
     });
 });
 
+describe('pushByIndexName - HTTP request snapshots', () => {
+    test('addObject push for fullCatalogReindex with realistic payload', () => {
+        const payload = {
+            action: 'addObject',
+            records: [
+                { objectID: 'M-25592581', name: 'Fitted Shirt', price: { USD: 29.99, EUR: 24.99 }, in_stock: true, variants: [{ objectID: '701644031206M', color: 'JJB52A0', size: '004' }] },
+                { objectID: 'M-25604524', name: 'Classic Jeans', price: { USD: 49.99, EUR: 39.99 }, in_stock: true, variants: [{ objectID: '701644031300M', color: 'BLK', size: '032' }] },
+            ],
+        };
+
+        indexingAPI.pushByIndexName(payload, 'test_products_en.tmp', 'fullCatalogReindex');
+
+        expect(mockRetryableCall.mock.calls[0][1]).toMatchSnapshot('fullCatalogReindex push request params');
+    });
+
+    test('deleteObject push for delta index', () => {
+        const payload = {
+            action: 'deleteObject',
+            records: [
+                { objectID: '701644031206M' },
+                { objectID: '701644031300M' },
+            ],
+        };
+
+        indexingAPI.pushByIndexName(payload, 'test_products_en');
+
+        expect(mockRetryableCall.mock.calls[0][1]).toMatchSnapshot('delta deleteObject push request params');
+    });
+
+    test('partialUpdateObject push for inventory update', () => {
+        const payload = {
+            action: 'partialUpdateObject',
+            records: [
+                { objectID: 'M-25592581', variants: [{ objectID: '701644031206M', in_stock: false }] },
+            ],
+        };
+
+        indexingAPI.pushByIndexName(payload, 'test_products_en');
+
+        expect(mockRetryableCall.mock.calls[0][1]).toMatchSnapshot('inventory update push request params');
+    });
+});
+
 describe('waitForRunEvent', () => {
     test('polls event endpoint until non-404', () => {
         mockRetryableCall

--- a/test/unit/int_algolia/scripts/algolia/helper/__snapshots__/requestHelper.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/helper/__snapshots__/requestHelper.test.js.snap
@@ -116,9 +116,11 @@ exports[`Ingestion API payload snapshots delta index flow: mixed addObject and d
     "object": {
       "body": {
         "indexingEvents": {
-          "run-delta": [
+          "run-test_products_en": [
             "evt-1",
             "evt-2",
+          ],
+          "run-test_products_fr": [
             "evt-3",
             "evt-4",
           ],
@@ -302,10 +304,10 @@ exports[`Ingestion API payload snapshots full reindex flow: grouping → push pa
     "object": {
       "body": {
         "indexingEvents": {
-          "run-testproductsentmp": [
+          "run-test_products_en.tmp": [
             "evt-1",
           ],
-          "run-testproductsfrtmp": [
+          "run-test_products_fr.tmp": [
             "evt-2",
           ],
         },
@@ -396,8 +398,10 @@ exports[`Ingestion API payload snapshots inventory update flow: single partialUp
     "object": {
       "body": {
         "indexingEvents": {
-          "run-inv": [
+          "run-test_products_en": [
             "evt-1",
+          ],
+          "run-test_products_fr": [
             "evt-2",
           ],
         },

--- a/test/unit/int_algolia/scripts/algolia/helper/__snapshots__/requestHelper.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/helper/__snapshots__/requestHelper.test.js.snap
@@ -1,0 +1,526 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Ingestion API payload snapshots delta index flow: mixed addObject and deleteObject payloads: grouped records for delta index 1`] = `
+{
+  "test_products_en": {
+    "addObject": [
+      {
+        "in_stock": true,
+        "name": "Fitted Shirt",
+        "objectID": "701644031206M",
+        "price": {
+          "USD": 29.99,
+        },
+      },
+    ],
+    "deleteObject": [
+      {
+        "objectID": "701644031300M",
+      },
+    ],
+  },
+  "test_products_fr": {
+    "addObject": [
+      {
+        "in_stock": true,
+        "name": "Chemise ajustée",
+        "objectID": "701644031206M",
+        "price": {
+          "EUR": 24.99,
+        },
+      },
+    ],
+    "deleteObject": [
+      {
+        "objectID": "701644031300M",
+      },
+    ],
+  },
+}
+`;
+
+exports[`Ingestion API payload snapshots delta index flow: mixed addObject and deleteObject payloads: pushByIndexName call 1 1`] = `
+{
+  "indexName": "test_products_en",
+  "indexingMethod": undefined,
+  "payload": {
+    "action": "addObject",
+    "records": [
+      {
+        "in_stock": true,
+        "name": "Fitted Shirt",
+        "objectID": "701644031206M",
+        "price": {
+          "USD": 29.99,
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`Ingestion API payload snapshots delta index flow: mixed addObject and deleteObject payloads: pushByIndexName call 2 1`] = `
+{
+  "indexName": "test_products_en",
+  "indexingMethod": undefined,
+  "payload": {
+    "action": "deleteObject",
+    "records": [
+      {
+        "objectID": "701644031300M",
+      },
+    ],
+  },
+}
+`;
+
+exports[`Ingestion API payload snapshots delta index flow: mixed addObject and deleteObject payloads: pushByIndexName call 3 1`] = `
+{
+  "indexName": "test_products_fr",
+  "indexingMethod": undefined,
+  "payload": {
+    "action": "addObject",
+    "records": [
+      {
+        "in_stock": true,
+        "name": "Chemise ajustée",
+        "objectID": "701644031206M",
+        "price": {
+          "EUR": 24.99,
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`Ingestion API payload snapshots delta index flow: mixed addObject and deleteObject payloads: pushByIndexName call 4 1`] = `
+{
+  "indexName": "test_products_fr",
+  "indexingMethod": undefined,
+  "payload": {
+    "action": "deleteObject",
+    "records": [
+      {
+        "objectID": "701644031300M",
+      },
+    ],
+  },
+}
+`;
+
+exports[`Ingestion API payload snapshots delta index flow: mixed addObject and deleteObject payloads: sendGroupedIngestionAPIRecords response 1`] = `
+{
+  "failedRecords": 0,
+  "result": {
+    "object": {
+      "body": {
+        "indexingEvents": {
+          "run-delta": [
+            "evt-1",
+            "evt-2",
+            "evt-3",
+            "evt-4",
+          ],
+        },
+      },
+    },
+    "ok": true,
+  },
+}
+`;
+
+exports[`Ingestion API payload snapshots full reindex flow: grouping → push payloads → response: grouped records for fullCatalogReindex 1`] = `
+{
+  "test_products_en.tmp": {
+    "addObject": [
+      {
+        "in_stock": true,
+        "name": "Fitted Shirt",
+        "objectID": "M-25592581",
+        "price": {
+          "EUR": 24.99,
+          "USD": 29.99,
+        },
+        "variants": [
+          {
+            "color": "JJB52A0",
+            "objectID": "701644031206M",
+            "size": "004",
+          },
+        ],
+      },
+      {
+        "in_stock": true,
+        "name": "Classic Jeans",
+        "objectID": "M-25604524",
+        "price": {
+          "EUR": 39.99,
+          "USD": 49.99,
+        },
+        "variants": [
+          {
+            "color": "BLK",
+            "objectID": "701644031300M",
+            "size": "032",
+          },
+        ],
+      },
+    ],
+  },
+  "test_products_fr.tmp": {
+    "addObject": [
+      {
+        "in_stock": true,
+        "name": "Chemise ajustée",
+        "objectID": "M-25592581",
+        "price": {
+          "EUR": 24.99,
+          "USD": 29.99,
+        },
+        "variants": [
+          {
+            "color": "JJB52A0",
+            "objectID": "701644031206M",
+            "size": "004",
+          },
+        ],
+      },
+      {
+        "in_stock": true,
+        "name": "Jean classique",
+        "objectID": "M-25604524",
+        "price": {
+          "EUR": 39.99,
+          "USD": 49.99,
+        },
+        "variants": [
+          {
+            "color": "BLK",
+            "objectID": "701644031300M",
+            "size": "032",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`Ingestion API payload snapshots full reindex flow: grouping → push payloads → response: pushByIndexName call 1 1`] = `
+{
+  "indexName": "test_products_en.tmp",
+  "indexingMethod": "fullCatalogReindex",
+  "payload": {
+    "action": "addObject",
+    "records": [
+      {
+        "in_stock": true,
+        "name": "Fitted Shirt",
+        "objectID": "M-25592581",
+        "price": {
+          "EUR": 24.99,
+          "USD": 29.99,
+        },
+        "variants": [
+          {
+            "color": "JJB52A0",
+            "objectID": "701644031206M",
+            "size": "004",
+          },
+        ],
+      },
+      {
+        "in_stock": true,
+        "name": "Classic Jeans",
+        "objectID": "M-25604524",
+        "price": {
+          "EUR": 39.99,
+          "USD": 49.99,
+        },
+        "variants": [
+          {
+            "color": "BLK",
+            "objectID": "701644031300M",
+            "size": "032",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`Ingestion API payload snapshots full reindex flow: grouping → push payloads → response: pushByIndexName call 2 1`] = `
+{
+  "indexName": "test_products_fr.tmp",
+  "indexingMethod": "fullCatalogReindex",
+  "payload": {
+    "action": "addObject",
+    "records": [
+      {
+        "in_stock": true,
+        "name": "Chemise ajustée",
+        "objectID": "M-25592581",
+        "price": {
+          "EUR": 24.99,
+          "USD": 29.99,
+        },
+        "variants": [
+          {
+            "color": "JJB52A0",
+            "objectID": "701644031206M",
+            "size": "004",
+          },
+        ],
+      },
+      {
+        "in_stock": true,
+        "name": "Jean classique",
+        "objectID": "M-25604524",
+        "price": {
+          "EUR": 39.99,
+          "USD": 49.99,
+        },
+        "variants": [
+          {
+            "color": "BLK",
+            "objectID": "701644031300M",
+            "size": "032",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`Ingestion API payload snapshots full reindex flow: grouping → push payloads → response: sendGroupedIngestionAPIRecords response 1`] = `
+{
+  "failedRecords": 0,
+  "result": {
+    "object": {
+      "body": {
+        "indexingEvents": {
+          "run-testproductsentmp": [
+            "evt-1",
+          ],
+          "run-testproductsfrtmp": [
+            "evt-2",
+          ],
+        },
+      },
+    },
+    "ok": true,
+  },
+}
+`;
+
+exports[`Ingestion API payload snapshots inventory update flow: single partialUpdateObject per locale: grouped records for inventory update 1`] = `
+{
+  "test_products_en": {
+    "partialUpdateObject": [
+      {
+        "objectID": "M-25592581",
+        "variants": [
+          {
+            "in_stock": false,
+            "objectID": "701644031206M",
+          },
+        ],
+      },
+    ],
+  },
+  "test_products_fr": {
+    "partialUpdateObject": [
+      {
+        "objectID": "M-25592581",
+        "variants": [
+          {
+            "in_stock": false,
+            "objectID": "701644031206M",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`Ingestion API payload snapshots inventory update flow: single partialUpdateObject per locale: pushByIndexName call 1 1`] = `
+{
+  "indexName": "test_products_en",
+  "indexingMethod": undefined,
+  "payload": {
+    "action": "partialUpdateObject",
+    "records": [
+      {
+        "objectID": "M-25592581",
+        "variants": [
+          {
+            "in_stock": false,
+            "objectID": "701644031206M",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`Ingestion API payload snapshots inventory update flow: single partialUpdateObject per locale: pushByIndexName call 2 1`] = `
+{
+  "indexName": "test_products_fr",
+  "indexingMethod": undefined,
+  "payload": {
+    "action": "partialUpdateObject",
+    "records": [
+      {
+        "objectID": "M-25592581",
+        "variants": [
+          {
+            "in_stock": false,
+            "objectID": "701644031206M",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`Ingestion API payload snapshots inventory update flow: single partialUpdateObject per locale: sendGroupedIngestionAPIRecords response 1`] = `
+{
+  "failedRecords": 0,
+  "result": {
+    "object": {
+      "body": {
+        "indexingEvents": {
+          "run-inv": [
+            "evt-1",
+            "evt-2",
+          ],
+        },
+      },
+    },
+    "ok": true,
+  },
+}
+`;
+
+exports[`groupRecordsForIngestionAPI - realistic multi-locale product batch: multi-locale grouped records with mixed actions 1`] = `
+{
+  "test_products_en.tmp": {
+    "addObject": [
+      {
+        "in_stock": true,
+        "name": "Fitted Shirt",
+        "objectID": "M-25592581",
+        "price": {
+          "EUR": 24.99,
+          "USD": 29.99,
+        },
+        "variants": [
+          {
+            "color": "JJB52A0",
+            "objectID": "701644031206M",
+            "size": "004",
+          },
+        ],
+      },
+      {
+        "in_stock": true,
+        "name": "Classic Jeans",
+        "objectID": "M-25604524",
+        "price": {
+          "EUR": 39.99,
+          "USD": 49.99,
+        },
+        "variants": [
+          {
+            "color": "BLK",
+            "objectID": "701644031300M",
+            "size": "032",
+          },
+        ],
+      },
+    ],
+    "deleteObject": [
+      {
+        "objectID": "M-99999999",
+      },
+    ],
+  },
+  "test_products_fr.tmp": {
+    "addObject": [
+      {
+        "in_stock": true,
+        "name": "Chemise ajustée",
+        "objectID": "M-25592581",
+        "price": {
+          "EUR": 24.99,
+          "USD": 29.99,
+        },
+        "variants": [
+          {
+            "color": "JJB52A0",
+            "objectID": "701644031206M",
+            "size": "004",
+          },
+        ],
+      },
+      {
+        "in_stock": true,
+        "name": "Jean classique",
+        "objectID": "M-25604524",
+        "price": {
+          "EUR": 39.99,
+          "USD": 49.99,
+        },
+        "variants": [
+          {
+            "color": "BLK",
+            "objectID": "701644031300M",
+            "size": "032",
+          },
+        ],
+      },
+    ],
+    "deleteObject": [
+      {
+        "objectID": "M-99999999",
+      },
+    ],
+  },
+}
+`;
+
+exports[`groupRecordsForIngestionAPI: grouped records by index and action 1`] = `
+{
+  "index_en": {
+    "addObject": [
+      {
+        "name": "Product 1",
+        "objectID": "1",
+      },
+      {
+        "name": "Product 2",
+        "objectID": "2",
+      },
+    ],
+    "deleteObject": [
+      {
+        "objectID": "3",
+      },
+    ],
+  },
+  "index_fr": {
+    "addObject": [
+      {
+        "name": "Produit 1",
+        "objectID": "1",
+      },
+    ],
+  },
+}
+`;

--- a/test/unit/int_algolia/scripts/algolia/helper/reindexHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/reindexHelper.test.js
@@ -105,3 +105,80 @@ test('waitForEvents', () => {
     expect(mockWaitForRunEvent).toHaveBeenCalledWith('run-1', 'evt-3');
     expect(mockWaitForRunEvent).toHaveBeenCalledWith('run-2', 'evt-4');
 });
+
+describe('finishAtomicReindex', () => {
+    beforeEach(() => {
+        mockGetIndexSettings.mockReturnValue({
+            ok: true,
+            object: { body: { attributesForFaceting: ['price.USD'] } },
+        });
+        mockCopySettingsFromProdIndices.mockReturnValue({
+            ok: true,
+            object: { body: { taskID: 99, updatedAt: '2023-10-01T12:00:00.000Z' } },
+        });
+        mockWaitTask.mockClear();
+        mockWaitForRunEvent.mockClear();
+        mockMoveIndex.mockClear();
+    });
+
+    test('Search API - calls waitForTasks for indexing tasks, copy settings tasks, then moveTemporaryIndices', () => {
+        const indexingTasks = { 'test_index___products__fr.tmp': 100, 'test_index___products__en.tmp': 101 };
+
+        reindexHelper.finishAtomicReindex('products', ['fr', 'en'], indexingTasks, 'search-api');
+
+        // copySettingsFromProdIndices called first (via getIndexSettings + copyIndexSettings)
+        expect(mockGetIndexSettings).toHaveBeenCalledTimes(2);
+
+        // waitTask called for: indexing tasks (2) + copy settings tasks (2)
+        expect(mockWaitTask).toHaveBeenCalledWith('test_index___products__fr.tmp', 100);
+        expect(mockWaitTask).toHaveBeenCalledWith('test_index___products__en.tmp', 101);
+
+        // waitForRunEvent should NOT be called for Search API
+        expect(mockWaitForRunEvent).not.toHaveBeenCalled();
+
+        // moveTemporaryIndices called
+        expect(mockMoveIndex).toHaveBeenCalledTimes(2);
+        expect(mockMoveIndex).toHaveBeenCalledWith('test_index___products__fr.tmp', 'test_index___products__fr');
+        expect(mockMoveIndex).toHaveBeenCalledWith('test_index___products__en.tmp', 'test_index___products__en');
+    });
+
+    test('Ingestion API - calls waitForEvents instead of waitForTasks for indexing events', () => {
+        const indexingEvents = {
+            'run-1': ['evt-1', 'evt-2'],
+            'run-2': ['evt-3'],
+        };
+
+        reindexHelper.finishAtomicReindex('products', ['fr', 'en'], indexingEvents, 'ingestion-api');
+
+        // waitForRunEvent called for each event
+        expect(mockWaitForRunEvent).toHaveBeenCalledTimes(3);
+        expect(mockWaitForRunEvent).toHaveBeenCalledWith('run-1', 'evt-1');
+        expect(mockWaitForRunEvent).toHaveBeenCalledWith('run-1', 'evt-2');
+        expect(mockWaitForRunEvent).toHaveBeenCalledWith('run-2', 'evt-3');
+
+        // waitTask still called for copy settings tasks
+        expect(mockWaitTask).toHaveBeenCalled();
+
+        // moveTemporaryIndices called
+        expect(mockMoveIndex).toHaveBeenCalledTimes(2);
+    });
+
+    test('default (undefined) indexingAPI uses Search API path', () => {
+        const indexingTasks = { 'test_index___products__fr.tmp': 200 };
+
+        reindexHelper.finishAtomicReindex('products', ['fr'], indexingTasks);
+
+        expect(mockWaitTask).toHaveBeenCalledWith('test_index___products__fr.tmp', 200);
+        expect(mockWaitForRunEvent).not.toHaveBeenCalled();
+        expect(mockMoveIndex).toHaveBeenCalledTimes(1);
+    });
+
+    test('Ingestion API with empty indexingEvents - still copies settings and moves indices', () => {
+        reindexHelper.finishAtomicReindex('products', ['fr'], {}, 'ingestion-api');
+
+        expect(mockWaitForRunEvent).not.toHaveBeenCalled();
+        // copy settings wait + move still happens
+        expect(mockWaitTask).toHaveBeenCalled();
+        expect(mockMoveIndex).toHaveBeenCalledTimes(1);
+    });
+});

--- a/test/unit/int_algolia/scripts/algolia/helper/requestHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/requestHelper.test.js
@@ -236,7 +236,7 @@ describe('Ingestion API payload snapshots', () => {
             callCount++;
             return {
                 ok: true,
-                object: { body: { runID: 'run-' + indexName.replace(/[^a-z]/g, ''), eventID: 'evt-' + callCount } },
+                object: { body: { runID: 'run-' + indexName, eventID: 'evt-' + callCount } },
             };
         });
 
@@ -265,11 +265,11 @@ describe('Ingestion API payload snapshots', () => {
         expect(groupedRecords).toMatchSnapshot('grouped records for delta index');
 
         let callCount = 0;
-        mockPushByIndexName.mockImplementation(() => {
+        mockPushByIndexName.mockImplementation((payload, indexName) => {
             callCount++;
             return {
                 ok: true,
-                object: { body: { runID: 'run-delta', eventID: 'evt-' + callCount } },
+                object: { body: { runID: 'run-' + indexName, eventID: 'evt-' + callCount } },
             };
         });
 
@@ -296,11 +296,11 @@ describe('Ingestion API payload snapshots', () => {
         expect(groupedRecords).toMatchSnapshot('grouped records for inventory update');
 
         let callCount = 0;
-        mockPushByIndexName.mockImplementation(() => {
+        mockPushByIndexName.mockImplementation((payload, indexName) => {
             callCount++;
             return {
                 ok: true,
-                object: { body: { runID: 'run-inv', eventID: 'evt-' + callCount } },
+                object: { body: { runID: 'run-' + indexName, eventID: 'evt-' + callCount } },
             };
         });
 

--- a/test/unit/int_algolia/scripts/algolia/helper/requestHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/requestHelper.test.js
@@ -1,4 +1,5 @@
 const mockSendMultiIndexBatch = jest.fn();
+const mockPushByIndexName = jest.fn();
 jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
     return {
         deleteIndex: jest.fn(),
@@ -8,11 +9,16 @@ jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
         moveIndex: jest.fn(),
         waitTask: jest.fn(),
         sendMultiIndexBatch: mockSendMultiIndexBatch,
-        pushByIndexName: jest.fn(),
+        pushByIndexName: mockPushByIndexName,
     }
 }, {virtual: true});
 
 const requestHelper = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper');
+
+beforeEach(() => {
+    mockSendMultiIndexBatch.mockReset();
+    mockPushByIndexName.mockReset();
+});
 
 test('sendRetryableBatch', () => {
     const batch = [
@@ -65,9 +71,150 @@ test('sendRetryableBatch', () => {
 });
 
 test('groupRecordsForIngestionAPI', () => {
-    // TODO: add test
+    const records = [
+        { action: 'addObject', indexName: 'index_en', body: { objectID: '1', name: 'Product 1' } },
+        { action: 'addObject', indexName: 'index_fr', body: { objectID: '1', name: 'Produit 1' } },
+        { action: 'addObject', indexName: 'index_en', body: { objectID: '2', name: 'Product 2' } },
+        { action: 'deleteObject', indexName: 'index_en', body: { objectID: '3' } },
+    ];
+
+    const result = requestHelper.groupRecordsForIngestionAPI(records);
+
+    expect(result).toEqual({
+        'index_en': {
+            'addObject': [
+                { objectID: '1', name: 'Product 1' },
+                { objectID: '2', name: 'Product 2' },
+            ],
+            'deleteObject': [
+                { objectID: '3' },
+            ],
+        },
+        'index_fr': {
+            'addObject': [
+                { objectID: '1', name: 'Produit 1' },
+            ],
+        },
+    });
 });
 
-test('sendGroupedIngestionAPIRecords', () => {
-    // TODO: add test
+describe('sendGroupedIngestionAPIRecords', () => {
+    test('all pushes succeed - returns ok with indexingEvents keyed by runID', () => {
+        const runIDs = { 'index_en': 'run-en', 'index_fr': 'run-fr' };
+        let callCount = 0;
+        mockPushByIndexName.mockImplementation((payload, indexName) => {
+            callCount++;
+            return {
+                ok: true,
+                object: { body: { runID: runIDs[indexName], eventID: 'evt-' + callCount } },
+            };
+        });
+
+        const groupedRecords = {
+            'index_en': {
+                'addObject': [{ objectID: '1' }, { objectID: '2' }],
+            },
+            'index_fr': {
+                'addObject': [{ objectID: '1' }],
+            },
+        };
+
+        const res = requestHelper.sendGroupedIngestionAPIRecords(groupedRecords);
+
+        expect(mockPushByIndexName).toHaveBeenCalledTimes(2);
+        expect(mockPushByIndexName).toHaveBeenCalledWith(
+            { action: 'addObject', records: [{ objectID: '1' }, { objectID: '2' }] },
+            'index_en',
+            undefined
+        );
+        expect(mockPushByIndexName).toHaveBeenCalledWith(
+            { action: 'addObject', records: [{ objectID: '1' }] },
+            'index_fr',
+            undefined
+        );
+        expect(res.result.ok).toBe(true);
+        expect(res.failedRecords).toBe(0);
+        expect(res.result.object.body.indexingEvents).toEqual({
+            'run-en': ['evt-1'],
+            'run-fr': ['evt-2'],
+        });
+    });
+
+    test('partial failure - ok is false, failed records counted, successful events kept', () => {
+        mockPushByIndexName
+            .mockReturnValueOnce({
+                ok: true,
+                object: { body: { runID: 'run-en', eventID: 'evt-1' } },
+            })
+            .mockReturnValueOnce({
+                ok: false,
+                getErrorMessage: () => 'Service error',
+            });
+
+        const groupedRecords = {
+            'index_en': {
+                'addObject': [{ objectID: '1' }, { objectID: '2' }],
+            },
+            'index_fr': {
+                'addObject': [{ objectID: '3' }],
+            },
+        };
+
+        const res = requestHelper.sendGroupedIngestionAPIRecords(groupedRecords);
+
+        expect(mockPushByIndexName).toHaveBeenCalledTimes(2);
+        expect(res.result.ok).toBe(false);
+        expect(res.failedRecords).toBe(1);
+        expect(res.result.object.body.indexingEvents).toEqual({
+            'run-en': ['evt-1'],
+        });
+    });
+
+    test('multiple actions per index - same runID, multiple eventIDs', () => {
+        let callCount = 0;
+        mockPushByIndexName.mockImplementation(() => {
+            callCount++;
+            return {
+                ok: true,
+                object: { body: { runID: 'run-en', eventID: 'evt-' + callCount } },
+            };
+        });
+
+        const groupedRecords = {
+            'index_en': {
+                'addObject': [{ objectID: '1' }],
+                'deleteObject': [{ objectID: '2' }],
+            },
+        };
+
+        const res = requestHelper.sendGroupedIngestionAPIRecords(groupedRecords);
+
+        expect(mockPushByIndexName).toHaveBeenCalledTimes(2);
+        expect(res.result.ok).toBe(true);
+        expect(res.failedRecords).toBe(0);
+        expect(res.result.object.body.indexingEvents).toEqual({
+            'run-en': ['evt-1', 'evt-2'],
+        });
+    });
+
+    test('forwards indexingMethod to pushByIndexName', () => {
+        mockPushByIndexName.mockReturnValue({
+            ok: true,
+            object: { body: { runID: 'run-1', eventID: 'evt-1' } },
+        });
+
+        const groupedRecords = {
+            'index_en.tmp': {
+                'addObject': [{ objectID: '1' }],
+            },
+        };
+
+        requestHelper.sendGroupedIngestionAPIRecords(groupedRecords, 'fullCatalogReindex');
+
+        expect(mockPushByIndexName).toHaveBeenCalledWith(
+            { action: 'addObject', records: [{ objectID: '1' }] },
+            'index_en.tmp',
+            'fullCatalogReindex'
+        );
+    });
 });

--- a/test/unit/int_algolia/scripts/algolia/helper/requestHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/requestHelper.test.js
@@ -80,22 +80,22 @@ test('groupRecordsForIngestionAPI', () => {
 
     const result = requestHelper.groupRecordsForIngestionAPI(records);
 
-    expect(result).toEqual({
-        'index_en': {
-            'addObject': [
-                { objectID: '1', name: 'Product 1' },
-                { objectID: '2', name: 'Product 2' },
-            ],
-            'deleteObject': [
-                { objectID: '3' },
-            ],
-        },
-        'index_fr': {
-            'addObject': [
-                { objectID: '1', name: 'Produit 1' },
-            ],
-        },
-    });
+    expect(result).toMatchSnapshot('grouped records by index and action');
+});
+
+test('groupRecordsForIngestionAPI - realistic multi-locale product batch', () => {
+    const batch = [
+        { action: 'addObject', indexName: 'test_products_en.tmp', body: { objectID: 'M-25592581', name: 'Fitted Shirt', price: { USD: 29.99, EUR: 24.99 }, in_stock: true, variants: [{ objectID: '701644031206M', color: 'JJB52A0', size: '004' }] } },
+        { action: 'addObject', indexName: 'test_products_fr.tmp', body: { objectID: 'M-25592581', name: 'Chemise ajustée', price: { USD: 29.99, EUR: 24.99 }, in_stock: true, variants: [{ objectID: '701644031206M', color: 'JJB52A0', size: '004' }] } },
+        { action: 'addObject', indexName: 'test_products_en.tmp', body: { objectID: 'M-25604524', name: 'Classic Jeans', price: { USD: 49.99, EUR: 39.99 }, in_stock: true, variants: [{ objectID: '701644031300M', color: 'BLK', size: '032' }] } },
+        { action: 'addObject', indexName: 'test_products_fr.tmp', body: { objectID: 'M-25604524', name: 'Jean classique', price: { USD: 49.99, EUR: 39.99 }, in_stock: true, variants: [{ objectID: '701644031300M', color: 'BLK', size: '032' }] } },
+        { action: 'deleteObject', indexName: 'test_products_en.tmp', body: { objectID: 'M-99999999' } },
+        { action: 'deleteObject', indexName: 'test_products_fr.tmp', body: { objectID: 'M-99999999' } },
+    ];
+
+    const groupedRecords = requestHelper.groupRecordsForIngestionAPI(batch);
+
+    expect(groupedRecords).toMatchSnapshot('multi-locale grouped records with mixed actions');
 });
 
 describe('sendGroupedIngestionAPIRecords', () => {
@@ -216,5 +216,104 @@ describe('sendGroupedIngestionAPIRecords', () => {
             'index_en.tmp',
             'fullCatalogReindex'
         );
+    });
+});
+
+describe('Ingestion API payload snapshots', () => {
+    test('full reindex flow: grouping → push payloads → response', () => {
+        const batch = [
+            { action: 'addObject', indexName: 'test_products_en.tmp', body: { objectID: 'M-25592581', name: 'Fitted Shirt', price: { USD: 29.99, EUR: 24.99 }, in_stock: true, variants: [{ objectID: '701644031206M', color: 'JJB52A0', size: '004' }] } },
+            { action: 'addObject', indexName: 'test_products_fr.tmp', body: { objectID: 'M-25592581', name: 'Chemise ajustée', price: { USD: 29.99, EUR: 24.99 }, in_stock: true, variants: [{ objectID: '701644031206M', color: 'JJB52A0', size: '004' }] } },
+            { action: 'addObject', indexName: 'test_products_en.tmp', body: { objectID: 'M-25604524', name: 'Classic Jeans', price: { USD: 49.99, EUR: 39.99 }, in_stock: true, variants: [{ objectID: '701644031300M', color: 'BLK', size: '032' }] } },
+            { action: 'addObject', indexName: 'test_products_fr.tmp', body: { objectID: 'M-25604524', name: 'Jean classique', price: { USD: 49.99, EUR: 39.99 }, in_stock: true, variants: [{ objectID: '701644031300M', color: 'BLK', size: '032' }] } },
+        ];
+
+        const groupedRecords = requestHelper.groupRecordsForIngestionAPI(batch);
+        expect(groupedRecords).toMatchSnapshot('grouped records for fullCatalogReindex');
+
+        let callCount = 0;
+        mockPushByIndexName.mockImplementation((payload, indexName) => {
+            callCount++;
+            return {
+                ok: true,
+                object: { body: { runID: 'run-' + indexName.replace(/[^a-z]/g, ''), eventID: 'evt-' + callCount } },
+            };
+        });
+
+        const response = requestHelper.sendGroupedIngestionAPIRecords(groupedRecords, 'fullCatalogReindex');
+
+        mockPushByIndexName.mock.calls.forEach(function(call, i) {
+            expect({
+                payload: call[0],
+                indexName: call[1],
+                indexingMethod: call[2],
+            }).toMatchSnapshot('pushByIndexName call ' + (i + 1));
+        });
+
+        expect(response).toMatchSnapshot('sendGroupedIngestionAPIRecords response');
+    });
+
+    test('delta index flow: mixed addObject and deleteObject payloads', () => {
+        const batch = [
+            { action: 'addObject', indexName: 'test_products_en', body: { objectID: '701644031206M', name: 'Fitted Shirt', price: { USD: 29.99 }, in_stock: true } },
+            { action: 'addObject', indexName: 'test_products_fr', body: { objectID: '701644031206M', name: 'Chemise ajustée', price: { EUR: 24.99 }, in_stock: true } },
+            { action: 'deleteObject', indexName: 'test_products_en', body: { objectID: '701644031300M' } },
+            { action: 'deleteObject', indexName: 'test_products_fr', body: { objectID: '701644031300M' } },
+        ];
+
+        const groupedRecords = requestHelper.groupRecordsForIngestionAPI(batch);
+        expect(groupedRecords).toMatchSnapshot('grouped records for delta index');
+
+        let callCount = 0;
+        mockPushByIndexName.mockImplementation(() => {
+            callCount++;
+            return {
+                ok: true,
+                object: { body: { runID: 'run-delta', eventID: 'evt-' + callCount } },
+            };
+        });
+
+        const response = requestHelper.sendGroupedIngestionAPIRecords(groupedRecords);
+
+        mockPushByIndexName.mock.calls.forEach(function(call, i) {
+            expect({
+                payload: call[0],
+                indexName: call[1],
+                indexingMethod: call[2],
+            }).toMatchSnapshot('pushByIndexName call ' + (i + 1));
+        });
+
+        expect(response).toMatchSnapshot('sendGroupedIngestionAPIRecords response');
+    });
+
+    test('inventory update flow: single partialUpdateObject per locale', () => {
+        const batch = [
+            { action: 'partialUpdateObject', indexName: 'test_products_en', body: { objectID: 'M-25592581', variants: [{ objectID: '701644031206M', in_stock: false }] } },
+            { action: 'partialUpdateObject', indexName: 'test_products_fr', body: { objectID: 'M-25592581', variants: [{ objectID: '701644031206M', in_stock: false }] } },
+        ];
+
+        const groupedRecords = requestHelper.groupRecordsForIngestionAPI(batch);
+        expect(groupedRecords).toMatchSnapshot('grouped records for inventory update');
+
+        let callCount = 0;
+        mockPushByIndexName.mockImplementation(() => {
+            callCount++;
+            return {
+                ok: true,
+                object: { body: { runID: 'run-inv', eventID: 'evt-' + callCount } },
+            };
+        });
+
+        const response = requestHelper.sendGroupedIngestionAPIRecords(groupedRecords);
+
+        mockPushByIndexName.mock.calls.forEach(function(call, i) {
+            expect({
+                payload: call[0],
+                indexName: call[1],
+                indexingMethod: call[2],
+            }).toMatchSnapshot('pushByIndexName call ' + (i + 1));
+        });
+
+        expect(response).toMatchSnapshot('sendGroupedIngestionAPIRecords response');
     });
 });

--- a/test/unit/int_algolia/scripts/algolia/helper/retryStrategy.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/retryStrategy.test.js
@@ -10,12 +10,15 @@ jest.mock('dw/svc/Result', () => {
     }
 },
 {virtual: true});
+const analyticsRegion = 'us';
 jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => {
     return {
         getPreference: jest.fn((property) => {
             switch (property) {
                 case 'ApplicationID':
                     return appID;
+                case 'AnalyticsRegion':
+                    return analyticsRegion;
             }
         }),
     }
@@ -128,4 +131,74 @@ test('retryableCall - error', () => {
     expect(result.getErrorMessage()).toBe('Bad Gateway');
     // All hosts have been marked down, getAvailableHosts() reset them all at the next call
     expect(retryStrategy.getAvailableHosts()).toHaveLength(4);
+});
+
+describe('Ingestion API hosts', () => {
+    beforeEach(() => {
+        retryStrategy.initHosts('ingestion-api');
+    });
+
+    test('getAvailableHosts returns single Ingestion host based on AnalyticsRegion', () => {
+        const hosts = retryStrategy.getAvailableHosts('ingestion-api');
+        expect(hosts).toHaveLength(1);
+        expect(hosts[0].hostname).toBe('data.' + analyticsRegion + '.algolia.com');
+    });
+
+    test('Ingestion and Search API use separate host pools', () => {
+        const ingestionHosts = retryStrategy.getAvailableHosts('ingestion-api');
+        const searchHosts = retryStrategy.getAvailableHosts('search-api');
+
+        expect(ingestionHosts).toHaveLength(1);
+        expect(searchHosts).toHaveLength(4);
+        expect(ingestionHosts[0].hostname).not.toBe(searchHosts[0].hostname);
+    });
+
+    test('retryableCall with ingestion-api uses Ingestion host', () => {
+        const callMock = jest.fn().mockReturnValue({ ok: true });
+        const service = { call: callMock };
+
+        retryStrategy.retryableCall(service, {
+            method: 'POST',
+            path: '/1/push/my_index',
+            body: { action: 'addObject', records: [] },
+            indexingAPI: 'ingestion-api',
+        });
+
+        expect(callMock).toHaveBeenCalledTimes(1);
+        expect(callMock).toHaveBeenCalledWith(expect.objectContaining({
+            url: 'https://data.' + analyticsRegion + '.algolia.com/1/push/my_index',
+        }));
+    });
+
+    test('retryableCall retries single Ingestion host on failure then returns last result', () => {
+        const serverErrorResult = {
+            ok: false,
+            getUnavailableReason: jest.fn(),
+            getError: jest.fn().mockReturnValue(502),
+            getErrorMessage: jest.fn().mockReturnValue('Bad Gateway'),
+        };
+
+        const callMock = jest.fn().mockReturnValue(serverErrorResult);
+        const service = { call: callMock };
+
+        const result = retryStrategy.retryableCall(service, {
+            path: '/1/push/my_index',
+            indexingAPI: 'ingestion-api',
+        });
+
+        // Only 1 host for Ingestion, so only 1 attempt
+        expect(callMock).toHaveBeenCalledTimes(1);
+        expect(result.ok).toBe(false);
+    });
+
+    test('undefined indexingAPI defaults to Search API hosts', () => {
+        const callMock = jest.fn().mockReturnValue({ ok: true });
+        const service = { call: callMock };
+
+        retryStrategy.retryableCall(service, { path: '/test' });
+
+        expect(callMock).toHaveBeenCalledWith(expect.objectContaining({
+            url: expect.stringContaining(appID),
+        }));
+    });
 });

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
@@ -11,12 +11,14 @@ jest.mock('*/cartridge/scripts/algoliaIndexingAPI', () => {
         pushByIndexName: jest.fn(),
     }
 }, {virtual: true});
+const mockGroupRecordsForIngestionAPI = jest.fn();
+const mockSendGroupedIngestionAPIRecords = jest.fn();
 jest.mock('*/cartridge/scripts/algolia/helper/requestHelper', () => {
     const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper');
     return {
         sendRetryableBatch: originalModule.sendRetryableBatch,
-        groupRecordsForIngestionAPI: originalModule.groupRecordsForIngestionAPI,
-        sendGroupedIngestionAPIRecords: originalModule.sendGroupedIngestionAPIRecords,
+        groupRecordsForIngestionAPI: mockGroupRecordsForIngestionAPI,
+        sendGroupedIngestionAPIRecords: mockSendGroupedIngestionAPIRecords,
     }
 }, {virtual: true});
 
@@ -61,6 +63,10 @@ const job = require('../../../../../../cartridges/int_algolia/cartridge/scripts/
 
 beforeEach(() => {
     mockLocalesForIndexing = [];
+    mockGroupRecordsForIngestionAPI.mockReset();
+    mockSendGroupedIngestionAPIRecords.mockReset();
+    delete global.customPreferences['Algolia_IndexingAPI'];
+    delete global.customPreferences['Algolia_AnalyticsRegion'];
 });
 
 describe('beforeStep', () => {
@@ -80,6 +86,25 @@ describe('beforeStep', () => {
         mockLocalesForIndexing = ['fr'];
         job.beforeStep({ localesForIndexing: 'en, fr', ...parameters }, stepExecution);
         expect(job.__getLocalesForIndexing()).toStrictEqual(['en', 'fr']);
+    });
+
+    test('Ingestion API with invalid AnalyticsRegion throws', () => {
+        global.customPreferences['Algolia_IndexingAPI'] = 'ingestion-api';
+        global.customPreferences['Algolia_AnalyticsRegion'] = 'invalid';
+        expect(() => job.beforeStep(parameters, stepExecution))
+            .toThrow('You need to define a valid Analytics region');
+    });
+
+    test('Ingestion API with missing AnalyticsRegion throws', () => {
+        global.customPreferences['Algolia_IndexingAPI'] = 'ingestion-api';
+        expect(() => job.beforeStep(parameters, stepExecution))
+            .toThrow('You need to define a valid Analytics region');
+    });
+
+    test('Ingestion API with valid AnalyticsRegion does not throw', () => {
+        global.customPreferences['Algolia_IndexingAPI'] = 'ingestion-api';
+        global.customPreferences['Algolia_AnalyticsRegion'] = 'us';
+        expect(() => job.beforeStep(parameters, stepExecution)).not.toThrow();
     });
 });
 
@@ -135,28 +160,84 @@ describe('process', () => {
     });
 });
 
-test('send', () => {
-    job.beforeStep(parameters, stepExecution);
-    job.__setIndexingAPI(job.__INDEXING_APIS.SEARCH_API);
-
-    const algoliaOperationsChunk = [];
-    for (let i = 0; i < 3; ++i) {
-        const algoliaOperations = [
-            { action: 'addObject', indexName: 'test_en', body: { id: `${i}` } },
-            { action: 'addObject', indexName: 'test_fr', body: { id: `${i}` } },
-        ];
-        algoliaOperations.toArray = function () {
-            return algoliaOperations;
-        };
-        algoliaOperationsChunk.push(algoliaOperations);
-    }
-    algoliaOperationsChunk.toArray = function () {
+describe('send', () => {
+    function makeChunk(count) {
+        const algoliaOperationsChunk = [];
+        for (let i = 0; i < count; ++i) {
+            const ops = [
+                { action: 'addObject', indexName: 'test_en', body: { id: String(i) } },
+                { action: 'addObject', indexName: 'test_fr', body: { id: String(i) } },
+            ];
+            ops.toArray = function () { return ops; };
+            algoliaOperationsChunk.push(ops);
+        }
+        algoliaOperationsChunk.toArray = function () { return algoliaOperationsChunk; };
         return algoliaOperationsChunk;
-    };
+    }
 
-    job.send(algoliaOperationsChunk);
+    test('Search API - sends multi-index batch', () => {
+        job.beforeStep(parameters, stepExecution);
+        job.__setIndexingAPI(job.__INDEXING_APIS.SEARCH_API);
 
-    expect(mockSendMultiIndexBatch).toHaveBeenCalledWith(algoliaOperationsChunk.flat());
+        const chunk = makeChunk(3);
+        job.send(chunk);
+
+        expect(mockSendMultiIndexBatch).toHaveBeenCalledWith(chunk.flat());
+    });
+
+    test('Ingestion API - calls groupRecordsForIngestionAPI and sendGroupedIngestionAPIRecords', () => {
+        job.beforeStep(parameters, stepExecution);
+        job.__setIndexingAPI(job.__INDEXING_APIS.INGESTION_API);
+
+        const grouped = { 'test_en': { 'addObject': [{ id: '0' }, { id: '1' }] } };
+        mockGroupRecordsForIngestionAPI.mockReturnValue(grouped);
+        mockSendGroupedIngestionAPIRecords.mockReturnValue({
+            result: { ok: true, object: { body: {} } },
+            failedRecords: 0,
+        });
+
+        const chunk = makeChunk(2);
+        job.send(chunk);
+
+        expect(mockGroupRecordsForIngestionAPI).toHaveBeenCalledWith(chunk.flat());
+        expect(mockSendGroupedIngestionAPIRecords).toHaveBeenCalledWith(grouped);
+        expect(job.__getJobReport().recordsSent).toBeGreaterThan(0);
+        expect(job.__getJobReport().chunksSent).toBeGreaterThan(0);
+    });
+
+    test('Ingestion API - failure updates jobReport', () => {
+        job.beforeStep(parameters, stepExecution);
+        job.__setIndexingAPI(job.__INDEXING_APIS.INGESTION_API);
+
+        mockGroupRecordsForIngestionAPI.mockReturnValue({});
+        mockSendGroupedIngestionAPIRecords.mockReturnValue({
+            result: { ok: false },
+            failedRecords: 2,
+        });
+
+        const chunk = makeChunk(2);
+        const batchLength = chunk.flat().length;
+        job.send(chunk);
+
+        // failedRecords from resultObj (2) + batch.length from the !result.ok branch
+        expect(job.__getJobReport().recordsFailed).toBe(2 + batchLength);
+        expect(job.__getJobReport().chunksFailed).toBe(1);
+    });
+
+    test('Ingestion API - does not pass indexingMethod (no fullCatalogReindex in delta)', () => {
+        job.beforeStep(parameters, stepExecution);
+        job.__setIndexingAPI(job.__INDEXING_APIS.INGESTION_API);
+
+        mockGroupRecordsForIngestionAPI.mockReturnValue({});
+        mockSendGroupedIngestionAPIRecords.mockReturnValue({
+            result: { ok: true, object: { body: {} } },
+            failedRecords: 0,
+        });
+
+        job.send(makeChunk(1));
+
+        expect(mockSendGroupedIngestionAPIRecords).toHaveBeenCalledWith({});
+    });
 });
 
 describe('afterStep', () => {

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -24,10 +24,14 @@ jest.mock('*/cartridge/scripts/algolia/helper/reindexHelper', () => {
     };
 }, {virtual: true});
 
+const mockGroupRecordsForIngestionAPI = jest.fn();
+const mockSendGroupedIngestionAPIRecords = jest.fn();
 jest.mock('*/cartridge/scripts/algolia/helper/requestHelper', () => {
     const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper');
     return {
         sendRetryableBatch: originalModule.sendRetryableBatch,
+        groupRecordsForIngestionAPI: mockGroupRecordsForIngestionAPI,
+        sendGroupedIngestionAPIRecords: mockSendGroupedIngestionAPIRecords,
     };
 }, {virtual: true});
 
@@ -314,6 +318,80 @@ describe('send', () => {
         job.send(algoliaOperationsChunk);
 
         expect(mockSendMultiIndexBatch).not.toHaveBeenCalled();
+    });
+
+    test('Ingestion API - events accumulated across multiple chunks', () => {
+        job.beforeStep({ indexingMethod: 'fullCatalogReindex' }, stepExecution);
+        job.__setIndexingAPI(job.__INDEXING_APIS.INGESTION_API);
+        job.__setIndexingTasksToWaitFor({});
+
+        function makeChunk() {
+            const algoliaOperationsChunk = [];
+            for (let i = 0; i < 2; ++i) {
+                const ops = [
+                    { action: 'addObject', indexName: 'test_en.tmp', body: { id: String(i) } },
+                    { action: 'addObject', indexName: 'test_fr.tmp', body: { id: String(i) } },
+                ];
+                ops.toArray = function () { return ops; };
+                algoliaOperationsChunk.push(ops);
+            }
+            algoliaOperationsChunk.toArray = function () { return algoliaOperationsChunk; };
+            return algoliaOperationsChunk;
+        }
+
+        mockGroupRecordsForIngestionAPI.mockReturnValue({});
+        mockSendGroupedIngestionAPIRecords
+            .mockReturnValueOnce({
+                result: {
+                    ok: true,
+                    object: {
+                        body: {
+                            indexingEvents: {
+                                'run-en': ['evt-1'],
+                                'run-fr': ['evt-2'],
+                            }
+                        }
+                    }
+                },
+                failedRecords: 0,
+            })
+            .mockReturnValueOnce({
+                result: {
+                    ok: true,
+                    object: {
+                        body: {
+                            indexingEvents: {
+                                'run-en': ['evt-3'],
+                                'run-fr': ['evt-4'],
+                            }
+                        }
+                    }
+                },
+                failedRecords: 0,
+            });
+
+        job.send(makeChunk());
+        job.send(makeChunk());
+
+        expect(mockGroupRecordsForIngestionAPI).toHaveBeenCalledTimes(2);
+        expect(mockSendGroupedIngestionAPIRecords).toHaveBeenCalledTimes(2);
+
+        // Verify accumulated events via afterStep → finishAtomicReindex
+        mockFinishAtomicReindex.mockClear();
+        job.__getJobReport().processedItems = ProductMgrMock.queryAllSiteProducts().count;
+        job.__getJobReport().recordsFailed = 0;
+        job.__getJobReport().recordsToSend = 100;
+        job.afterStep(true);
+
+        expect(mockFinishAtomicReindex).toHaveBeenCalledWith(
+            'products',
+            expect.arrayContaining(['default', 'fr', 'en']),
+            {
+                'run-en': ['evt-1', 'evt-3'],
+                'run-fr': ['evt-2', 'evt-4'],
+            },
+            'ingestion-api'
+        );
     });
 });
 

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -393,6 +393,118 @@ describe('send', () => {
             'ingestion-api'
         );
     });
+
+    test('Ingestion API - non-reindex method (partialRecordUpdate)', () => {
+        job.beforeStep({ indexingMethod: 'partialRecordUpdate' }, stepExecution);
+        job.__setIndexingAPI(job.__INDEXING_APIS.INGESTION_API);
+
+        mockGroupRecordsForIngestionAPI.mockReturnValue({});
+        mockSendGroupedIngestionAPIRecords.mockReturnValue({
+            result: { ok: true, object: { body: {} } },
+            failedRecords: 0,
+        });
+
+        function makeChunk() {
+            const algoliaOperationsChunk = [];
+            for (let i = 0; i < 2; ++i) {
+                const ops = [
+                    { action: 'partialUpdateObject', indexName: 'test_en', body: { id: String(i) } },
+                ];
+                ops.toArray = function () { return ops; };
+                algoliaOperationsChunk.push(ops);
+            }
+            algoliaOperationsChunk.toArray = function () { return algoliaOperationsChunk; };
+            return algoliaOperationsChunk;
+        }
+
+        job.send(makeChunk());
+
+        expect(mockGroupRecordsForIngestionAPI).toHaveBeenCalled();
+        expect(mockSendGroupedIngestionAPIRecords).toHaveBeenCalledWith({}, 'partialRecordUpdate');
+        expect(job.__getJobReport().recordsSent).toBeGreaterThan(0);
+    });
+
+    test('Ingestion API - failure updates jobReport', () => {
+        job.beforeStep({}, stepExecution);
+        job.__setIndexingAPI(job.__INDEXING_APIS.INGESTION_API);
+
+        mockGroupRecordsForIngestionAPI.mockReturnValue({});
+        mockSendGroupedIngestionAPIRecords.mockReturnValue({
+            result: { ok: false },
+            failedRecords: 3,
+        });
+
+        function makeChunk() {
+            const algoliaOperationsChunk = [];
+            const ops = [
+                { action: 'addObject', indexName: 'test_en', body: { id: '0' } },
+                { action: 'addObject', indexName: 'test_fr', body: { id: '0' } },
+            ];
+            ops.toArray = function () { return ops; };
+            algoliaOperationsChunk.push(ops);
+            algoliaOperationsChunk.toArray = function () { return algoliaOperationsChunk; };
+            return algoliaOperationsChunk;
+        }
+
+        job.send(makeChunk());
+
+        // failedRecords from resultObj (3) + batch.length from the !result.ok branch (2)
+        expect(job.__getJobReport().recordsFailed).toBe(3 + 2);
+        expect(job.__getJobReport().chunksFailed).toBe(1);
+    });
+
+    test('Ingestion API - exception in send is caught', () => {
+        job.beforeStep({}, stepExecution);
+        job.__setIndexingAPI(job.__INDEXING_APIS.INGESTION_API);
+
+        mockGroupRecordsForIngestionAPI.mockImplementation(() => { throw new Error('Grouping error'); });
+
+        function makeChunk() {
+            const algoliaOperationsChunk = [];
+            const ops = [{ action: 'addObject', indexName: 'test_en', body: { id: '0' } }];
+            ops.toArray = function () { return ops; };
+            algoliaOperationsChunk.push(ops);
+            algoliaOperationsChunk.toArray = function () { return algoliaOperationsChunk; };
+            return algoliaOperationsChunk;
+        }
+
+        // Should not throw - caught internally
+        expect(() => job.send(makeChunk())).not.toThrow();
+    });
+});
+
+describe('beforeStep - Ingestion API validation', () => {
+    test('throws if Ingestion API selected with invalid AnalyticsRegion', () => {
+        global.customPreferences['Algolia_IndexingAPI'] = 'ingestion-api';
+        global.customPreferences['Algolia_AnalyticsRegion'] = 'invalid';
+        expect(() => job.beforeStep({}, stepExecution))
+            .toThrow('You need to define a valid Analytics region');
+        delete global.customPreferences['Algolia_IndexingAPI'];
+        delete global.customPreferences['Algolia_AnalyticsRegion'];
+    });
+
+    test('throws if Ingestion API selected with missing AnalyticsRegion', () => {
+        global.customPreferences['Algolia_IndexingAPI'] = 'ingestion-api';
+        expect(() => job.beforeStep({}, stepExecution))
+            .toThrow('You need to define a valid Analytics region');
+        delete global.customPreferences['Algolia_IndexingAPI'];
+    });
+
+    test('does not throw if Ingestion API selected with valid AnalyticsRegion (us)', () => {
+        global.customPreferences['Algolia_IndexingAPI'] = 'ingestion-api';
+        global.customPreferences['Algolia_AnalyticsRegion'] = 'us';
+        expect(() => job.beforeStep({}, stepExecution)).not.toThrow();
+        delete global.customPreferences['Algolia_IndexingAPI'];
+        delete global.customPreferences['Algolia_AnalyticsRegion'];
+    });
+
+    test('does not throw if Ingestion API selected with valid AnalyticsRegion (eu)', () => {
+        global.customPreferences['Algolia_IndexingAPI'] = 'ingestion-api';
+        global.customPreferences['Algolia_AnalyticsRegion'] = 'eu';
+        expect(() => job.beforeStep({}, stepExecution)).not.toThrow();
+        delete global.customPreferences['Algolia_IndexingAPI'];
+        delete global.customPreferences['Algolia_AnalyticsRegion'];
+    });
 });
 
 describe('afterStep', () => {

--- a/test/unit/int_algolia/scripts/hooks/order/algoliaHooks.test.js
+++ b/test/unit/int_algolia/scripts/hooks/order/algoliaHooks.test.js
@@ -1,7 +1,12 @@
 'use strict';
 
+const mockSendRetryableBatch = jest.fn().mockReturnValue({ ok: true });
+const mockGroupRecordsForIngestionAPI = jest.fn().mockReturnValue({});
+const mockSendGroupedIngestionAPIRecords = jest.fn();
 jest.mock('*/cartridge/scripts/algolia/helper/requestHelper', () => ({
-    sendRetryableBatch: jest.fn().mockReturnValue({ ok: true })
+    sendRetryableBatch: mockSendRetryableBatch,
+    groupRecordsForIngestionAPI: mockGroupRecordsForIngestionAPI,
+    sendGroupedIngestionAPIRecords: mockSendGroupedIngestionAPIRecords,
 }), { virtual: true });
 
 let mockConfig = {
@@ -26,6 +31,8 @@ jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => ({
                 return mockConfig.IndexOutOfStock;
             case 'AttributeSlicedRecordModel_GroupingAttribute':
                 return mockConfig.AttributeSlicedRecordModel_GroupingAttribute;
+            case 'IndexingAPI':
+                return mockConfig.IndexingAPI || null;
             default:
                 return null;
         }
@@ -581,5 +588,93 @@ describe('Algolia Hooks - In Stock Tests (InStockThreshold: 1, IndexOutOfStock: 
 
         // Assert
         expect(operations).toMatchSnapshot();
+    });
+});
+
+describe('inventoryUpdate', () => {
+    let testData;
+
+    beforeEach(() => {
+        mockConfig.InStockThreshold = 10;
+        mockConfig.IndexOutOfStock = true;
+        testData = setupTestData();
+        mockSendRetryableBatch.mockClear();
+        mockGroupRecordsForIngestionAPI.mockClear();
+        mockSendGroupedIngestionAPIRecords.mockClear();
+    });
+
+    test('Search API (default) - calls sendRetryableBatch', () => {
+        const mockOrder = {
+            orderNo: 'TEST-ORDER-001',
+            getShipments: () => [testData.mockShipmentStandard],
+        };
+
+        const result = algoliaHooks.inventoryUpdate(mockOrder);
+
+        expect(mockSendRetryableBatch).toHaveBeenCalled();
+        expect(mockGroupRecordsForIngestionAPI).not.toHaveBeenCalled();
+        expect(result.status).toBe(0); // Status.OK
+    });
+
+    test('Search API - does not send when no operations are generated', () => {
+        mockConfig.InStockThreshold = 1;
+        const freshTestData = setupTestData();
+
+        const mockOrder = {
+            orderNo: 'TEST-ORDER-002',
+            getShipments: () => [freshTestData.mockShipmentStandard],
+        };
+
+        const result = algoliaHooks.inventoryUpdate(mockOrder);
+
+        expect(mockSendRetryableBatch).not.toHaveBeenCalled();
+        expect(result.status).toBe(0);
+    });
+
+    test('Ingestion API - calls groupRecordsForIngestionAPI and sendGroupedIngestionAPIRecords', () => {
+        mockConfig.IndexingAPI = 'ingestion-api';
+
+        let algoliaHooksIngestion;
+        jest.isolateModules(() => {
+            algoliaHooksIngestion = require('../../../../../../cartridges/int_algolia_sfra/cartridge/scripts/hooks/order/algoliaHooks');
+        });
+
+        const mockOrder = {
+            orderNo: 'TEST-ORDER-003',
+            getShipments: () => [testData.mockShipmentStandard],
+        };
+
+        algoliaHooksIngestion.inventoryUpdate(mockOrder);
+
+        expect(mockGroupRecordsForIngestionAPI).toHaveBeenCalled();
+        expect(mockSendGroupedIngestionAPIRecords).toHaveBeenCalled();
+        expect(mockSendRetryableBatch).not.toHaveBeenCalled();
+
+        mockConfig.IndexingAPI = null;
+    });
+
+    test('returns Status.OK even when an error occurs', () => {
+        mockSendRetryableBatch.mockImplementation(() => { throw new Error('Service failure'); });
+
+        const mockOrder = {
+            orderNo: 'TEST-ORDER-004',
+            getShipments: () => [testData.mockShipmentStandard],
+        };
+
+        const result = algoliaHooks.inventoryUpdate(mockOrder);
+
+        expect(result.status).toBe(0); // Status.OK
+    });
+
+    test('handles multiple shipments (standard + instore)', () => {
+        const mockOrder = {
+            orderNo: 'TEST-ORDER-005',
+            getShipments: () => [testData.mockShipmentStandard, testData.mockShipmentInStore],
+        };
+
+        const result = algoliaHooks.inventoryUpdate(mockOrder);
+
+        expect(mockSendRetryableBatch).toHaveBeenCalled();
+        expect(result.status).toBe(0);
     });
 });


### PR DESCRIPTION
Added missing unit tests, adjusted existing ones for Ingestion API indexing and added snapshots for the Ingestion API payloads.

| | Before | After | Diff |
|--------|--------|--------|--------|
| Tests | 222 | 267 | +45 |
| Snapshots | 42 | 61 | +19 |
