### PR TITLE
feat: [SFCC-508] Added separate ACL for Ingestion and improved permission validation in the Algolia BM module

### DIFF
--- a/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
+++ b/cartridges/bm_algolia/cartridge/controllers/AlgoliaBM.js
@@ -61,7 +61,8 @@ function handleSettings() {
             serviceAdmin,
             applicationID,
             adminApikey,
-            finalIndexPrefix
+            finalIndexPrefix,
+            indexingAPI
         );
 
         // validate AdminApiKey

--- a/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
+++ b/cartridges/bm_algolia/cartridge/templates/resources/algolia.properties
@@ -138,8 +138,8 @@ algolia.msg.confirmclean=Are you sure you want to clean the indexing queue?
 
 algolia.error.analyticsregion.invalid=Analytics region must be "us" or "eu".
 algolia.error.service=Service request failed
-algolia.error.missing.permissions=The API key is missing required permissions: {0}
+algolia.error.missing.permissions=The API key is missing required permissions for "{0}": {1}. Required permissions: {2}
 algolia.error.key.validation=Failed to validate API key
-algolia.warning.excessive.permissions=Your API key has more permissions than necessary. Consider removing these permissions: {0}
+algolia.warning.excessive.permissions=Your API key has more permissions than necessary for "{0}". Consider removing these permissions: {1}. Required permissions: {2}
 algolia.error.index.restrictedprefix=The API key does not have access to the required indices: {0}*
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaConstants.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaConstants.js
@@ -25,6 +25,40 @@ const INDEXING_APIS = {
     INGESTION_API: 'ingestion-api',
 }
 
