### PR TITLE
feat: [SFCC-523][KTLO] Changed direct product property accesses to getters and setters

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/filters/productFilter.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/filters/productFilter.js
@@ -23,7 +23,7 @@ function isOnline(product) {
     if (config.includeOfflineProducts === true) {
         return true;
     }
-    return product.online;
+    return product.isOnline();
 }
 
 /**
@@ -36,7 +36,7 @@ function isSearchable(product) {
     if (config.includeNotSearchableProducts === true) {
         return true;
     }
-    return product.searchable;
+    return product.isSearchable();
 }
 
 /**
@@ -65,7 +65,10 @@ function isInclude(product) {
     // Do not include Option products
     // if (product.optionProduct) return false;
     // Do not include bundled product
-    if (product.bundled && !(product.priceModel && product.priceModel.price && product.priceModel.price.available)) return false;
+    if (product.isBundled()) {
+        var priceModel = product.getPriceModel();
+        if (!(priceModel && priceModel.price && priceModel.price.available)) return false;
+    }
 
     // Check online status
     if (!isOnline(product)) return false;
@@ -100,7 +103,7 @@ function isInStock(product, threshold) {
 
     // even if one variant is in stock, we consider the product as in stock
     if (product.isMaster() || product.isVariationGroup()) {
-        const variantsIt = product.variants.iterator();
+        const variantsIt = product.getVariants().iterator();
 
         while (variantsIt.hasNext()) {
             let variant = variantsIt.next();

--- a/cartridges/int_algolia/cartridge/scripts/algolia/filters/productFilter.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/filters/productFilter.js
@@ -67,7 +67,7 @@ function isInclude(product) {
     // Do not include bundled product
     if (product.isBundled()) {
         var priceModel = product.getPriceModel();
-        if (!(priceModel && priceModel.price && priceModel.price.available)) return false;
+        if (!(priceModel && priceModel.getPrice() && priceModel.getPrice().isAvailable())) return false;
     }
 
     // Check online status

--- a/cartridges/int_algolia/cartridge/scripts/algolia/filters/productFilter.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/filters/productFilter.js
@@ -66,8 +66,9 @@ function isInclude(product) {
     // if (product.optionProduct) return false;
     // Do not include bundled product
     if (product.isBundled()) {
-        var priceModel = product.getPriceModel();
-        if (!(priceModel && priceModel.getPrice() && priceModel.getPrice().isAvailable())) return false;
+        let priceModel = product.getPriceModel();
+        if (!(priceModel && priceModel.getPrice() && priceModel.getPrice().isAvailable())) {
+            return false;
     }
 
     // Check online status

--- a/cartridges/int_algolia/cartridge/scripts/algolia/filters/productFilter.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/filters/productFilter.js
@@ -69,6 +69,7 @@ function isInclude(product) {
         let priceModel = product.getPriceModel();
         if (!(priceModel && priceModel.getPrice() && priceModel.getPrice().isAvailable())) {
             return false;
+        }
     }
 
     // Check online status

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
@@ -741,13 +741,13 @@ function generateAttributeSlicedRecords(parameters) {
     let variationModel = parameters.baseProduct.getVariationModel();
     let variationAttribute = variationModel.getProductVariationAttribute(parameters.variationAttributeID);
     if (!variationAttribute) {
-        algoliaLogger.info('No ' + parameters.variationAttributeID + ' attribute found for product ' + parameters.baseProduct.ID);
+        algoliaLogger.info('No ' + parameters.variationAttributeID + ' attribute found for product ' + parameters.baseProduct.getID());
         return algoliaRecordsPerLocale;
     }
     let variationValues = variationModel.getAllValues(variationAttribute).iterator();
     while (variationValues.hasNext()) {
         let variationValue = variationValues.next();
-        variationModel.setSelectedAttributeValue(variationAttribute.ID, variationValue.ID);
+        variationModel.setSelectedAttributeValue(variationAttribute.getID(), variationValue.getID());
         let baseModel = new AlgoliaLocalizedProduct({
             product: parameters.baseProduct,
             locale: 'default',
@@ -766,7 +766,7 @@ function generateAttributeSlicedRecords(parameters) {
                 variantAttributes: parameters.variantAttributes,
                 baseModel: baseModel,
                 variationModel: variationModel,
-                variationValueID: variationValue.ID,
+                variationValueID: variationValue.getID(),
             });
             algoliaRecordsPerLocale[locale].push(localizedVariationGroup);
         }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
@@ -111,9 +111,9 @@ function getImageGroups(imagesList, viewtype) {
             title: {},
         };
 
-        image.alt = imagesList[i].alt;
-        image.dis_base_link = imagesList[i].absURL.toString();
-        image.title = imagesList[i].title;
+        image.alt = imagesList.get(i).alt;
+        image.dis_base_link = imagesList.get(i).absURL.toString();
+        image.title = imagesList.get(i).title;
 
         result.images.push(image);
     }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
@@ -32,7 +32,7 @@ function getColorVariations(product, locale) {
         );
         if (!hasOrderableVariants) {
             logger.info(
-                'Product ' + product.ID + ' has no orderable variant for color ' + colorValue.value
+                'Product ' + product.getID() + ' has no orderable variant for color ' + colorValue.getValue()
             );
             continue;
         }
@@ -46,15 +46,15 @@ function getColorVariations(product, locale) {
                 variationURL: URLUtils.url(
                     'Product-Show',
                     'pid',
-                    product.ID,
+                    product.getID(),
                     variationModel.getHtmlName(colorVariationAttribute), // returns 'dwvar_' + product.ID + '_color',
-                    colorValue.value
+                    colorValue.getValue()
                 ).toString(),
-                color: colorValue.displayValue,
+                color: colorValue.getDisplayValue(),
             };
 
             if (IS_PWA) {
-                variationObject.colorCode = colorValue.value; // Required to create product detail page URL in PWA
+                variationObject.colorCode = colorValue.getValue(); // Required to create product detail page URL in PWA
             }
 
             colorVariations.push(variationObject);
@@ -73,7 +73,7 @@ function getColorVariations(product, locale) {
 function getColorVariationImagesGroup(variationModel, colorAttributeValue) {
     var imageGroupsArr = [];
 
-    variationModel.setSelectedAttributeValue('color', colorAttributeValue.ID);
+    variationModel.setSelectedAttributeValue('color', colorAttributeValue.getID());
 
     ['large', 'small', 'swatch'].forEach(function (viewtype) {
         var imagesList = variationModel.getImages(viewtype);
@@ -111,9 +111,10 @@ function getImageGroups(imagesList, viewtype) {
             title: {},
         };
 
-        image.alt = imagesList.get(i).alt;
-        image.dis_base_link = imagesList.get(i).absURL.toString();
-        image.title = imagesList.get(i).title;
+        var mediaFile = imagesList.get(i);
+        image.alt = mediaFile.getAlt();
+        image.dis_base_link = mediaFile.getAbsURL().toString();
+        image.title = mediaFile.getTitle();
 
         result.images.push(image);
     }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedCategory.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedCategory.js
@@ -19,7 +19,7 @@ function getCategoryUrl(category) {
  * @returns {string} - Final ID of the category
  */
 function getCategoryId(catalogId, category) {
-    return catalogId + '/' + category.ID;
+    return catalogId + '/' + category.getID();
 }
 
 /**

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -109,7 +109,7 @@ function getPromotionalPrices(product, campaigns) {
                 if (price === dw.value.Money.NOT_AVAILABLE) {
                     return null;
                 }
-                let promoId = promotion.ID;
+                let promoId = promotion.getID();
                 return {
                     price: price.getValue(),
                     promoId: promoId
@@ -244,7 +244,7 @@ var aggregatedValueHandlers = {
     },
     defaultVariantID: function(product) {
         const defaultVariant = product.getVariationModel().getDefaultVariant();
-        return defaultVariant ? defaultVariant.ID : null;
+        return defaultVariant ? defaultVariant.getID() : null;
     },
     categories: function (product) {
         var productCategories = product.getOnlineCategories();
@@ -281,7 +281,7 @@ var aggregatedValueHandlers = {
         var result = null;
         if (empty(product.getPrimaryCategory())) {
             var primaryCategory = product.isVariant() ? product.getMasterProduct().getPrimaryCategory() : null;
-            result = empty(primaryCategory) ? null : primaryCategory.ID;
+            result = empty(primaryCategory) ? null : primaryCategory.getID();
         } else {
             result = product.getPrimaryCategory().getID();
         }
@@ -306,7 +306,7 @@ var aggregatedValueHandlers = {
         var variationModel = parameters.variationModel || product.getVariationModel();
         var colorAttribute = variationModel.getProductVariationAttribute('color');
         return (colorAttribute && variationModel.getSelectedValue(colorAttribute))
-            ? variationModel.getSelectedValue(colorAttribute).displayValue
+            ? variationModel.getSelectedValue(colorAttribute).getDisplayValue()
             : product.custom.color; // this is a workaround to retrieve color values which are otherwise not returned properly by the API via the variation model, likely due to an SFCC bug. It either returns the color value that `getSelectedValue()` couldn't or `null` as before.
 
     },
@@ -329,7 +329,7 @@ var aggregatedValueHandlers = {
         var variationModel = parameters.variationModel || product.getVariationModel();
         var sizeAttribute = variationModel.getProductVariationAttribute('size');
         return (sizeAttribute && variationModel.getSelectedValue(sizeAttribute))
-            ? variationModel.getSelectedValue(sizeAttribute).displayValue
+            ? variationModel.getSelectedValue(sizeAttribute).getDisplayValue()
             : product.custom.size; // this is a workaround to retrieve size values which are otherwise not returned properly by the API via the variation model, likely due to an SFCC bug. It either returns the size value that `getSelectedValue()` couldn't or `null` as before.
     },
     refinementSize: function (product) {
@@ -348,10 +348,10 @@ var aggregatedValueHandlers = {
         for (var k = 0; k < siteCurrenciesSize; k += 1) {
             var currency = Currency.getCurrency(siteCurrencies.get(k));
             currentSession.setCurrency(currency);
-            var price = product.isProductSet() ? product.getPriceModel().minPrice : product.getPriceModel().price;
-            if (price.available) {
+            var price = product.isProductSet() ? product.getPriceModel().getMinPrice() : product.getPriceModel().getPrice();
+            if (price.isAvailable()) {
                 if (!productPrice) { productPrice = {}; }
-                productPrice[price.currencyCode] = price.value;
+                productPrice[price.getCurrencyCode()] = price.getValue();
             }
         }
         currentSession.setCurrency(currentCurrency);
@@ -364,19 +364,22 @@ var aggregatedValueHandlers = {
 
         while (sitePriceBooks.hasNext()) {
             var pricebook = sitePriceBooks.next();
-            if (siteCurrencies.indexOf(pricebook.currencyCode) < 0) {
+            var pricebookCurrencyCode = pricebook.getCurrencyCode();
+            if (siteCurrencies.indexOf(pricebookCurrencyCode) < 0) {
                 continue;
             }
-            var priceInfo = product.getPriceModel().getPriceBookPriceInfo(pricebook.ID);
+            var priceInfo = product.getPriceModel().getPriceBookPriceInfo(pricebook.getID());
             if (priceInfo) {
-                if (!pricebooks[pricebook.currencyCode]) {
-                    pricebooks[pricebook.currencyCode] = [];
+                if (!pricebooks[pricebookCurrencyCode]) {
+                    pricebooks[pricebookCurrencyCode] = [];
                 }
-                pricebooks[pricebook.currencyCode].push({
-                    price: priceInfo.price.value,
-                    onlineFrom: priceInfo.onlineFrom ? priceInfo.onlineFrom.getTime() : undefined,
-                    onlineTo: priceInfo.onlineTo ? priceInfo.onlineTo.getTime() : undefined,
-                    pricebookID: pricebook.ID,
+                var onlineFrom = priceInfo.getOnlineFrom();
+                var onlineTo = priceInfo.getOnlineTo();
+                pricebooks[pricebookCurrencyCode].push({
+                    price: priceInfo.getPrice().getValue(),
+                    onlineFrom: onlineFrom ? onlineFrom.getTime() : undefined,
+                    onlineTo: onlineTo ? onlineTo.getTime() : undefined,
+                    pricebookID: pricebook.getID(),
                 });
             }
         }
@@ -416,7 +419,7 @@ var aggregatedValueHandlers = {
     },
     url: function (product) {
         // Get product page url for the current locale
-        var productPageUrl = URLUtils.url('Product-Show', 'pid', product.ID);
+        var productPageUrl = URLUtils.url('Product-Show', 'pid', product.getID());
         return productPageUrl ? productPageUrl.toString() : null;
     },
     promotionalPrice: function (product) {
@@ -512,7 +515,7 @@ var aggregatedValueHandlers = {
         }
     },
     _tags: function(product) {
-        return ['id:' + product.ID];
+        return ['id:' + product.getID()];
     },
     storeAvailability: function(product) {
         var storeArray = [];

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -279,7 +279,7 @@ var aggregatedValueHandlers = {
     },
     primary_category_id: function (product) {
         var result = null;
-        if (empty(product.primaryCategory)) {
+        if (empty(product.getPrimaryCategory())) {
             var primaryCategory = product.isVariant() ? product.getMasterProduct().getPrimaryCategory() : null;
             result = empty(primaryCategory) ? null : primaryCategory.ID;
         } else {
@@ -289,9 +289,9 @@ var aggregatedValueHandlers = {
     },
     __primary_category: function (product) {
         var res = {};
-        var primaryCategory = product.primaryCategory;
+        var primaryCategory = product.getPrimaryCategory();
         if (empty(primaryCategory)) {
-            primaryCategory = product.isVariant() ? product.masterProduct.primaryCategory : null;
+            primaryCategory = product.isVariant() ? product.getMasterProduct().getPrimaryCategory() : null;
             if (empty(primaryCategory)) {
                 return null;
             }
@@ -319,7 +319,7 @@ var aggregatedValueHandlers = {
         if (product.isMaster() || product.isVariationGroup()) {
             return modelHelper.getColorVariations(product);
         }
-        const masterProduct = product.getVariationModel().master;
+        const masterProduct = product.getVariationModel().getMaster();
         if (!masterProduct) {
             return null;
         }
@@ -346,9 +346,9 @@ var aggregatedValueHandlers = {
         var currentCurrency = currentSession.getCurrency();
 
         for (var k = 0; k < siteCurrenciesSize; k += 1) {
-            var currency = Currency.getCurrency(siteCurrencies[k]);
+            var currency = Currency.getCurrency(siteCurrencies.get(k));
             currentSession.setCurrency(currency);
-            var price = product.productSet ? product.priceModel.minPrice : product.priceModel.price;
+            var price = product.isProductSet() ? product.getPriceModel().minPrice : product.getPriceModel().price;
             if (price.available) {
                 if (!productPrice) { productPrice = {}; }
                 productPrice[price.currencyCode] = price.value;
@@ -367,7 +367,7 @@ var aggregatedValueHandlers = {
             if (siteCurrencies.indexOf(pricebook.currencyCode) < 0) {
                 continue;
             }
-            var priceInfo = product.priceModel.getPriceBookPriceInfo(pricebook.ID);
+            var priceInfo = product.getPriceModel().getPriceBookPriceInfo(pricebook.ID);
             if (priceInfo) {
                 if (!pricebooks[pricebook.currencyCode]) {
                     pricebooks[pricebook.currencyCode] = [];
@@ -428,7 +428,7 @@ var aggregatedValueHandlers = {
         var currentCurrency = currentSession.getCurrency();
 
         for (var k = 0; k < siteCurrenciesSize; k += 1) {
-            var currency = Currency.getCurrency(siteCurrencies[k]);
+            var currency = Currency.getCurrency(siteCurrencies.get(k));
             currentSession.setCurrency(currency);
             var price = getPromotionalPrice(product);
             if (price) {
@@ -448,13 +448,13 @@ var aggregatedValueHandlers = {
         var currentCurrency = currentSession.getCurrency();
         var campaigns = PromotionMgr.getCampaigns().toArray();
         for (var k = 0; k < siteCurrenciesSize; k += 1) {
-            var currency = Currency.getCurrency(siteCurrencies[k]);
+            var currency = Currency.getCurrency(siteCurrencies.get(k));
             currentSession.setCurrency(currency);
             var promotionObjects = getPromotionalPrices(product, campaigns);
 
             if (promotionObjects.length > 0) {
                 if (!promotionalPrices) { promotionalPrices = {}; }
-                promotionalPrices[siteCurrencies[k]] = promotionObjects;
+                promotionalPrices[siteCurrencies.get(k)] = promotionObjects;
             }
         }
         currentSession.setCurrency(currentCurrency);
@@ -469,7 +469,7 @@ var aggregatedValueHandlers = {
             if (parameters.variationModel) {
                 variantsIt = parameters.variationModel.getSelectedVariants().iterator();
             } else {
-                variantsIt = product.variants.iterator();
+                variantsIt = product.getVariants().iterator();
             }
 
             while (variantsIt.hasNext()) {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/recommend/utils.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/recommend/utils.js
@@ -51,7 +51,7 @@ function getAnchorProductIDs(slotcontent) {
     } else {
         for (let i = 0; i < slotcontent.content.length; i++) {
             let product = slotcontent.content[i];
-            productIDs.push(product.ID);
+            productIDs.push(product.getID());
         }
     }
 
@@ -71,7 +71,7 @@ function getAnchorProductIDs(slotcontent) {
         var appropriateProduct = getAppropriateProduct(product, recordModel);
 
         if (appropriateProduct) {
-            anchorProductIDsArr.push(appropriateProduct.ID);
+            anchorProductIDsArr.push(appropriateProduct.getID());
         }
     }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/recommend/utils.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/recommend/utils.js
@@ -26,11 +26,11 @@ function getProductType(product) {
 function getAppropriateProduct(product, recordModel) {
     const productType = getProductType(product);
     if (recordModel === RECORD_MODEL_TYPES.MASTER_LEVEL && productType !== 'Master') {
-        return product.masterProduct; // @TODO: refactor to be safer: only Variants and Variation Groups have the `masterProduct` property, add checks
+        return product.getMasterProduct(); // @TODO: refactor to be safer: only Variants and Variation Groups have the `masterProduct` property, add checks
     } else if (recordModel === RECORD_MODEL_TYPES.MASTER_LEVEL && (productType === 'Master' || productType === 'Variation Group')) {
         return product;
     } else if (recordModel !== RECORD_MODEL_TYPES.MASTER_LEVEL && (productType === 'Master' || productType === 'Variation Group')) {
-        return product.variationModel.defaultVariant;
+        return product.getVariationModel().getDefaultVariant();
     } else if (recordModel !== RECORD_MODEL_TYPES.MASTER_LEVEL && productType === 'Variant') {
         return product;
     }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaContentIndex.js
@@ -164,7 +164,7 @@ exports.process = function(content, parameters, stepExecution) {
     var baseModel = new AlgoliaLocalizedContent({ content: content, locale: 'default', attributeList: nonLocalizedAttributes, includedContent: includedContent });
 
     for (let l = 0; l < siteLocales.size(); ++l) {
-        var locale = siteLocales[l];
+        var locale = siteLocales.get(l);
         var indexName = jobHelper.toTmp(algoliaData.calculateIndexName('contents', locale));
         let localizedContent = new AlgoliaLocalizedContent({ content: content, locale: locale, attributeList: attributesToSend, baseModel: baseModel, includedContent: includedContent });
         let splits = [];

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -376,7 +376,7 @@ exports.process = function(cpObj, parameters, stepExecution) {
                 // This variant will be processed when we handle its master product, skip it for now.
                 return [];
             }
-            if (product.master) {
+            if (product.isMaster()) {
                 let inStock = productFilter.isInStock(product, ALGOLIA_IN_STOCK_THRESHOLD);
 
                 if ((inStock || INDEX_OUT_OF_STOCK) &&
@@ -417,7 +417,7 @@ exports.process = function(cpObj, parameters, stepExecution) {
                 return [];
             }
 
-            if (product.master) {
+            if (product.isMaster()) {
                 let variationModel = product.getVariationModel();
                 let variationAttribute = variationModel.getProductVariationAttribute(variationAttributeForAttributeSlicedRecordModel);
 
@@ -528,7 +528,7 @@ exports.process = function(cpObj, parameters, stepExecution) {
                 });
 
                 // Check if we need a delete operation because of product filter because delta jobs are record updates not a full reindex
-                let variants = product.variants;
+                let variants = product.getVariants();
                 if (variants && variants.size() > 0) {
                     for (let v = 0; v < variants.size(); ++v) {
                         let variant = variants[v];

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -423,7 +423,7 @@ exports.process = function(cpObj, parameters, stepExecution) {
 
                 // masters that DON'T have the specified variation attribute -- treat them as regular masters
                 if (!variationAttribute) {
-                    logger.info('Specified variation attribute "' + variationAttributeForAttributeSlicedRecordModel + '" not found for master product "' + product.ID + '", falling back to master-type record.');
+                    logger.info('Specified variation attribute "' + variationAttributeForAttributeSlicedRecordModel + '" not found for master product "' + product.getID() + '", falling back to master-type record.');
 
                     let inStock = productFilter.isInStock(product, ALGOLIA_IN_STOCK_THRESHOLD);
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -297,7 +297,7 @@ exports.process = function(product, parameters, stepExecution) {
             // This variant will be processed when we handle its master product, skip it for now.
             return [];
         }
-        if (product.master) {
+        if (product.isMaster()) {
             // Check if master product meets basic criteria
             if (!productFilter.isOnline(product) || !productFilter.isSearchable(product) || !productFilter.hasOnlineCategory(product)) {
                 return [];
@@ -337,7 +337,7 @@ exports.process = function(product, parameters, stepExecution) {
             // This variant will be processed when we handle its master product, skip it for now.
             return [];
         }
-        if (product.master) {
+        if (product.isMaster()) {
             if (!productFilter.isOnline(product) || !productFilter.isSearchable(product) || !productFilter.hasOnlineCategory(product)) {
                 return [];
             }
@@ -417,7 +417,7 @@ exports.process = function(product, parameters, stepExecution) {
             // This variant will be processed when we handle its master product, skip it for now.
             return [];
         }
-        if (product.master) {
+        if (product.isMaster()) {
             if (!productFilter.isOnline(product) || !productFilter.isSearchable(product) || !productFilter.hasOnlineCategory(product)) {
                 return [];
             }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -258,7 +258,7 @@ exports.beforeStep = function(parameters, stepExecution) {
  */
 // eslint-disable-next-line no-unused-vars
 exports.getTotalCount = function(parameters, stepExecution) {
-    return products.count;
+    return products.getCount();
 }
 
 /**
@@ -347,7 +347,7 @@ exports.process = function(product, parameters, stepExecution) {
 
             // masters that DON'T have the specified variation attribute -- treat them as regular masters
             if (!variationAttribute) {
-                logger.info('Specified variation attribute "' + variationAttributeForAttributeSlicedRecordModel + '" not found for master product "' + product.ID + '", falling back to master-type record.');
+                logger.info('Specified variation attribute "' + variationAttributeForAttributeSlicedRecordModel + '" not found for master product "' + product.getID() + '", falling back to master-type record.');
 
                 let baseModel = new AlgoliaLocalizedProduct({ product: product, locale: 'default', attributeList: nonLocalizedMasterAttributes });
                 for (let l = 0; l < siteLocales.size(); ++l) {
@@ -636,7 +636,7 @@ exports.afterStep = function(success, parameters, stepExecution) {
         jobReport.errorMessage = 'An error occurred during the job. Please see the error log for more details.';
     }
 
-    logger.info('Total number of processed products: {0} / {1}', jobReport.processedItems, products.count);
+    logger.info('Total number of processed products: {0} / {1}', jobReport.processedItems, products.getCount());
     logger.info('Number of products marked for sending: {0}', jobReport.processedItemsToSend);
     logger.info('Number of locales configured for the site: {0}', jobReport.siteLocales);
     logger.info('Records sent: {0}; Records failed: {1}', jobReport.recordsSent, jobReport.recordsFailed);
@@ -648,11 +648,11 @@ exports.afterStep = function(success, parameters, stepExecution) {
         jobReport.error = true;
         jobReport.errorMessage = 'The percentage of records that failed to be indexed (' + failurePercentage + '%) exceeds the failureThresholdPercentage (' +
             paramFailureThresholdPercentage + '%). Check the logs for details.';
-    } else if (jobReport.processedItems !== products.count) {
+    } else if (jobReport.processedItems !== products.getCount()) {
         jobReport.error = true;
         jobReport.errorMessage =
             'Not all products were processed: ' +
-            jobReport.processedItems + ' / ' + products.count +
+            jobReport.processedItems + ' / ' + products.getCount() +
             '. Check the logs for details.';
     } else if (jobReport.chunksFailed > 0) {
         jobReport.error = true;

--- a/cartridges/int_algolia_sfra/cartridge/controllers/Algolia.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Algolia.js
@@ -46,7 +46,7 @@ server.get('Price', cache.applyShortPromotionSensitiveCache, function (req, res,
             };
         }
 
-        var defaultPrice = apiProduct.productSet ? apiProduct.priceModel.minPrice : apiProduct.priceModel.price;
+        var defaultPrice = apiProduct.isProductSet() ? apiProduct.getPriceModel().minPrice : apiProduct.getPriceModel().price;
         product.defaultPrice = defaultPrice.value;
 
         productsArr.push(product);

--- a/cartridges/int_algolia_sfra/cartridge/controllers/Algolia.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Algolia.js
@@ -33,8 +33,8 @@ server.get('Price', cache.applyShortPromotionSensitiveCache, function (req, res,
             var apiPromotion = PromotionMgr.getPromotion(promotion.id);
             var promotionPrice = apiPromotion.getPromotionalPrice(apiProduct);
 
-            if (promotionPrice.value && promotionPrice.value < minPrice ) {
-                minPrice = promotionPrice.value;
+            if (promotionPrice.getValue() && promotionPrice.getValue() < minPrice ) {
+                minPrice = promotionPrice.getValue();
                 activePromotion = promotion;
             }
         }
@@ -46,8 +46,8 @@ server.get('Price', cache.applyShortPromotionSensitiveCache, function (req, res,
             };
         }
 
-        var defaultPrice = apiProduct.isProductSet() ? apiProduct.getPriceModel().minPrice : apiProduct.getPriceModel().price;
-        product.defaultPrice = defaultPrice.value;
+        var defaultPrice = apiProduct.isProductSet() ? apiProduct.getPriceModel().getMinPrice() : apiProduct.getPriceModel().getPrice();
+        product.defaultPrice = defaultPrice.getValue();
 
         productsArr.push(product);
     }

--- a/cartridges/int_algolia_sfra/cartridge/controllers/Order.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Order.js
@@ -30,9 +30,9 @@ server.append('Confirm', function (req, res, next) {
                 var algoliaProduct = {};
 
                 try {
-                    algoliaProduct.pid = algoliaData.getPreference('RecordModel') === RECORD_MODEL_TYPES.MASTER_LEVEL ? product.getMasterProduct().ID : product.ID;
+                    algoliaProduct.pid = algoliaData.getPreference('RecordModel') === RECORD_MODEL_TYPES.MASTER_LEVEL ? product.getMasterProduct().getID() : product.getID();
                 } catch (e) { // eslint-disable-line no-unused-vars
-                    algoliaProduct.pid = product.ID;
+                    algoliaProduct.pid = product.getID();
                 }
 
                 var price = priceFactory.getPrice(product);
@@ -41,7 +41,7 @@ server.append('Confirm', function (req, res, next) {
                     algoliaProduct.discount = +(price.list.value - price.sales.value).toFixed(2);
                 }
                 currency = price.sales.currency;
-                algoliaProduct.qty = pliArr[i].quantityValue;
+                algoliaProduct.qty = pliArr[i].getQuantityValue();
                 algoliaProducts.push(algoliaProduct);
             }
         };

--- a/cartridges/int_algolia_sfra/cartridge/controllers/Order.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Order.js
@@ -30,7 +30,7 @@ server.append('Confirm', function (req, res, next) {
                 var algoliaProduct = {};
 
                 try {
-                    algoliaProduct.pid = algoliaData.getPreference('RecordModel') === RECORD_MODEL_TYPES.MASTER_LEVEL ? product.masterProduct.ID : product.ID;
+                    algoliaProduct.pid = algoliaData.getPreference('RecordModel') === RECORD_MODEL_TYPES.MASTER_LEVEL ? product.getMasterProduct().ID : product.ID;
                 } catch (e) { // eslint-disable-line no-unused-vars
                     algoliaProduct.pid = product.ID;
                 }

--- a/cartridges/int_algolia_sfra/cartridge/scripts/hooks/order/algoliaHooks.js
+++ b/cartridges/int_algolia_sfra/cartridge/scripts/hooks/order/algoliaHooks.js
@@ -196,7 +196,7 @@ function handleInStorePickupShipment(shipment, threshold, additionalAttributes, 
 
     for (let j = 0; j < plis.length; j++) {
         let pli = plis[j];
-        let product = pli.product;
+        let product = pli.getProduct();
         let storeId = shipment.custom.fromStoreId;
 
         let inStoreStock = isInStoreStock(product, storeId, threshold);
@@ -244,7 +244,7 @@ function handleStandardShipment(shipment, threshold, additionalAttributes, recor
 
     for (let j = 0; j < plis.length; j++) {
         let pli = plis[j];
-        let product = pli.product; // product can only be a Variant or a simple product
+        let product = pli.getProduct(); // product can only be a Variant or a simple product
 
         let isInStock = productFilter.isInStock(product, threshold);
         if (!isInStock) {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -131,6 +131,9 @@ jest.mock('dw/system/Site', () => {
                 },
                 getAllowedCurrencies: function () {
                     var arr = ['USD', 'EUR'];
+                    arr.get = function (i) {
+                        return arr[i];
+                    };
                     arr.size = function () {
                         return arr.length;
                     };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -19,6 +19,9 @@ jest.mock('dw/catalog/ProductMgr', () => {
         queryAllSiteProducts: jest.fn().mockReturnValue({
             close: jest.fn(),
             count: 4658,
+            getCount: function () {
+                return 4658;
+            },
         }),
         getProduct: jest.fn((id) => {
             const VariantMock = require('./test/mocks/dw/catalog/Variant');
@@ -42,7 +45,7 @@ jest.mock('dw/catalog/PriceBookMgr', () => {
     return {
         getSitePriceBooks: jest.fn(() => {
             const collectionHelper = require("./test/mocks/helpers/collectionHelper");
-            return collectionHelper.createCollection([
+            const priceBooks = [
                 {
                     ID: 'list-prices-usd',
                     currencyCode: 'USD',
@@ -59,7 +62,16 @@ jest.mock('dw/catalog/PriceBookMgr', () => {
                     ID: 'sale-prices-eur',
                     currencyCode: 'EUR',
                 },
-            ]);
+            ].map(function (priceBook) {
+                priceBook.getID = function () {
+                    return priceBook.ID;
+                };
+                priceBook.getCurrencyCode = function () {
+                    return priceBook.currencyCode;
+                };
+                return priceBook;
+            });
+            return collectionHelper.createCollection(priceBooks);
         }),
     }
 }, { virtual: true });

--- a/test/mocks/dw/catalog/MasterProduct.js
+++ b/test/mocks/dw/catalog/MasterProduct.js
@@ -1,5 +1,7 @@
 const ProductVariationModel = require('./ProductVariationModel');
 const collectionHelper = require('../../helpers/collectionHelper');
+const mediaFileHelper = require('../../helpers/mediaFileHelper');
+const { createMoney } = require('../../helpers/moneyHelper');
 
 // https://salesforcecommercecloud.github.io/b2c-dev-doc/docs/current/scriptapi/html/api/class_dw_catalog_Product.html
 // The instantiated product is a master product.
@@ -102,22 +104,17 @@ class Product {
         const minPrice = Math.min(...prices);
         const maxPrice = Math.max(...prices);
         if (this.master) {
+            const currencyCode = request.getSession().getCurrency().currencyCode;
+            const priceMoney = createMoney(0, 'N/A', false);
+            const minPriceMoney = createMoney(minPrice, currencyCode, true);
+            const maxPriceMoney = createMoney(maxPrice, currencyCode, true);
             return {
-                price: {
-                    available: false,
-                    currencyCode: 'N/A',
-                    value: 0,
-                },
-                minPrice: {
-                    available: true,
-                    currencyCode: request.getSession().getCurrency().currencyCode,
-                    value: minPrice,
-                },
-                maxPrice: {
-                    available: true,
-                    currencyCode: request.getSession().getCurrency().currencyCode,
-                    value: maxPrice,
-                }
+                price: priceMoney,
+                minPrice: minPriceMoney,
+                maxPrice: maxPriceMoney,
+                getPrice: () => priceMoney,
+                getMinPrice: () => minPriceMoney,
+                getMaxPrice: () => maxPriceMoney,
             };
         }
     }
@@ -309,7 +306,7 @@ class Product {
     getImages(viewtype) {
         const images = this.images[viewtype];
         const locale = request.getLocale();
-        return collectionHelper.createCollection(images[locale] || images['en']);
+        return collectionHelper.createCollection(mediaFileHelper.decorate(images[locale] || images['en']));
     }
 
     getVariants() {

--- a/test/mocks/dw/catalog/MasterProduct.js
+++ b/test/mocks/dw/catalog/MasterProduct.js
@@ -143,6 +143,15 @@ class Product {
     isProductSet() {
         return this.productSet;
     }
+    isOnline() {
+        return this.online;
+    }
+    isSearchable() {
+        return this.searchable;
+    }
+    isBundled() {
+        return this.bundled || false;
+    }
     get availabilityModel() {
         return this.getAvailabilityModel();
     }

--- a/test/mocks/dw/catalog/MasterProduct.js
+++ b/test/mocks/dw/catalog/MasterProduct.js
@@ -11,6 +11,7 @@ class Product {
         this.assignedToSiteCatalog = true;
         this.brand = null;
         this.bundle = false;
+        this.bundled = false;
         this.images = images || PRODUCT_IMAGES;
         this.online = online;
         this.searchable = searchable;
@@ -135,7 +136,7 @@ class Product {
         return this.optionProduct;
     }
     isBundle() {
-        return this.bundle;
+        return this.bundle || false;
     }
     isProductSet() {
         return this.productSet;

--- a/test/mocks/dw/catalog/ProductVariationAttributeValue.js
+++ b/test/mocks/dw/catalog/ProductVariationAttributeValue.js
@@ -9,6 +9,18 @@ class ProductVariationAttributeValue {
     get displayValue() {
         return this.displayValues[request.getLocale()] || this.displayValues['en'];
     }
+
+    getID() {
+        return this.ID;
+    }
+
+    getValue() {
+        return this.value;
+    }
+
+    getDisplayValue() {
+        return this.displayValues[request.getLocale()] || this.displayValues['en'];
+    }
 }
 
 module.exports = ProductVariationAttributeValue;

--- a/test/mocks/dw/catalog/ProductVariationModel.js
+++ b/test/mocks/dw/catalog/ProductVariationModel.js
@@ -1,4 +1,5 @@
 const collectionHelper = require('../../helpers/collectionHelper');
+const mediaFileHelper = require('../../helpers/mediaFileHelper');
 const ProductVariationAttributeValue = require('./ProductVariationAttributeValue');
 const mockImages = require('../../../mocks/data/images');
 
@@ -36,7 +37,13 @@ class ProductVariationModel {
                 fr: { ID: 'size', displayName: 'Taille' },
             },
         };
-        return productVariationAttributes[id][request.getLocale()];
+        const attribute = productVariationAttributes[id][request.getLocale()];
+        if (attribute && !attribute.getID) {
+            attribute.getID = function () {
+                return attribute.ID;
+            };
+        }
+        return attribute;
     }
     getMaster() {
         return this.master || null;
@@ -83,7 +90,7 @@ class ProductVariationModel {
         let locale = request.getLocale() || 'en';
         const images = mockImages[this.variationAttributes['color']] || this.images;
         const res = images[viewtype][locale] || images[viewtype]['en'];
-        return collectionHelper.createCollection(res);
+        return collectionHelper.createCollection(mediaFileHelper.decorate(res));
     }
 
     getHtmlName(variationAttribute) {

--- a/test/mocks/dw/catalog/Variant.js
+++ b/test/mocks/dw/catalog/Variant.js
@@ -1,5 +1,6 @@
 const MasterProduct = require('./MasterProduct');
 const ProductVariationModel = require("./ProductVariationModel");
+const { createMoney } = require('../../helpers/moneyHelper');
 
 // https://salesforcecommercecloud.github.io/b2c-dev-doc/docs/current/scriptapi/html/api/class_dw_catalog_Variant.html
 class Variant extends MasterProduct {
@@ -48,26 +49,10 @@ class Variant extends MasterProduct {
         };
 
         this.prices = {
-            'sale-prices-usd': {
-                available: true,
-                currencyCode: 'USD',
-                value: 129,
-            },
-            'list-prices-usd': {
-                available: true,
-                currencyCode: 'USD',
-                value: 132,
-            },
-            'sale-prices-eur': {
-                available: true,
-                currencyCode: 'EUR',
-                value: 92.88,
-            },
-            'list-prices-eur': {
-                available: true,
-                currencyCode: 'EUR',
-                value: 94,
-            }
+            'sale-prices-usd': createMoney(129, 'USD', true),
+            'list-prices-usd': createMoney(132, 'USD', true),
+            'sale-prices-eur': createMoney(92.88, 'EUR', true),
+            'list-prices-eur': createMoney(94, 'EUR', true),
         }
     }
 
@@ -108,18 +93,23 @@ class Variant extends MasterProduct {
             default:
                 return null;
         }
+        const prices = this.prices;
         return {
             price,
+            getPrice: () => price,
+            getMinPrice: () => price,
             getPriceBookPriceInfo: (priceBookID) => {
-                const priceInfo = {
-                    price: this.prices[priceBookID],
-                }
-                if (priceBookID === 'sale-prices-eur') {
-                    priceInfo.onlineFrom = {
-                        getTime: () => 1704067200000,
-                    }
-                }
-                return priceInfo;
+                const priceBookPrice = prices[priceBookID];
+                const onlineFrom = priceBookID === 'sale-prices-eur'
+                    ? { getTime: () => 1704067200000 }
+                    : undefined;
+                return {
+                    price: priceBookPrice,
+                    onlineFrom: onlineFrom,
+                    getPrice: () => priceBookPrice,
+                    getOnlineFrom: () => onlineFrom,
+                    getOnlineTo: () => undefined,
+                };
             }
         }
     }

--- a/test/mocks/helpers/collectionHelper.js
+++ b/test/mocks/helpers/collectionHelper.js
@@ -2,6 +2,9 @@ function createCollection(array) {
     array.size = function() {
         return array.length;
     };
+    array.get = function(index) {
+        return array[index];
+    };
     array.iterator = function() {
         let nextIndex = 0;
 

--- a/test/mocks/helpers/mediaFileHelper.js
+++ b/test/mocks/helpers/mediaFileHelper.js
@@ -1,0 +1,30 @@
+/**
+ * Wraps plain image fixtures (which can come from a JSON file, so they cannot
+ * carry methods) into dw.content.MediaFile-like mocks that expose both the
+ * direct properties (alt, absURL, title) and the getter methods (getAlt,
+ * getAbsURL, getTitle) used by code that accesses MediaFile through the SFCC API.
+ * @param {Array<Object>} images - array of plain image fixtures
+ * @returns {Array<Object>} array of MediaFile-like mocks
+ */
+function decorate(images) {
+    return (images || []).map(function (image) {
+        return {
+            alt: image.alt,
+            absURL: image.absURL,
+            title: image.title,
+            getAlt: function () {
+                return image.alt;
+            },
+            getAbsURL: function () {
+                return image.absURL;
+            },
+            getTitle: function () {
+                return image.title;
+            },
+        };
+    });
+}
+
+module.exports = {
+    decorate: decorate,
+};

