### PR TITLE
feat: [SFCC-518][SEO-friendly URLs] Canonical URL support for the Algolia path

### DIFF
--- a/cartridges/int_algolia_sfra/cartridge/controllers/Search.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Search.js
@@ -4,6 +4,7 @@ var server = require('server');
 
 /* API includes */
 var CatalogMgr = require('dw/catalog/CatalogMgr');
+var URLUtils = require('dw/web/URLUtils');
 /* Local includes */
 var cache = require('*/cartridge/scripts/middleware/cache');
 var consentTracking = require('*/cartridge/scripts/middleware/consentTracking');
@@ -52,6 +53,15 @@ server.replace('Show', cache.applyShortPromotionSensitiveCache, consentTracking.
             res.cachePeriodUnit = 'hours';
             res.personalized = true;
 
+            // Canonical URL excludes refinements and pagination so that crawlers
+            // see a single representative URL per category (or per query),
+            var canonicalUrl;
+            if (cgid) {
+                canonicalUrl = URLUtils.url('Search-Show', 'cgid', cgid).abs().toString();
+            } else if (q) {
+                canonicalUrl = URLUtils.url('Search-Show', 'q', q).abs().toString();
+            }
+
             // server-side rendering to improve SEO - makes a server-side request to Algolia to return CLP search results
             // only triggered when the user-agent looks like a bot, as we want it triggered only for search engines bots (DuckDuckBot, GoogleBot, BingBot, YandexBot, Baiduspider, ...)
             var searchenginesbots = /bot|crawler|spider/i;
@@ -96,6 +106,7 @@ server.replace('Show', cache.applyShortPromotionSensitiveCache, consentTracking.
                 contentHits: contentHits,
                 cgid: req.querystring.cgid,
                 q: req.querystring.q,
+                canonicalUrl: canonicalUrl,
                 activePromotions: activePromotions
             }
 


### PR DESCRIPTION
The cartridge overloads the Search.js controller from SFRA and replaces the Search-Show endpoint. The Seach-Show endpoint branches off based on whether the Algolia frontend features are enabled in BM or not.

The original branch (SFRA) has support for canonical URLs (rel=”canonical”) which prevents indexing of the same endpoint lots of times due to different GET parameters and instead tells crawlers that they should index URLs with the same stem as the same page, ignoring certain GET parameters.

The Algolia path didn't have this feature, this PR remedies that.