### PR TITLE
fix: [SFCC-506] Record counting fix

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper.js
@@ -7,8 +7,8 @@ const algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
  * Sends an Algolia batch to the Search API `multiple-batch` endpoint
  * https://www.algolia.com/doc/rest-api/search/multiple-batch
  * If records fail to be indexed (because e.g. they are too big), they are removed from the batch and the batch is retried.
- * @param {Object} batch - Algolia multi-indices batch
- * @param {String} [indexName] Target index -- only used with the Ingestion API
+ * Note: this function mutates the batch array by splicing out failed records.
+ * @param {Object[]} batch - Algolia multi-indices batch
  * @return {Object} returns an object with the last call result and the number of failed records.
  */
 function sendRetryableBatch(batch) {
@@ -144,7 +144,7 @@ function groupRecordsForIngestionAPI(recordArray) {
  * Sends Algolia records to the Ingestion API grouped by indexName and action
  * @param {Object} groupedRecords - Records grouped by `indexName` and `action`.
  * @param {string} [indexingMethod] - the indexing method (e.g. 'fullCatalogReindex'), forwarded to pushByIndexName
- * @returns {Object} result object containing status and number of failed records
+ * @returns {Object} result object containing { result, failedRecords, sentRecords }
  */
 function sendGroupedIngestionAPIRecords(groupedRecords, indexingMethod) {
     let indices = Object.keys(groupedRecords);

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/requestHelper.js
@@ -149,6 +149,7 @@ function groupRecordsForIngestionAPI(recordArray) {
 function sendGroupedIngestionAPIRecords(groupedRecords, indexingMethod) {
     let indices = Object.keys(groupedRecords);
     let failedRecords = 0;
+    let sentRecords = 0;
     let wasThereAnError = false;
     let indexingEvents = {};
 
@@ -165,6 +166,7 @@ function sendGroupedIngestionAPIRecords(groupedRecords, indexingMethod) {
             }
             let result = algoliaIndexingAPI.pushByIndexName(recordToSend, indexName, indexingMethod);
             if (result.ok) {
+                sentRecords += recordToSend.records.length;
                 let runID = result.object.body.runID;
                 let eventID = result.object.body.eventID;
                 if (!indexingEvents[runID]) {
@@ -186,6 +188,7 @@ function sendGroupedIngestionAPIRecords(groupedRecords, indexingMethod) {
             }
         },
         failedRecords: failedRecords,
+        sentRecords: sentRecords,
     }
 }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -619,32 +619,56 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
         batch = batch.concat(algoliaOperationsArray[i].toArray());
     }
 
-    let resultObj;
     switch (indexingAPI) {
         case INDEXING_APIS.INGESTION_API: {
-            let sortedRecords = requestHelper.groupRecordsForIngestionAPI(batch);
-            resultObj = requestHelper.sendGroupedIngestionAPIRecords(sortedRecords);
+            // With the Ingestion API, an OK response only means the payload was accepted;
+            // record-level errors (e.g. "record too big") happen asynchronously — check the Algolia Dashboard.
+            // sentRecords/failedRecords reflect transport-level success per push call.
+            let resultObj;
+            try {
+                let sortedRecords = requestHelper.groupRecordsForIngestionAPI(batch);
+                resultObj = requestHelper.sendGroupedIngestionAPIRecords(sortedRecords);
+            } catch (e) {
+                logger.error('Error while sending batch to Algolia: ' + e);
+            }
+
+            if (resultObj) {
+                jobReport.recordsSent += resultObj.sentRecords;
+                jobReport.recordsFailed += resultObj.failedRecords;
+                if (resultObj.failedRecords > 0) {
+                    jobReport.chunksFailed++;
+                } else {
+                    jobReport.chunksSent++;
+                }
+            } else {
+                jobReport.recordsFailed += batch.length;
+                jobReport.chunksFailed++;
+            }
             break;
         }
         case INDEXING_APIS.SEARCH_API:
         default: {
-            resultObj = requestHelper.sendRetryableBatch(batch);
+            // Search API: sendRetryableBatch mutates the batch array by splicing out failed records,
+            // so batch.length reflects only the remaining records after retries.
+            let resultObj, result;
+            try {
+                resultObj = requestHelper.sendRetryableBatch(batch);
+                result = resultObj.result;
+            } catch (e) {
+                logger.error('Error while sending batch to Algolia: ' + e);
+            }
+
+            jobReport.recordsFailed += resultObj ? resultObj.failedRecords : 0;
+
+            if (result && result.ok) {
+                jobReport.recordsSent += batch.length;
+                jobReport.chunksSent++;
+            } else {
+                jobReport.recordsFailed += batch.length;
+                jobReport.chunksFailed++;
+            }
             break;
         }
-    }
-
-    // recordsFailed count is not necessarily accurate when using the Ingestion API
-    // An OK response from a sending call only means that the endpoint received the payload;
-    // "record too large" or other indexing-time errors can still happen -- check your Algolia Dashboard for these errors
-    let result = resultObj.result;
-    jobReport.recordsFailed += resultObj.failedRecords;
-
-    if (result.ok) {
-        jobReport.recordsSent += batch.length;
-        jobReport.chunksSent++;
-    } else {
-        jobReport.recordsFailed += batch.length;
-        jobReport.chunksFailed++;
     }
 }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -527,45 +527,31 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
         return;
     }
 
-    let resultObj, result;
+    switch (indexingAPI) {
+        case INDEXING_APIS.INGESTION_API: {
+            // With the Ingestion API, an OK response only means the payload was accepted;
+            // record-level errors (e.g. "record too big") happen asynchronously — check the Algolia Dashboard.
+            // sentRecords/failedRecords reflect transport-level success per push call.
+            let resultObj;
+            try {
+                let sortedRecords = requestHelper.groupRecordsForIngestionAPI(batch);
+                resultObj = requestHelper.sendGroupedIngestionAPIRecords(sortedRecords, paramIndexingMethod);
+            } catch (e) {
+                logger.error('Error while sending batch to Algolia: ' + e);
+            }
 
-    try {
-        if (indexingAPI === INDEXING_APIS.SEARCH_API) {
-            resultObj = requestHelper.sendRetryableBatch(batch);
-        } else { // INDEXING_APIS.INGESTION_API
-            let sortedRecords = requestHelper.groupRecordsForIngestionAPI(batch);
-            resultObj = requestHelper.sendGroupedIngestionAPIRecords(sortedRecords, paramIndexingMethod);
-        }
-
-        // recordsFailed count is not necessarily accurate when using the Ingestion API
-        // An OK response from a sending call only means that the endpoint received the payload;
-        // "record too large" or other indexing-time errors can still happen -- check your Algolia Dashboard for these errors
-        result = resultObj.result;
-        jobReport.recordsFailed += resultObj.failedRecords;
-    } catch (e) {
-        logger.error('Error while sending batch to Algolia: ' + e);
-    }
-
-    if (result && result.ok) {
-        jobReport.recordsSent += batch.length;
-        jobReport.chunksSent++;
-
-        // Store Algolia indexing task/event IDs per index.
-        // When performing a fullCatalogReindex, afterStep waits for these to complete before moving temp to prod.
-        // For Search API, taskIDs are sequential per index — the last one completing guarantees all prior
-        // are done, so we only keep the latest value.
-        // For Ingestion API, events have no sequential processing guarantee — we must track all of them.
-        if (paramIndexingMethod === 'fullCatalogReindex') {
-            switch (indexingAPI) {
-                default:
-                case INDEXING_APIS.SEARCH_API: {
-                    let taskIDs = result.object.body.taskID;
-                    Object.keys(taskIDs).forEach(function (taskIndexName) {
-                        indexingTasksToWaitFor[taskIndexName] = taskIDs[taskIndexName];
-                    });
-                    break;
+            if (resultObj) {
+                jobReport.recordsSent += resultObj.sentRecords;
+                jobReport.recordsFailed += resultObj.failedRecords;
+                if (resultObj.failedRecords > 0) {
+                    jobReport.chunksFailed++;
+                } else {
+                    jobReport.chunksSent++;
                 }
-                case INDEXING_APIS.INGESTION_API: {
+
+                // Store Ingestion API event IDs for fullCatalogReindex
+                if (paramIndexingMethod === 'fullCatalogReindex') {
+                    let result = resultObj.result;
                     let indexingEvents = result.object.body.indexingEvents;
                     Object.keys(indexingEvents).forEach(function (runID) {
                         if (!indexingTasksToWaitFor[runID]) {
@@ -573,13 +559,45 @@ exports.send = function(algoliaOperations, parameters, stepExecution) {
                         }
                         indexingTasksToWaitFor[runID] = indexingTasksToWaitFor[runID].concat(indexingEvents[runID]);
                     });
-                    break;
                 }
+            } else {
+                jobReport.recordsFailed += batch.length;
+                jobReport.chunksFailed++;
             }
+            break;
         }
-    } else {
-        jobReport.recordsFailed += batch.length;
-        jobReport.chunksFailed++;
+        case INDEXING_APIS.SEARCH_API:
+        default: {
+            // Search API: sendRetryableBatch mutates the batch array by splicing out failed records,
+            // so batch.length reflects only the remaining records after retries.
+            let resultObj, result;
+            try {
+                resultObj = requestHelper.sendRetryableBatch(batch);
+                result = resultObj.result;
+            } catch (e) {
+                logger.error('Error while sending batch to Algolia: ' + e);
+            }
+
+            jobReport.recordsFailed += resultObj ? resultObj.failedRecords : 0;
+
+            if (result && result.ok) {
+                jobReport.recordsSent += batch.length;
+                jobReport.chunksSent++;
+
+                // Store Search API task IDs for fullCatalogReindex.
+                // taskIDs are sequential per index — the last one guarantees all prior are done.
+                if (paramIndexingMethod === 'fullCatalogReindex') {
+                    let taskIDs = result.object.body.taskID;
+                    Object.keys(taskIDs).forEach(function (taskIndexName) {
+                        indexingTasksToWaitFor[taskIndexName] = taskIDs[taskIndexName];
+                    });
+                }
+            } else {
+                jobReport.recordsFailed += batch.length;
+                jobReport.chunksFailed++;
+            }
+            break;
+        }
     }
 }
 

--- a/test/unit/int_algolia/scripts/algolia/helper/__snapshots__/requestHelper.test.js.snap
+++ b/test/unit/int_algolia/scripts/algolia/helper/__snapshots__/requestHelper.test.js.snap
@@ -129,6 +129,7 @@ exports[`Ingestion API payload snapshots delta index flow: mixed addObject and d
     },
     "ok": true,
   },
+  "sentRecords": 4,
 }
 `;
 
@@ -315,6 +316,7 @@ exports[`Ingestion API payload snapshots full reindex flow: grouping → push pa
     },
     "ok": true,
   },
+  "sentRecords": 4,
 }
 `;
 
@@ -409,6 +411,7 @@ exports[`Ingestion API payload snapshots inventory update flow: single partialUp
     },
     "ok": true,
   },
+  "sentRecords": 2,
 }
 `;
 

--- a/test/unit/int_algolia/scripts/algolia/helper/requestHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/requestHelper.test.js
@@ -134,6 +134,7 @@ describe('sendGroupedIngestionAPIRecords', () => {
         );
         expect(res.result.ok).toBe(true);
         expect(res.failedRecords).toBe(0);
+        expect(res.sentRecords).toBe(3);
         expect(res.result.object.body.indexingEvents).toEqual({
             'run-en': ['evt-1'],
             'run-fr': ['evt-2'],
@@ -165,6 +166,7 @@ describe('sendGroupedIngestionAPIRecords', () => {
         expect(mockPushByIndexName).toHaveBeenCalledTimes(2);
         expect(res.result.ok).toBe(false);
         expect(res.failedRecords).toBe(1);
+        expect(res.sentRecords).toBe(2);
         expect(res.result.object.body.indexingEvents).toEqual({
             'run-en': ['evt-1'],
         });
@@ -192,6 +194,7 @@ describe('sendGroupedIngestionAPIRecords', () => {
         expect(mockPushByIndexName).toHaveBeenCalledTimes(2);
         expect(res.result.ok).toBe(true);
         expect(res.failedRecords).toBe(0);
+        expect(res.sentRecords).toBe(2);
         expect(res.result.object.body.indexingEvents).toEqual({
             'run-en': ['evt-1', 'evt-2'],
         });

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
@@ -194,6 +194,7 @@ describe('send', () => {
         mockSendGroupedIngestionAPIRecords.mockReturnValue({
             result: { ok: true, object: { body: {} } },
             failedRecords: 0,
+            sentRecords: 4,
         });
 
         const chunk = makeChunk(2);
@@ -201,7 +202,7 @@ describe('send', () => {
 
         expect(mockGroupRecordsForIngestionAPI).toHaveBeenCalledWith(chunk.flat());
         expect(mockSendGroupedIngestionAPIRecords).toHaveBeenCalledWith(grouped);
-        expect(job.__getJobReport().recordsSent).toBeGreaterThan(0);
+        expect(job.__getJobReport().recordsSent).toBe(4);
         expect(job.__getJobReport().chunksSent).toBeGreaterThan(0);
     });
 
@@ -213,14 +214,14 @@ describe('send', () => {
         mockSendGroupedIngestionAPIRecords.mockReturnValue({
             result: { ok: false },
             failedRecords: 2,
+            sentRecords: 2,
         });
 
         const chunk = makeChunk(2);
-        const batchLength = chunk.flat().length;
         job.send(chunk);
 
-        // failedRecords from resultObj (2) + batch.length from the !result.ok branch
-        expect(job.__getJobReport().recordsFailed).toBe(2 + batchLength);
+        expect(job.__getJobReport().recordsFailed).toBe(2);
+        expect(job.__getJobReport().recordsSent).toBe(2);
         expect(job.__getJobReport().chunksFailed).toBe(1);
     });
 
@@ -232,6 +233,7 @@ describe('send', () => {
         mockSendGroupedIngestionAPIRecords.mockReturnValue({
             result: { ok: true, object: { body: {} } },
             failedRecords: 0,
+            sentRecords: 2,
         });
 
         job.send(makeChunk(1));

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductIndex.test.js
@@ -354,6 +354,7 @@ describe('send', () => {
                     }
                 },
                 failedRecords: 0,
+                sentRecords: 4,
             })
             .mockReturnValueOnce({
                 result: {
@@ -368,6 +369,7 @@ describe('send', () => {
                     }
                 },
                 failedRecords: 0,
+                sentRecords: 4,
             });
 
         job.send(makeChunk());
@@ -402,6 +404,7 @@ describe('send', () => {
         mockSendGroupedIngestionAPIRecords.mockReturnValue({
             result: { ok: true, object: { body: {} } },
             failedRecords: 0,
+            sentRecords: 2,
         });
 
         function makeChunk() {
@@ -421,7 +424,7 @@ describe('send', () => {
 
         expect(mockGroupRecordsForIngestionAPI).toHaveBeenCalled();
         expect(mockSendGroupedIngestionAPIRecords).toHaveBeenCalledWith({}, 'partialRecordUpdate');
-        expect(job.__getJobReport().recordsSent).toBeGreaterThan(0);
+        expect(job.__getJobReport().recordsSent).toBe(2);
     });
 
     test('Ingestion API - failure updates jobReport', () => {
@@ -432,6 +435,7 @@ describe('send', () => {
         mockSendGroupedIngestionAPIRecords.mockReturnValue({
             result: { ok: false },
             failedRecords: 3,
+            sentRecords: 2,
         });
 
         function makeChunk() {
@@ -448,8 +452,8 @@ describe('send', () => {
 
         job.send(makeChunk());
 
-        // failedRecords from resultObj (3) + batch.length from the !result.ok branch (2)
-        expect(job.__getJobReport().recordsFailed).toBe(3 + 2);
+        expect(job.__getJobReport().recordsFailed).toBe(3);
+        expect(job.__getJobReport().recordsSent).toBe(2);
         expect(job.__getJobReport().chunksFailed).toBe(1);
     });
 
@@ -470,6 +474,8 @@ describe('send', () => {
 
         // Should not throw - caught internally
         expect(() => job.send(makeChunk())).not.toThrow();
+        expect(job.__getJobReport().recordsFailed).toBe(1);
+        expect(job.__getJobReport().chunksFailed).toBe(1);
     });
 });
 


### PR DESCRIPTION
`recordsFailed` was double-counted when using the Ingestion API. The counting pattern was designed for the Search API's `sendRetryableBatch`, which mutates the batch array by splicing out failed records.
The Ingestion API's `sendGroupedIngestionAPIRecords` doesn't mutate the batch, so the original code counted failures from the return value _and_ the full batch length, which are overlapping sets.

## Changes
- `requestHelper.js`: added a `sentRecords` counter to `sendGroupedIngestionAPIRecords` that tracks how many records were accepted by successful push calls. It's returned alongside `failedRecords`, giving callers exact counts for both outcomes
- `algoliaProductIndex.js`: rewrote `send()` as a single `switch` based on `indexingAPI` -- each case is self-contained now with its own try/catch send call and counting logic. Ingestion API case uses `resultObj.sentRecords` and `resultObj.failedRecords`. Search API logic unchanged, still relies on `batch.length` after retries
- `algoliaProductDeltaIndex.js`: same refactor. Also added a try/catch that was previously missing
- updated unit tests and JSDoc where applicable