+// ACL requirements per indexing API mode. Used by the BM module to validate the configured
+// admin API key against the actual endpoints the cartridge calls at runtime, so customers
+// don't need to grant a broader ACL than they actually exercise.
+//
+//   Common to both modes (the atomic-reindex orchestration uses the Search API regardless of mode,
+//   and category/content indexing always uses the Search API regardless of the IndexingAPI preference):
+//     addObject     — POST   /1/indexes/<n>/batch                 (Search API batch writes)
+//                   - POST   /1/indexes/<src>/operation           (copy/move; required ACL per the operation-index OpenAPI)
+//                   - POST   /1/push/<n>                          (Ingestion API push)
+//                   - GET    /1/runs/<runID>/events/<eventID>     (Ingestion API observability)
+//     deleteObject  — POST /1/indexes/<n>/batch  (delete actions in product delta jobs and real-time inventory hooks)
+//                     Strictly speaking, in Ingestion API mode no Search-API / batch call currently carries
+//                     a `deleteObject` action — product delta and the real-time inventory hook route delete actions through
+//                     POST /1/push/<n> when Ingestion is selected, and the unconditional Search-API jobs
+//                     (categories, content) only emit `addObject` actions today. We still require it in
+//                     both modes so the Ingestion list is a superset of Search: one key works for both modes.
+//     deleteIndex   — DELETE /1/indexes/<n>                       (tmp cleanup; also required by /1/push and /runs/events)
+//     settings      — GET    /1/indexes/<n>/settings              (read source settings before copy)
+//
+//   Ingestion API mode only:
+//     editSettings  — POST /1/push/<n> and GET /1/runs/<runID>/events/<eventID>
+//                     The cartridge does not call PUT /1/indexes/<n>/settings, so editSettings is not
+//                     required in Search API mode.
+//
+// Sources:
+//   - ACL reference:                   https://www.algolia.com/doc/guides/security/api-keys/
+//   - Search API operation-index:      https://www.algolia.com/doc/rest-api/search/operation-index
+//                                      (`Required ACL: addObject` for POST /1/indexes/<src>/operation)
+//   - Ingestion API push and events:   POST /1/push/{indexName} and GET /1/runs/{runID}/events/{eventID}
+//                                      both list `addObject, deleteIndex, editSettings` as required ACL.
+const REQUIRED_ACL_BY_INDEXING_API = {};
+REQUIRED_ACL_BY_INDEXING_API[INDEXING_APIS.SEARCH_API] = ['addObject', 'deleteObject', 'deleteIndex', 'settings'];
+REQUIRED_ACL_BY_INDEXING_API[INDEXING_APIS.INGESTION_API] = ['addObject', 'deleteObject', 'deleteIndex', 'settings', 'editSettings'];
+
 const RECORD_MODEL_TYPES = {
     MASTER_LEVEL: 'master-level',
     VARIANT_LEVEL: 'variant-level',
@@ -55,6 +89,7 @@ module.exports = {
     ALGOLIA_DELTA_EXPORT_UPDATE_FILE_NAME: ALGOLIA_DELTA_EXPORT_UPDATE_FILE_NAME,
 
     INDEXING_APIS: INDEXING_APIS,
+    REQUIRED_ACL_BY_INDEXING_API: REQUIRED_ACL_BY_INDEXING_API,
     RECORD_MODEL_TYPES: RECORD_MODEL_TYPES,
     ANALYTICS_REGIONS: ANALYTICS_REGIONS,
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaConstants.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaConstants.js
@@ -25,36 +25,9 @@ const INDEXING_APIS = {
     INGESTION_API: 'ingestion-api',
 }
 
-// ACL requirements per indexing API mode. Used by the BM module to validate the configured
-// admin API key against the actual endpoints the cartridge calls at runtime, so customers
-// don't need to grant a broader ACL than they actually exercise.
-//
-//   Common to both modes (the atomic-reindex orchestration uses the Search API regardless of mode,
-//   and category/content indexing always uses the Search API regardless of the IndexingAPI preference):
-//     addObject     — POST   /1/indexes/<n>/batch                 (Search API batch writes)
-//                   - POST   /1/indexes/<src>/operation           (copy/move; required ACL per the operation-index OpenAPI)
-//                   - POST   /1/push/<n>                          (Ingestion API push)
-//                   - GET    /1/runs/<runID>/events/<eventID>     (Ingestion API observability)
-//     deleteObject  — POST /1/indexes/<n>/batch  (delete actions in product delta jobs and real-time inventory hooks)
-//                     Strictly speaking, in Ingestion API mode no Search-API / batch call currently carries
-//                     a `deleteObject` action — product delta and the real-time inventory hook route delete actions through
-//                     POST /1/push/<n> when Ingestion is selected, and the unconditional Search-API jobs
-//                     (categories, content) only emit `addObject` actions today. We still require it in
-//                     both modes so the Ingestion list is a superset of Search: one key works for both modes.
-//     deleteIndex   — DELETE /1/indexes/<n>                       (tmp cleanup; also required by /1/push and /runs/events)
-//     settings      — GET    /1/indexes/<n>/settings              (read source settings before copy)
-//
-//   Ingestion API mode only:
-//     editSettings  — POST /1/push/<n> and GET /1/runs/<runID>/events/<eventID>
-//                     The cartridge does not call PUT /1/indexes/<n>/settings, so editSettings is not
-//                     required in Search API mode.
-//
-// Sources:
-//   - ACL reference:                   https://www.algolia.com/doc/guides/security/api-keys/
-//   - Search API operation-index:      https://www.algolia.com/doc/rest-api/search/operation-index
-//                                      (`Required ACL: addObject` for POST /1/indexes/<src>/operation)
-//   - Ingestion API push and events:   POST /1/push/{indexName} and GET /1/runs/{runID}/events/{eventID}
-//                                      both list `addObject, deleteIndex, editSettings` as required ACL.
+// ACL requirements per indexing API mode. Used by the BM module to validate the configured API key against the
+// actual endpoints the cartridge calls at runtime, so customers don't need to grant a broader ACL than necessary.
+// ACL reference: https://www.algolia.com/doc/guides/security/api-keys/
 const REQUIRED_ACL_BY_INDEXING_API = {};
 REQUIRED_ACL_BY_INDEXING_API[INDEXING_APIS.SEARCH_API] = ['addObject', 'deleteObject', 'deleteIndex', 'settings'];
 REQUIRED_ACL_BY_INDEXING_API[INDEXING_APIS.INGESTION_API] = ['addObject', 'deleteObject', 'deleteIndex', 'settings', 'editSettings'];

--- a/cartridges/int_algolia/cartridge/scripts/services/algoliaServiceHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/services/algoliaServiceHelper.js
@@ -7,6 +7,7 @@
 const logger = require('*/cartridge/scripts/algolia/helper/jobHelper').getAlgoliaLogger();
 const Resource = require('dw/web/Resource');
 const stringUtils = require('dw/util/StringUtils');
+const { INDEXING_APIS, REQUIRED_ACL_BY_INDEXING_API } = require('*/cartridge/scripts/algolia/lib/algoliaConstants');
 
 /**
  * Formats standard error message string
@@ -144,19 +145,23 @@ function callJsonService(title, service, params) {
 
 /**
  * Validates an Algolia API key’s permissions and index restrictions.
- * It retrieves key details from Algolia, then verifies that the key contains
- * all required ACLs and that the provided indexPrefix is covered by one of the allowed index patterns.
+ * It retrieves key details from Algolia, then verifies that the key’s ACL
+ * contains every entry required by the selected indexing API and that the
+ * provided indexPrefix is covered by one of the allowed index patterns.
  *
  * @param {dw.svc.Service} service - The service instance used for the API call.
  * @param {string} applicationID - The Algolia Application ID.
  * @param {string} apiKey - The API key to validate.
  * @param {string} indexPrefix - The index prefix to validate against.
+ * @param {string} [indexingAPI] - Selected indexing API ('search-api' or 'ingestion-api').
+ *                                 Defaults to 'search-api' when omitted to match the rest of the cartridge.
  * @returns {Object} An object with properties { error: Boolean, errorMessage: String, warning: String }.
  */
-function validateAPIKey(service, applicationID, apiKey, indexPrefix) {
+function validateAPIKey(service, applicationID, apiKey, indexPrefix, indexingAPI) {
 
-    // Define the required ACLs.
-    var requiredACLs = ['addObject', 'deleteObject', 'deleteIndex', 'settings'];
+    var selectedIndexingAPI = indexingAPI || INDEXING_APIS.SEARCH_API;
+    var requiredACL = REQUIRED_ACL_BY_INDEXING_API[selectedIndexingAPI]
+        || REQUIRED_ACL_BY_INDEXING_API[INDEXING_APIS.SEARCH_API];
 
     var response = service.call({
         method: 'GET',
@@ -171,16 +176,23 @@ function validateAPIKey(service, applicationID, apiKey, indexPrefix) {
     }
 
     var keyData = response.object.body;
-    var actualACLs = keyData.acl || [];
+    var actualACLPerms = keyData.acl || [];
 
-    // Check for missing required ACLs.
-    var missingACLs = requiredACLs.filter(function (acl) {
-        return actualACLs.indexOf(acl) === -1;
+    // Identify required ACL entries that are missing from the key.
+    var missingACLPerms = requiredACL.filter(function (entry) {
+        return actualACLPerms.indexOf(entry) === -1;
     });
-    if (missingACLs.length > 0) {
+    if (missingACLPerms.length > 0) {
         return {
             error: true,
-            errorMessage: Resource.msgf('algolia.error.missing.permissions', 'algolia', null, missingACLs.join(', '))
+            errorMessage: Resource.msgf(
+                'algolia.error.missing.permissions',
+                'algolia',
+                null,
+                selectedIndexingAPI,
+                missingACLPerms.join(', '),
+                requiredACL.join(', ')
+            )
         };
     }
 
@@ -208,16 +220,23 @@ function validateAPIKey(service, applicationID, apiKey, indexPrefix) {
         }
     }
 
-    // Identify any extra (excessive) ACLs.
-    var excessiveACLs = actualACLs.filter(function (acl) {
-        return requiredACLs.indexOf(acl) === -1;
+    // Identify ACL entries on the key that exceed what the selected indexing API requires.
+    var excessiveACL = actualACLPerms.filter(function (entry) {
+        return requiredACL.indexOf(entry) === -1;
     });
 
     return {
         error: false,
         errorMessage: '',
-        warning: excessiveACLs.length > 0
-            ? Resource.msgf('algolia.warning.excessive.permissions', 'algolia', null, excessiveACLs.join(', '))
+        warning: excessiveACL.length > 0
+            ? Resource.msgf(
+                'algolia.warning.excessive.permissions',
+                'algolia',
+                null,
+                selectedIndexingAPI,
+                excessiveACL.join(', '),
+                requiredACL.join(', ')
+            )
             : ''
     };
 }

--- a/test/unit/int_algolia/scripts/services/algoliaServiceHelper.test.js
+++ b/test/unit/int_algolia/scripts/services/algoliaServiceHelper.test.js
@@ -34,7 +34,7 @@ describe('algoliaServiceHelper.validateAPIKey', () => {
         expect(result.errorMessage).toContain('MSG:algolia.error.key.validation');
     });
 
-    it('should require admin ACLs when some required permissions are missing', () => {
+    it('should require admin ACL entries when some required permissions are missing', () => {
         mockService.call.mockReturnValueOnce({
             ok: true,
             object: {
@@ -56,12 +56,12 @@ describe('algoliaServiceHelper.validateAPIKey', () => {
         expect(result.errorMessage).toMatch(/MSGF:algolia.error.missing.permissions/);
     });
 
-    it('should allow extra ACLs and return a warning', () => {
+    it('should allow extra ACL entries and return a warning', () => {
         mockService.call.mockReturnValueOnce({
             ok: true,
             object: {
                 body: {
-                    // All required ACLs plus an extra one.
+                    // All required ACL entries plus an extra one.
                     acl: ['addObject', 'deleteObject', 'deleteIndex', 'settings', 'extraACL'],
                     indexes: []
                 }


### PR DESCRIPTION
The Ingestion API requires different permissions for its operations than the Search API.

Creating a separate access control list for each of the indexing APIs and changing validation to take into account the selected indexing API.

The error and warning messages for missing / extra permissions is also improved: they now display:
- the selected indexing API
- the missing / extra permissions
- the complete list of permissions for the selected indexing API

ACLs required by indexing API:
- Search: `['addObject', 'deleteObject', 'deleteIndex', 'settings']`
- Ingestion: `['addObject', 'deleteObject', 'deleteIndex', 'settings', 'editSettings']`

Missing permissions error message:
<img width="424" height="87" alt="image-20260427-165911" src="https://github.com/user-attachments/assets/50a6a1d3-f668-45ec-ad73-c0d1f2f51db7" />

Extra permissions warning message:
<img width="415" height="109" alt="image-20260427-170514" src="https://github.com/user-attachments/assets/f29b5d57-4d1c-45c3-8c33-ab0e58c1cc59" />

### `deleteObject` for Ingestion
Technically, deleteObject is not required for Ingestion API (the [Push records by indexName](https://www.algolia.com/doc/rest-api/ingestion/push) endpoint doesn’t currently list it), but it will still be included in the Ingestion ACL so that it’s a superset of the Search ACL: this way one key can be used for both APIs.

I confirmed through testing that the Ingestion API's Push records by indexName endpoint does indeed not require the `deleteObject` permission to remove records. The details of the test and additional information can be found on the [ticket](https://algolia.atlassian.net/browse/SFCC-508).