--- a/test/mocks/helpers/moneyHelper.js
+++ b/test/mocks/helpers/moneyHelper.js
@@ -1,0 +1,30 @@
+/**
+ * Builds a dw.value.Money-like mock that exposes both the direct properties
+ * (value, currencyCode, available) used by config-driven attribute lookups and
+ * the getter methods (getValue, getCurrencyCode, isAvailable) used by code that
+ * accesses Money through the SFCC API.
+ * @param {number} value - monetary value
+ * @param {string} currencyCode - ISO currency code
+ * @param {boolean} available - whether the price is available
+ * @returns {Object} Money-like mock
+ */
+function createMoney(value, currencyCode, available) {
+    return {
+        value: value,
+        currencyCode: currencyCode,
+        available: available,
+        getValue: function () {
+            return value;
+        },
+        getCurrencyCode: function () {
+            return currencyCode;
+        },
+        isAvailable: function () {
+            return available;
+        },
+    };
+}
+
+module.exports = {
+    createMoney: createMoney,
+};

--- a/test/unit/int_algolia/scripts/algolia/recommend/utils.test.js
+++ b/test/unit/int_algolia/scripts/algolia/recommend/utils.test.js
@@ -7,9 +7,9 @@ describe('getAnchorProductIDs', () => {
         isVariationGroup: jest.fn(() => false),
         isVariant: jest.fn(() => true),
         master: false,
-        masterProduct: {
+        getMasterProduct: jest.fn(() => ({
             ID: 'masterProduct1'
-        },
+        })),
     };
 
     const masterProduct = {
@@ -17,11 +17,11 @@ describe('getAnchorProductIDs', () => {
         isVariationGroup: jest.fn(() => false),
         isVariant: jest.fn(() => false),
         master: true,
-        variationModel: {
-            defaultVariant: {
+        getVariationModel: jest.fn(() => ({
+            getDefaultVariant: jest.fn(() => ({
                 ID: 'product1'
-            },
-        }
+            })),
+        })),
     };
 
     const variationGroupProduct = {
@@ -29,14 +29,14 @@ describe('getAnchorProductIDs', () => {
         isVariationGroup: jest.fn(() => true),
         isVariant: jest.fn(() => false),
         master: false,
-        variationModel: {
-            defaultVariant: {
+        getVariationModel: jest.fn(() => ({
+            getDefaultVariant: jest.fn(() => ({
                 ID: 'product1'
-            },
-        },
-        masterProduct: {
+            })),
+        })),
+        getMasterProduct: jest.fn(() => ({
             ID: 'masterProduct1'
-        },
+        })),
     };
 
     beforeEach(() => {

--- a/test/unit/int_algolia/scripts/algolia/recommend/utils.test.js
+++ b/test/unit/int_algolia/scripts/algolia/recommend/utils.test.js
@@ -4,38 +4,41 @@ describe('getAnchorProductIDs', () => {
 
     const variantProduct = {
         ID: 'product1',
+        getID: jest.fn(() => 'product1'),
         isVariationGroup: jest.fn(() => false),
         isVariant: jest.fn(() => true),
         master: false,
         getMasterProduct: jest.fn(() => ({
-            ID: 'masterProduct1'
+            getID: jest.fn(() => 'masterProduct1')
         })),
     };
 
     const masterProduct = {
         ID: 'masterProduct1',
+        getID: jest.fn(() => 'masterProduct1'),
         isVariationGroup: jest.fn(() => false),
         isVariant: jest.fn(() => false),
         master: true,
         getVariationModel: jest.fn(() => ({
             getDefaultVariant: jest.fn(() => ({
-                ID: 'product1'
+                getID: jest.fn(() => 'product1')
             })),
         })),
     };
 
     const variationGroupProduct = {
         ID: 'variationGroupProduct1',
+        getID: jest.fn(() => 'variationGroupProduct1'),
         isVariationGroup: jest.fn(() => true),
         isVariant: jest.fn(() => false),
         master: false,
         getVariationModel: jest.fn(() => ({
             getDefaultVariant: jest.fn(() => ({
-                ID: 'product1'
+                getID: jest.fn(() => 'product1')
             })),
         })),
         getMasterProduct: jest.fn(() => ({
-            ID: 'masterProduct1'
+            getID: jest.fn(() => 'masterProduct1')
         })),
     };
 
@@ -71,9 +74,9 @@ describe('getAnchorProductIDs', () => {
         global.session.privacy.algoliaAnchorProducts = null;
         const slotcontent = {
             content: [{
-                ID: 'product1'
+                getID: jest.fn(() => 'product1')
             }, {
-                ID: 'product1'
+                getID: jest.fn(() => 'product1')
             }]
         };
         productMgrMock.getProduct.mockReturnValue(variantProduct);

--- a/test/unit/int_algolia/scripts/hooks/order/algoliaHooks.test.js
+++ b/test/unit/int_algolia/scripts/hooks/order/algoliaHooks.test.js
@@ -131,14 +131,14 @@ function setupTestData() {
         shipmentType: 'instore',
         fromStoreId: 'store1',
         productLineItems: [{
-            product: mockVariant
+            getProduct: () => mockVariant
         }]
     });
 
     const mockShipmentStandard = new ShipmentMock({
         shipmentType: 'standard',
         productLineItems: [{
-            product: mockVariant2
+            getProduct: () => mockVariant2
         }]
     });
 


### PR DESCRIPTION
Normalized SFCC API usage across the cartridge. The code now uses setters and getters instead of direct property access, as it is recommended by Salesforce.