### PR TITLE
fix: [SFCC-441] Preferences and store list are injected into AlgoliaLocalizedProduct directly

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
@@ -637,6 +637,8 @@ function updateCPObjectFromXML(xmlFile, changedProducts, resourceType) {
  * @param {Array} parameters.nonLocalizedAttributes - list of non-localized attributes
  * @param {Array} parameters.attributesComputedFromBaseProduct - list of attributes computed from the masterProduct and shared in all variants
  * @param {Array} parameters.fullRecordUpdate - specify if the generated records are mean to replace entirely the existing ones
+ * @param {Object} [parameters.sitePreferences] - site preference values forwarded to AlgoliaLocalizedProduct
+ * @param {Array} [parameters.stores] - stores with their inventory list forwarded to AlgoliaLocalizedProduct (for storeAvailability)
  * @returns {Object} An object containing, for each locale, an array of AlgoliaLocalizedProduct
  */
 function generateVariantRecords(parameters) {
@@ -656,6 +658,8 @@ function generateVariantRecords(parameters) {
             product: parameters.masterProduct,
             locale: locale,
             attributeList: attributesComputedFromBaseProduct,
+            sitePreferences: parameters.sitePreferences,
+            stores: parameters.stores,
         });
         algoliaRecordsPerLocale[locale] = [];
     }
@@ -669,7 +673,9 @@ function generateVariantRecords(parameters) {
             product: variant,
             locale: 'default',
             attributeList: parameters.nonLocalizedAttributes,
-            fullRecordUpdate: parameters.fullRecordUpdate
+            fullRecordUpdate: parameters.fullRecordUpdate,
+            sitePreferences: parameters.sitePreferences,
+            stores: parameters.stores,
         });
         for (let l = 0; l < parameters.locales.size(); ++l) {
             let locale = parameters.locales.get(l);
@@ -682,6 +688,8 @@ function generateVariantRecords(parameters) {
                 locale: locale,
                 attributeList: parameters.attributeList,
                 baseModel: baseModel,
+                sitePreferences: parameters.sitePreferences,
+                stores: parameters.stores,
             });
             algoliaRecordsPerLocale[locale].push(localizedVariant);
         }
@@ -705,6 +713,8 @@ function generateVariantRecords(parameters) {
  * @property {Array} parameters.nonLocalizedAttributes - list of non-localized attributes
  * @property {Array} parameters.attributesComputedFromBaseProduct - list of attributes computed from the baseProduct and shared in all variants
  * @property {string} parameters.variationAttributeID - ID of the variation attribute used to group the variants (e.g. 'color')
+ * @property {Object} [parameters.sitePreferences] - site preference values forwarded to AlgoliaLocalizedProduct
+ * @property {Array} [parameters.stores] - stores with their inventory list forwarded to AlgoliaLocalizedProduct (for storeAvailability)
  * @returns {Object} An object containing, for each locale, an array of AlgoliaLocalizedProduct (one per variation value)
  * @example
  * {
@@ -734,6 +744,8 @@ function generateAttributeSlicedRecords(parameters) {
             product: parameters.baseProduct,
             locale: locale,
             attributeList: attributesComputedFromBaseProduct,
+            sitePreferences: parameters.sitePreferences,
+            stores: parameters.stores,
         });
         algoliaRecordsPerLocale[locale] = [];
     }
@@ -752,6 +764,8 @@ function generateAttributeSlicedRecords(parameters) {
             product: parameters.baseProduct,
             locale: 'default',
             attributeList: parameters.nonLocalizedAttributes,
+            sitePreferences: parameters.sitePreferences,
+            stores: parameters.stores,
         });
         for (let l = 0; l < parameters.locales.size(); ++l) {
             let locale = parameters.locales.get(l);
@@ -767,6 +781,8 @@ function generateAttributeSlicedRecords(parameters) {
                 baseModel: baseModel,
                 variationModel: variationModel,
                 variationValueID: variationValue.getID(),
+                sitePreferences: parameters.sitePreferences,
+                stores: parameters.stores,
             });
             algoliaRecordsPerLocale[locale].push(localizedVariationGroup);
         }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
@@ -162,8 +162,36 @@ function getAttributeSlicedModelRecordID(product) {
     return recordID;
 }
 
+/**
+ * Build the list of stores that have an inventory list, used to compute the `storeAvailability` attribute.
+ * The lookup is intentionally broad (whole world) so that every store assigned to the site is returned.
+ * This is expensive, so callers should build it once and pass it to AlgoliaLocalizedProduct via `parameters.stores`.
+ * @returns {Array<{id: string, storeInventory: dw.catalog.ProductInventoryList}>} stores with their inventory list
+ */
+function getStoresWithInventory() {
+    var StoreMgr = require('dw/catalog/StoreMgr');
+    var result = [];
+    var storesMap = StoreMgr.searchStoresByCoordinates(0, 0, 'mi', 99999999);
+
+    if (storesMap && !storesMap.empty) {
+        var storeObjects = storesMap.keySet().toArray();
+        for (var i = 0; i < storeObjects.length; i++) {
+            var store = storeObjects[i];
+            if (store && store.inventoryList) {
+                result.push({
+                    id: store.ID,
+                    storeInventory: store.inventoryList
+                });
+            }
+        }
+    }
+
+    return result;
+}
+
 module.exports = {
     getColorVariations: getColorVariations,
     getImageGroups: getImageGroups,
     getAttributeSlicedModelRecordID: getAttributeSlicedModelRecordID,
+    getStoresWithInventory: getStoresWithInventory,
 };

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
@@ -169,14 +169,14 @@ function getAttributeSlicedModelRecordID(product) {
  * @returns {Array<{id: string, storeInventory: dw.catalog.ProductInventoryList}>} stores with their inventory list
  */
 function getStoresWithInventory() {
-    var StoreMgr = require('dw/catalog/StoreMgr');
+    const StoreMgr = require('dw/catalog/StoreMgr');
+    const storesMap = StoreMgr.searchStoresByCoordinates(0, 0, 'mi', 99999999);
     var result = [];
-    var storesMap = StoreMgr.searchStoresByCoordinates(0, 0, 'mi', 99999999);
 
     if (storesMap && !storesMap.empty) {
         var storeObjects = storesMap.keySet().toArray();
-        for (var i = 0; i < storeObjects.length; i++) {
-            var store = storeObjects[i];
+        for (let i = 0; i < storeObjects.length; i++) {
+            let store = storeObjects[i];
             if (store && store.inventoryList) {
                 result.push({
                     id: store.ID,

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -29,18 +29,23 @@ try {
 }
 
 /**
- * Resolve the in-stock threshold for this model.
+ * Resolve the in-stock threshold for this construction.
  * Prefers the value injected by the caller (`parameters.sitePreferences.InStockThreshold`) and falls back to the
  * site preference when it is not supplied, so callers that do not inject still behave as before.
+ * The value is resolved once per construction and cached on the `parameters` object, so the in_stock, variants and
+ * storeAvailability handlers reuse it instead of re-reading the preference. The cache is per-construction, not
+ * module-level, which is what keeps successive constructions testable with different preference values.
  * @param {Object} parameters - the constructor parameters
  * @returns {number} the in-stock threshold
  */
 function resolveInStockThreshold(parameters) {
-    var sitePreferences = parameters.sitePreferences;
-    if (sitePreferences && sitePreferences.InStockThreshold !== undefined && sitePreferences.InStockThreshold !== null) {
-        return sitePreferences.InStockThreshold;
+    if (parameters.resolvedInStockThreshold === undefined) {
+        const sitePreferences = parameters.sitePreferences;
+        parameters.resolvedInStockThreshold = (!empty(sitePreferences) && !empty(sitePreferences.InStockThreshold))
+            ? sitePreferences.InStockThreshold
+            : (algoliaData.getPreference('InStockThreshold') || 1);
     }
-    return algoliaData.getPreference('InStockThreshold') || 1;
+    return parameters.resolvedInStockThreshold;
 }
 
 /**
@@ -51,8 +56,8 @@ function resolveInStockThreshold(parameters) {
  * @returns {boolean} whether out-of-stock products should be indexed
  */
 function resolveIndexOutOfStock(parameters) {
-    var sitePreferences = parameters.sitePreferences;
-    if (sitePreferences && sitePreferences.IndexOutOfStock !== undefined && sitePreferences.IndexOutOfStock !== null) {
+    const sitePreferences = parameters.sitePreferences;
+    if (!empty(sitePreferences) && !empty(sitePreferences.IndexOutOfStock)) {
         return sitePreferences.IndexOutOfStock;
     }
     return algoliaData.getPreference('IndexOutOfStock');
@@ -546,9 +551,9 @@ var aggregatedValueHandlers = {
         return ['id:' + product.getID()];
     },
     storeAvailability: function(product, parameters) {
+        const stores = resolveStores(parameters);
+        const inStockThreshold = resolveInStockThreshold(parameters);
         var storeArray = [];
-        var stores = resolveStores(parameters);
-        var inStockThreshold = resolveInStockThreshold(parameters);
         if (stores.length > 0) {
             for (var i = 0; i < stores.length; i++) {
                 var storeEl = stores[i];

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -28,27 +28,49 @@ try {
 } catch (e) { // eslint-disable-line no-unused-vars
 }
 
-var ALGOLIA_IN_STOCK_THRESHOLD = algoliaData.getPreference('InStockThreshold') || 1;
-var INDEX_OUT_OF_STOCK = algoliaData.getPreference('IndexOutOfStock');
-var ATTRIBUTE_LIST = algoliaData.getSetOfArray('AdditionalAttributes');
-const stores = [];
-
-if (ATTRIBUTE_LIST.indexOf('storeAvailability') !== -1) {
-    var StoreMgr = require('dw/catalog/StoreMgr');
-    var storesMap = StoreMgr.searchStoresByCoordinates(0, 0, 'mi', 99999999);
-
-    if (storesMap && !storesMap.empty) {
-        var storeObjects = storesMap.keySet().toArray();
-        for (var l = 0; l < storeObjects.length; l++) {
-            var store = storeObjects[l];
-            if (store && store.inventoryList) {
-                stores.push({
-                    id: store.ID,
-                    storeInventory: store.inventoryList
-                });
-            }
-        }
+/**
+ * Resolve the in-stock threshold for this model.
+ * Prefers the value injected by the caller (`parameters.sitePreferences.InStockThreshold`) and falls back to the
+ * site preference when it is not supplied, so callers that do not inject still behave as before.
+ * @param {Object} parameters - the constructor parameters
+ * @returns {number} the in-stock threshold
+ */
+function resolveInStockThreshold(parameters) {
+    var sitePreferences = parameters.sitePreferences;
+    if (sitePreferences && sitePreferences.InStockThreshold !== undefined && sitePreferences.InStockThreshold !== null) {
+        return sitePreferences.InStockThreshold;
     }
+    return algoliaData.getPreference('InStockThreshold') || 1;
+}
+
+/**
+ * Resolve the "index out of stock" flag for this model.
+ * Prefers the value injected by the caller (`parameters.sitePreferences.IndexOutOfStock`) and falls back to the
+ * site preference when it is not supplied.
+ * @param {Object} parameters - the constructor parameters
+ * @returns {boolean} whether out-of-stock products should be indexed
+ */
+function resolveIndexOutOfStock(parameters) {
+    var sitePreferences = parameters.sitePreferences;
+    if (sitePreferences && sitePreferences.IndexOutOfStock !== undefined && sitePreferences.IndexOutOfStock !== null) {
+        return sitePreferences.IndexOutOfStock;
+    }
+    return algoliaData.getPreference('IndexOutOfStock');
+}
+
+/**
+ * Resolve the store-inventory list used to compute `storeAvailability`.
+ * Prefers the list injected by the caller (`parameters.stores`, built once at the job/hook level) and falls back to
+ * building it on demand when it is not supplied. In production the list is always injected, so the expensive scan
+ * runs once per job/hook rather than once per record.
+ * @param {Object} parameters - the constructor parameters
+ * @returns {Array<{id: string, storeInventory: dw.catalog.ProductInventoryList}>} stores with their inventory list
+ */
+function resolveStores(parameters) {
+    if (parameters.stores) {
+        return parameters.stores;
+    }
+    return modelHelper.getStoresWithInventory();
 }
 
 /**
@@ -385,8 +407,8 @@ var aggregatedValueHandlers = {
         }
         return pricebooks;
     },
-    in_stock: function (product) {
-        return productFilter.isInStock(product, ALGOLIA_IN_STOCK_THRESHOLD);
+    in_stock: function (product, parameters) {
+        return productFilter.isInStock(product, resolveInStockThreshold(parameters));
     },
     image_groups: function (product, parameters) {
         var imageGroupsArr = [];
@@ -465,6 +487,8 @@ var aggregatedValueHandlers = {
     },
     variants: function(product, parameters) { // only called when record model is either MASTER_LEVEL or VARIATION_GROUP_LEVEL
         const variants = [];
+        const inStockThreshold = resolveInStockThreshold(parameters);
+        const indexOutOfStock = resolveIndexOutOfStock(parameters);
 
         if (product.isMaster() || product.isVariationGroup()) {
             let variantsIt;
@@ -482,8 +506,8 @@ var aggregatedValueHandlers = {
                     continue;
                 }
 
-                let inStock = productFilter.isInStock(variant, ALGOLIA_IN_STOCK_THRESHOLD);
-                if (!inStock && !INDEX_OUT_OF_STOCK) {
+                let inStock = productFilter.isInStock(variant, inStockThreshold);
+                if (!inStock && !indexOutOfStock) {
                     continue;
                 }
 
@@ -496,6 +520,8 @@ var aggregatedValueHandlers = {
                     attributeList: parameters.variantAttributes,
                     isVariant: true,
                     baseModel: baseModel,
+                    sitePreferences: parameters.sitePreferences,
+                    stores: parameters.stores,
                 });
                 variants.push(localizedVariant);
             }
@@ -508,6 +534,8 @@ var aggregatedValueHandlers = {
                 locale: request.getLocale(),
                 attributeList: parameters.variantAttributes,
                 isVariant: true, // otherwise the variant object will have an 'objectID'
+                sitePreferences: parameters.sitePreferences,
+                stores: parameters.stores,
             });
             variants.push(localizedVariant);
 
@@ -517,15 +545,17 @@ var aggregatedValueHandlers = {
     _tags: function(product) {
         return ['id:' + product.getID()];
     },
-    storeAvailability: function(product) {
+    storeAvailability: function(product, parameters) {
         var storeArray = [];
+        var stores = resolveStores(parameters);
+        var inStockThreshold = resolveInStockThreshold(parameters);
         if (stores.length > 0) {
             for (var i = 0; i < stores.length; i++) {
                 var storeEl = stores[i];
                 var storeElInventory = storeEl.storeInventory;
                 if (storeElInventory) {
                     var inventoryRecord = storeElInventory.getRecord(product.ID);
-                    if (inventoryRecord && inventoryRecord.ATS.value && inventoryRecord.ATS.value >= ALGOLIA_IN_STOCK_THRESHOLD && inventoryRecord.ATS.value > 0) { // comparing to zero explicitly so that a threshold of 0 wouldn't return true
+                    if (inventoryRecord && inventoryRecord.ATS.value && inventoryRecord.ATS.value >= inStockThreshold && inventoryRecord.ATS.value > 0) { // comparing to zero explicitly so that a threshold of 0 wouldn't return true
                         storeArray.push(storeEl.id);
                     }
                 }
@@ -539,7 +569,8 @@ var aggregatedValueHandlers = {
 }
 
 /**
- * AlgoliaLocalizedProduct class that represents a localized algoliaProduct ready to be indexed
+ * Represents a localized algoliaProduct ready to be indexed.
+ * @class
  * @param {Object} parameters - model parameters
  * @param {dw.catalog.Product} parameters.product - Product
  * @param {string} parameters.locale - The requested locale
@@ -550,6 +581,10 @@ var aggregatedValueHandlers = {
  * @param {boolean?} [parameters.isVariant] -  Indicates if the model is meant to live in a parent record
  * @param {Object?} [parameters.variationModel] - variationModel of a master
  * @param {string?} [parameters.variationValueID] - variationValueID to append to the objectID
+ * @param {Object?} [parameters.sitePreferences] - site preferences, keyed by preference ID. Falls back to algoliaData when omitted.
+ * @param {number?} [parameters.sitePreferences.InStockThreshold] - minimum ATS for a product to count as in stock
+ * @param {boolean?} [parameters.sitePreferences.IndexOutOfStock] - whether out-of-stock products should be indexed
+ * @param {Array?} [parameters.stores] - stores with their inventory list, used for `storeAvailability`. Built once at the job/hook level. Falls back to modelHelper.getStoresWithInventory() when omitted.
  * @constructor
  */
 function algoliaLocalizedProduct(parameters) {
@@ -618,18 +653,5 @@ function algoliaLocalizedProduct(parameters) {
         }
     }
 }
-
-// For testing - static methods on constructor
-algoliaLocalizedProduct.__setThreshold = function(threshold) {
-    ALGOLIA_IN_STOCK_THRESHOLD = threshold;
-};
-
-algoliaLocalizedProduct.__setIndexOutOfStock = function(indexOutOfStock) {
-    INDEX_OUT_OF_STOCK = indexOutOfStock;
-};
-
-algoliaLocalizedProduct.__setAttributeList = function(attributeList) {
-    ATTRIBUTE_LIST = attributeList;
-};
 
 module.exports = algoliaLocalizedProduct;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -575,7 +575,6 @@ var aggregatedValueHandlers = {
 
 /**
  * Represents a localized algoliaProduct ready to be indexed.
- * @class
  * @param {Object} parameters - model parameters
  * @param {dw.catalog.Product} parameters.product - Product
  * @param {string} parameters.locale - The requested locale

--- a/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct.js
@@ -6,7 +6,6 @@ var PriceBookMgr = require('dw/catalog/PriceBookMgr');
 var PromotionMgr = require('dw/campaign/PromotionMgr');
 var URLUtils = require('dw/web/URLUtils');
 var modelHelper = require('*/cartridge/scripts/algolia/helper/modelHelper');
-var algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
 var algoliaProductConfig = require('*/cartridge/scripts/algolia/lib/algoliaProductConfig');
 var productModelCustomizer = require('*/cartridge/scripts/algolia/customization/productModelCustomizer');
 var ObjectHelper = require('*/cartridge/scripts/algolia/helper/objectHelper');
@@ -26,41 +25,6 @@ try {
     extendedProductRecordCustomizer = require('*/cartridge/configuration/productRecordCustomizer.js');
     logger.info('Extension file "productRecordCustomizer.js" loaded');
 } catch (e) { // eslint-disable-line no-unused-vars
-}
-
-/**
- * Resolve the in-stock threshold for this construction.
- * Prefers the value injected by the caller (`parameters.sitePreferences.InStockThreshold`) and falls back to the
- * site preference when it is not supplied, so callers that do not inject still behave as before.
- * The value is resolved once per construction and cached on the `parameters` object, so the in_stock, variants and
- * storeAvailability handlers reuse it instead of re-reading the preference. The cache is per-construction, not
- * module-level, which is what keeps successive constructions testable with different preference values.
- * @param {Object} parameters - the constructor parameters
- * @returns {number} the in-stock threshold
- */
-function resolveInStockThreshold(parameters) {
-    if (parameters.resolvedInStockThreshold === undefined) {
-        const sitePreferences = parameters.sitePreferences;
-        parameters.resolvedInStockThreshold = (!empty(sitePreferences) && !empty(sitePreferences.InStockThreshold))
-            ? sitePreferences.InStockThreshold
-            : (algoliaData.getPreference('InStockThreshold') || 1);
-    }
-    return parameters.resolvedInStockThreshold;
-}
-
-/**
- * Resolve the "index out of stock" flag for this model.
- * Prefers the value injected by the caller (`parameters.sitePreferences.IndexOutOfStock`) and falls back to the
- * site preference when it is not supplied.
- * @param {Object} parameters - the constructor parameters
- * @returns {boolean} whether out-of-stock products should be indexed
- */
-function resolveIndexOutOfStock(parameters) {
-    const sitePreferences = parameters.sitePreferences;
-    if (!empty(sitePreferences) && !empty(sitePreferences.IndexOutOfStock)) {
-        return sitePreferences.IndexOutOfStock;
-    }
-    return algoliaData.getPreference('IndexOutOfStock');
 }
 
 /**
@@ -413,7 +377,7 @@ var aggregatedValueHandlers = {
         return pricebooks;
     },
     in_stock: function (product, parameters) {
-        return productFilter.isInStock(product, resolveInStockThreshold(parameters));
+        return productFilter.isInStock(product, parameters.sitePreferences.InStockThreshold);
     },
     image_groups: function (product, parameters) {
         var imageGroupsArr = [];
@@ -492,8 +456,8 @@ var aggregatedValueHandlers = {
     },
     variants: function(product, parameters) { // only called when record model is either MASTER_LEVEL or VARIATION_GROUP_LEVEL
         const variants = [];
-        const inStockThreshold = resolveInStockThreshold(parameters);
-        const indexOutOfStock = resolveIndexOutOfStock(parameters);
+        const inStockThreshold = parameters.sitePreferences.InStockThreshold;
+        const indexOutOfStock = parameters.sitePreferences.IndexOutOfStock;
 
         if (product.isMaster() || product.isVariationGroup()) {
             let variantsIt;
@@ -552,7 +516,7 @@ var aggregatedValueHandlers = {
     },
     storeAvailability: function(product, parameters) {
         const stores = resolveStores(parameters);
-        const inStockThreshold = resolveInStockThreshold(parameters);
+        const inStockThreshold = parameters.sitePreferences.InStockThreshold;
         var storeArray = [];
         if (stores.length > 0) {
             for (var i = 0; i < stores.length; i++) {
@@ -585,9 +549,9 @@ var aggregatedValueHandlers = {
  * @param {boolean?} [parameters.isVariant] -  Indicates if the model is meant to live in a parent record
  * @param {Object?} [parameters.variationModel] - variationModel of a master
  * @param {string?} [parameters.variationValueID] - variationValueID to append to the objectID
- * @param {Object?} [parameters.sitePreferences] - site preferences, keyed by preference ID. Falls back to algoliaData when omitted.
- * @param {number?} [parameters.sitePreferences.InStockThreshold] - minimum ATS for a product to count as in stock
- * @param {boolean?} [parameters.sitePreferences.IndexOutOfStock] - whether out-of-stock products should be indexed
+ * @param {Object} [parameters.sitePreferences] - stock-related preferences resolved once by the caller (job or order hook); required when the attribute list contains in_stock, variants or storeAvailability
+ * @param {number} [parameters.sitePreferences.InStockThreshold] - minimum ATS for a product to count as in stock; required for in_stock, variants and storeAvailability
+ * @param {boolean} [parameters.sitePreferences.IndexOutOfStock] - whether out-of-stock products should be indexed; required for variants
  * @param {Array?} [parameters.stores] - stores with their inventory list, used for `storeAvailability`. Built once at the job/hook level. Falls back to modelHelper.getStoresWithInventory() when omitted.
  * @constructor
  */
@@ -595,6 +559,20 @@ function algoliaLocalizedProduct(parameters) {
     const product = parameters.product;
     const attributeList = parameters.attributeList || [];
     const baseModel = parameters.baseModel;
+
+    // in_stock, variants and storeAvailability are derived from the InStockThreshold and IndexOutOfStock site
+    // preferences, which the indexing jobs and the order hook resolve once and pass in. Validate them up front so a
+    // caller that requests those attributes without supplying the preferences fails before any record is built.
+    const indexVariants = attributeList.indexOf('variants') !== -1;
+    if (indexVariants || attributeList.indexOf('in_stock') !== -1 || attributeList.indexOf('storeAvailability') !== -1) {
+        const sitePreferences = parameters.sitePreferences;
+        if (empty(sitePreferences) || !('InStockThreshold' in sitePreferences)) {
+            throw new Error('AlgoliaLocalizedProduct: sitePreferences.InStockThreshold must be provided by the caller (indexing job or order hook) when indexing in_stock, variants or storeAvailability.');
+        }
+        if (indexVariants && !('IndexOutOfStock' in sitePreferences)) {
+            throw new Error('AlgoliaLocalizedProduct: sitePreferences.IndexOutOfStock must be provided by the caller (indexing job or order hook) when indexing variants.');
+        }
+    }
 
     request.setLocale(parameters.locale || 'default');
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -12,7 +12,7 @@ var recordModel;
 
 // Algolia requires
 var algoliaData, AlgoliaLocalizedProduct, algoliaProductConfig, algoliaIndexingAPI, productFilter, CPObjectIterator, AlgoliaJobReport;
-var fileHelper, jobHelper, requestHelper;
+var fileHelper, jobHelper, requestHelper, modelHelper;
 
 // logging-related variables and constants
 var jobReport;
@@ -43,6 +43,9 @@ var INDEX_OUT_OF_STOCK;
 var variationAttributeForAttributeSlicedRecordModel; // e.g. "color"
 var indexingAPI;
 var analyticsRegion;
+
+var sitePreferences;
+var stores = [];
 
 /*
  * Rough algorithm of chunk-oriented script module execution:
@@ -82,10 +85,15 @@ exports.beforeStep = function(parameters, stepExecution) {
 
     CPObjectIterator = require('*/cartridge/scripts/algolia/helper/CPObjectIterator');
     AlgoliaJobReport = require('*/cartridge/scripts/algolia/helper/AlgoliaJobReport');
+    modelHelper = require('*/cartridge/scripts/algolia/helper/modelHelper');
 
     // Algolia preferences
     ALGOLIA_IN_STOCK_THRESHOLD = algoliaData.getPreference('InStockThreshold') || 1;
     INDEX_OUT_OF_STOCK = algoliaData.getPreference('IndexOutOfStock');
+    sitePreferences = {
+        InStockThreshold: ALGOLIA_IN_STOCK_THRESHOLD,
+        IndexOutOfStock: INDEX_OUT_OF_STOCK,
+    };
     recordModel = algoliaData.getPreference('RecordModel'); // 'variant-level' || 'master-level' || 'attribute-sliced'
     variationAttributeForAttributeSlicedRecordModel = algoliaData.getPreference('AttributeSlicedRecordModel_GroupingAttribute');
     indexingAPI = algoliaData.getPreference('IndexingAPI') || INDEXING_APIS.SEARCH_API; // "search-api" (default) or "ingestion-api"
@@ -155,6 +163,11 @@ exports.beforeStep = function(parameters, stepExecution) {
     }
     logger.info('attributeListOverride parameter: ' + paramAttributeListOverride);
     logger.info('Actual attributes to be sent: ' + JSON.stringify(attributesToSend));
+
+    // Build the store-inventory list once (only when storeAvailability is indexed), to pass to each AlgoliaLocalizedProduct
+    if (attributesToSend.indexOf('storeAvailability') !== -1) {
+        stores = modelHelper.getStoresWithInventory();
+    }
 
 
     /* --- indexingMethod parameter --- */
@@ -383,7 +396,13 @@ exports.process = function(cpObj, parameters, stepExecution) {
                     productFilter.isOnline(product) &&
                     productFilter.isSearchable(product) &&
                     productFilter.hasOnlineCategory(product)) {
-                    let baseModel = new AlgoliaLocalizedProduct({ product: product, locale: 'default', attributeList: nonLocalizedMasterAttributes });
+                    let baseModel = new AlgoliaLocalizedProduct({
+                        product: product,
+                        locale: 'default',
+                        attributeList: nonLocalizedMasterAttributes,
+                        sitePreferences: sitePreferences,
+                        stores: stores,
+                    });
                     for (let l = 0; l < siteLocales.size(); ++l) {
                         let locale = siteLocales.get(l);
                         let indexName = algoliaData.calculateIndexName('products', locale);
@@ -393,6 +412,8 @@ exports.process = function(cpObj, parameters, stepExecution) {
                             attributeList: masterAttributes,
                             variantAttributes: variantAttributes,
                             baseModel: baseModel,
+                            sitePreferences: sitePreferences,
+                            stores: stores,
                         });
                         processedVariantsToSend = localizedMaster.variants ? localizedMaster.variants.length : 0;
                         algoliaOperations.push(new jobHelper.AlgoliaOperation(baseIndexingOperation, localizedMaster, indexName));
@@ -431,7 +452,13 @@ exports.process = function(cpObj, parameters, stepExecution) {
                         productFilter.isOnline(product) &&
                         productFilter.isSearchable(product) &&
                         productFilter.hasOnlineCategory(product)) {
-                        let baseModel = new AlgoliaLocalizedProduct({ product: product, locale: 'default', attributeList: nonLocalizedMasterAttributes });
+                        let baseModel = new AlgoliaLocalizedProduct({
+                            product: product,
+                            locale: 'default',
+                            attributeList: nonLocalizedMasterAttributes,
+                            sitePreferences: sitePreferences,
+                            stores: stores,
+                        });
                         for (let l = 0; l < siteLocales.size(); ++l) {
                             let locale = siteLocales.get(l);
                             let indexName = algoliaData.calculateIndexName('products', locale);
@@ -441,6 +468,8 @@ exports.process = function(cpObj, parameters, stepExecution) {
                                 attributeList: masterAttributes,
                                 variantAttributes: variantAttributes,
                                 baseModel: baseModel,
+                                sitePreferences: sitePreferences,
+                                stores: stores,
                             });
                             processedVariantsToSend = localizedMaster.variants ? localizedMaster.variants.length : 0;
                             algoliaOperations.push(new jobHelper.AlgoliaOperation(baseIndexingOperation, localizedMaster, indexName));
@@ -469,6 +498,8 @@ exports.process = function(cpObj, parameters, stepExecution) {
                     nonLocalizedAttributes: nonLocalizedAttributes,
                     attributesComputedFromBaseProduct: attributesComputedFromBaseProduct,
                     variationAttributeID: variationAttributeForAttributeSlicedRecordModel,
+                    sitePreferences: sitePreferences,
+                    stores: stores,
                 });
 
                 for (let l = 0; l < siteLocales.size(); ++l) {
@@ -511,6 +542,8 @@ exports.process = function(cpObj, parameters, stepExecution) {
                 nonLocalizedAttributes: nonLocalizedAttributes,
                 attributesComputedFromBaseProduct: attributesComputedFromBaseProduct,
                 fullRecordUpdate: fullRecordUpdate,
+                sitePreferences: sitePreferences,
+                stores: stores,
             });
 
             for (let l = 0; l < siteLocales.size(); ++l) {
@@ -554,7 +587,9 @@ exports.process = function(cpObj, parameters, stepExecution) {
                 product: product,
                 locale: 'default',
                 attributeList: nonLocalizedAttributes,
-                fullRecordUpdate: fullRecordUpdate
+                fullRecordUpdate: fullRecordUpdate,
+                sitePreferences: sitePreferences,
+                stores: stores,
             });
 
             for (let l = 0; l < siteLocales.size(); l++) {
@@ -571,7 +606,9 @@ exports.process = function(cpObj, parameters, stepExecution) {
                         locale: locale,
                         attributeList: attributesToSend,
                         baseModel: baseModel,
-                        fullRecordUpdate: fullRecordUpdate
+                        fullRecordUpdate: fullRecordUpdate,
+                        sitePreferences: sitePreferences,
+                        stores: stores,
                     });
 
                 } else {
@@ -583,6 +620,8 @@ exports.process = function(cpObj, parameters, stepExecution) {
                         variantAttributes: variantAttributes,
                         baseModel: baseModel,
                         fullRecordUpdate: fullRecordUpdate,
+                        sitePreferences: sitePreferences,
+                        stores: stores,
                     });
                 }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -35,7 +35,6 @@ var variationAttributeForAttributeSlicedRecordModel // e.g. "color"
 var indexingAPI;
 var analyticsRegion;
 
-// Stock-related inputs passed to each AlgoliaLocalizedProduct, built once in beforeStep
 var sitePreferences;
 var stores = [];
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -11,7 +11,7 @@ var recordModel;
 
 // Algolia requires
 var algoliaData, AlgoliaLocalizedProduct, algoliaProductConfig, algoliaIndexingAPI, productFilter, AlgoliaJobReport;
-var jobHelper, reindexHelper, requestHelper;
+var jobHelper, reindexHelper, requestHelper, modelHelper;
 var indexingOperation;
 var fullRecordUpdate = false;
 
@@ -34,6 +34,10 @@ var INDEX_OUT_OF_STOCK;
 var variationAttributeForAttributeSlicedRecordModel // e.g. "color"
 var indexingAPI;
 var analyticsRegion;
+
+// Stock-related inputs passed to each AlgoliaLocalizedProduct, built once in beforeStep
+var sitePreferences;
+var stores = [];
 
 /*
  * Rough algorithm of chunk-oriented script module execution:
@@ -71,10 +75,15 @@ exports.beforeStep = function(parameters, stepExecution) {
     productFilter = require('*/cartridge/scripts/algolia/filters/productFilter');
     algoliaProductConfig = require('*/cartridge/scripts/algolia/lib/algoliaProductConfig');
     AlgoliaJobReport = require('*/cartridge/scripts/algolia/helper/AlgoliaJobReport');
+    modelHelper = require('*/cartridge/scripts/algolia/helper/modelHelper');
 
     // Algolia preferences
     ALGOLIA_IN_STOCK_THRESHOLD = algoliaData.getPreference('InStockThreshold') || 1;
     INDEX_OUT_OF_STOCK = algoliaData.getPreference('IndexOutOfStock');
+    sitePreferences = {
+        InStockThreshold: ALGOLIA_IN_STOCK_THRESHOLD,
+        IndexOutOfStock: INDEX_OUT_OF_STOCK,
+    };
     recordModel = algoliaData.getPreference('RecordModel'); // 'variant-level' || 'master-level' || 'attribute-sliced'
     variationAttributeForAttributeSlicedRecordModel = algoliaData.getPreference('AttributeSlicedRecordModel_GroupingAttribute');
     indexingAPI = algoliaData.getPreference('IndexingAPI') || INDEXING_APIS.SEARCH_API; // "search-api" (default) or "ingestion-api"
@@ -147,6 +156,11 @@ exports.beforeStep = function(parameters, stepExecution) {
 
     logger.info('attributeListOverride parameter: ' + paramAttributeListOverride);
     logger.info('Actual attributes to be sent: ' + JSON.stringify(attributesToSend));
+
+    // Build the store-inventory list once (only when storeAvailability is indexed), to pass to each AlgoliaLocalizedProduct
+    if (attributesToSend.indexOf('storeAvailability') !== -1) {
+        stores = modelHelper.getStoresWithInventory();
+    }
 
 
     /* --- indexingMethod parameter --- */
@@ -304,7 +318,13 @@ exports.process = function(product, parameters, stepExecution) {
             }
 
             // Master-level indexing
-            let baseModel = new AlgoliaLocalizedProduct({ product: product, locale: 'default', attributeList: nonLocalizedMasterAttributes });
+            let baseModel = new AlgoliaLocalizedProduct({
+                product: product,
+                locale: 'default',
+                attributeList: nonLocalizedMasterAttributes,
+                sitePreferences: sitePreferences,
+                stores: stores,
+            });
             for (let l = 0; l < siteLocales.size(); ++l) {
                 let locale = siteLocales.get(l);
                 let indexName = algoliaData.calculateIndexName('products', locale);
@@ -318,6 +338,8 @@ exports.process = function(product, parameters, stepExecution) {
                     attributeList: masterAttributes,
                     variantAttributes: variantAttributes,
                     baseModel: baseModel,
+                    sitePreferences: sitePreferences,
+                    stores: stores,
                 });
 
                 if (!INDEX_OUT_OF_STOCK && (localizedMaster && localizedMaster.variants && (localizedMaster.variants.length === 0))) {
@@ -349,7 +371,13 @@ exports.process = function(product, parameters, stepExecution) {
             if (!variationAttribute) {
                 logger.info('Specified variation attribute "' + variationAttributeForAttributeSlicedRecordModel + '" not found for master product "' + product.getID() + '", falling back to master-type record.');
 
-                let baseModel = new AlgoliaLocalizedProduct({ product: product, locale: 'default', attributeList: nonLocalizedMasterAttributes });
+                let baseModel = new AlgoliaLocalizedProduct({
+                    product: product,
+                    locale: 'default',
+                    attributeList: nonLocalizedMasterAttributes,
+                    sitePreferences: sitePreferences,
+                    stores: stores,
+                });
                 for (let l = 0; l < siteLocales.size(); ++l) {
                     let locale = siteLocales.get(l);
                     let indexName = algoliaData.calculateIndexName('products', locale);
@@ -362,6 +390,8 @@ exports.process = function(product, parameters, stepExecution) {
                         attributeList: masterAttributes,
                         variantAttributes: variantAttributes,
                         baseModel: baseModel,
+                        sitePreferences: sitePreferences,
+                        stores: stores,
                     });
 
                     if (!INDEX_OUT_OF_STOCK && (localizedMaster && localizedMaster.variants && (localizedMaster.variants.length === 0))) {
@@ -386,6 +416,8 @@ exports.process = function(product, parameters, stepExecution) {
                 nonLocalizedAttributes: nonLocalizedAttributes,
                 attributesComputedFromBaseProduct: attributesComputedFromBaseProduct,
                 variationAttributeID: variationAttributeForAttributeSlicedRecordModel,
+                sitePreferences: sitePreferences,
+                stores: stores,
             });
 
             for (let l = 0; l < siteLocales.size(); ++l) {
@@ -428,6 +460,8 @@ exports.process = function(product, parameters, stepExecution) {
                 nonLocalizedAttributes: nonLocalizedAttributes,
                 attributesComputedFromBaseProduct: attributesComputedFromBaseProduct,
                 fullRecordUpdate: fullRecordUpdate,
+                sitePreferences: sitePreferences,
+                stores: stores,
             });
 
             for (let l = 0; l < siteLocales.size(); ++l) {
@@ -469,6 +503,8 @@ exports.process = function(product, parameters, stepExecution) {
             locale: 'default',
             attributeList: nonLocalizedAttributes,
             fullRecordUpdate: fullRecordUpdate,
+            sitePreferences: sitePreferences,
+            stores: stores,
         });
 
         for (let l = 0; l < siteLocales.size(); ++l) {
@@ -489,6 +525,8 @@ exports.process = function(product, parameters, stepExecution) {
                     attributeList: attributesToSend,
                     baseModel: baseModel,
                     fullRecordUpdate: fullRecordUpdate,
+                    sitePreferences: sitePreferences,
+                    stores: stores,
                 });
 
             } else {
@@ -500,6 +538,8 @@ exports.process = function(product, parameters, stepExecution) {
                     variantAttributes: variantAttributes,
                     baseModel: baseModel,
                     fullRecordUpdate: fullRecordUpdate,
+                    sitePreferences: sitePreferences,
+                    stores: stores,
                 });
             }
 

--- a/cartridges/int_algolia_sfra/cartridge/scripts/hooks/order/algoliaHooks.js
+++ b/cartridges/int_algolia_sfra/cartridge/scripts/hooks/order/algoliaHooks.js
@@ -215,14 +215,14 @@ exports.inventoryUpdate = function (order) {
 function handleInStorePickupShipment(shipment, sitePreferences, stores, additionalAttributes, recordModel) {
     let algoliaOperations = [];
     let plis = shipment.getProductLineItems();
-    let threshold = sitePreferences.InStockThreshold;
+    let InStockThreshold = sitePreferences.InStockThreshold;
 
     for (let j = 0; j < plis.length; j++) {
         let pli = plis[j];
         let product = pli.getProduct();
         let storeId = shipment.custom.fromStoreId;
 
-        let inStoreStock = isInStoreStock(product, storeId, threshold);
+        let inStoreStock = isInStoreStock(product, storeId, InStockThreshold);
         if (!inStoreStock && additionalAttributes.indexOf('storeAvailability') > -1) {
 
             switch (recordModel) {
@@ -264,14 +264,14 @@ function handleInStorePickupShipment(shipment, sitePreferences, stores, addition
 function handleStandardShipment(shipment, sitePreferences, stores, additionalAttributes, recordModel) {
     let algoliaOperations = [];
     let plis = shipment.getProductLineItems();
-    let threshold = sitePreferences.InStockThreshold;
+    let InStockThreshold = sitePreferences.InStockThreshold;
     let indexOutOfStock = sitePreferences.IndexOutOfStock;
 
     for (let j = 0; j < plis.length; j++) {
         let pli = plis[j];
         let product = pli.getProduct(); // product can only be a Variant or a simple product
 
-        let isInStock = productFilter.isInStock(product, threshold);
+        let isInStock = productFilter.isInStock(product, InStockThreshold);
         if (!isInStock) {
 
             if (indexOutOfStock) {
@@ -315,7 +315,7 @@ function handleStandardShipment(shipment, sitePreferences, stores, additionalAtt
 
                             if (!empty(productConfig.variationModel)) { // variation group
 
-                                let isGroupInStock = productFilter.isCustomVariationGroupInStock(productConfig.variationModel, threshold);
+                                let isGroupInStock = productFilter.isCustomVariationGroupInStock(productConfig.variationModel, InStockThreshold);
                                 if (!isGroupInStock) {
                                     productOps.forEach(function(productOp) {
                                         algoliaOperations = algoliaOperations.concat(
@@ -330,7 +330,7 @@ function handleStandardShipment(shipment, sitePreferences, stores, additionalAtt
                                     algoliaOperations = algoliaOperations.concat(productOps);
                                 }
                             } else { // regular master
-                                let isMasterInStock = productFilter.isInStock(product.getMasterProduct(), threshold);
+                                let isMasterInStock = productFilter.isInStock(product.getMasterProduct(), InStockThreshold);
                                 if (!isMasterInStock) {
                                     productOps.forEach(function(productOp) {
                                         algoliaOperations = algoliaOperations.concat(
@@ -363,7 +363,7 @@ function handleStandardShipment(shipment, sitePreferences, stores, additionalAtt
 
                     case RECORD_MODEL_TYPES.MASTER_LEVEL: {
                         if (productConfig.product.isMaster()) { // master
-                            let isMasterInStock = productFilter.isInStock(product.getMasterProduct(), threshold);
+                            let isMasterInStock = productFilter.isInStock(product.getMasterProduct(), InStockThreshold);
                             if (!isMasterInStock) {
                                 productOps.forEach(function(productOp) {
                                     algoliaOperations = algoliaOperations.concat(

--- a/cartridges/int_algolia_sfra/cartridge/scripts/hooks/order/algoliaHooks.js
+++ b/cartridges/int_algolia_sfra/cartridge/scripts/hooks/order/algoliaHooks.js
@@ -9,6 +9,7 @@ let requestHelper = require('*/cartridge/scripts/algolia/helper/requestHelper');
 let algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
 let productFilter = require('*/cartridge/scripts/algolia/filters/productFilter');
 let AlgoliaLocalizedProduct = require('*/cartridge/scripts/algolia/model/algoliaLocalizedProduct');
+let modelHelper = require('*/cartridge/scripts/algolia/helper/modelHelper');
 
 let orderHelper = require('*/cartridge/scripts/algolia/helper/orderHelper');
 let isInStoreStock = productFilter.isInStoreStock;
@@ -22,11 +23,15 @@ const { INDEXING_APIS, RECORD_MODEL_TYPES } = require('*/cartridge/scripts/algol
  * @param {dw.catalog.Product | dw.catalog.Variant} product - The product to create config for.
  * @param {string} recordModel - The type of record model.
  * @param {Array} additionalAttributes - User-defined attributes to index.
+ * @param {Object} sitePreferences - site preferences forwarded to AlgoliaLocalizedProduct.
+ * @param {Array} stores - Stores with their inventory list forwarded to AlgoliaLocalizedProduct (for storeAvailability).
  * @returns {Object} Configuration object to pass to generateAlgoliaOperations.
  */
-function createProductConfig(product, recordModel, additionalAttributes) {
+function createProductConfig(product, recordModel, additionalAttributes, sitePreferences, stores) {
     let attributesConfig = jobHelper.getAttributes(additionalAttributes);
     let productConfig = {};
+    productConfig.sitePreferences = sitePreferences;
+    productConfig.stores = stores;
 
     let variationAttributeForAttributeSlicedRecordModel = algoliaData.getPreference('AttributeSlicedRecordModel_GroupingAttribute');
     let productVariationModel = product.getVariationModel();
@@ -44,6 +49,8 @@ function createProductConfig(product, recordModel, additionalAttributes) {
                     product: masterProduct,
                     locale: 'default',
                     attributeList: attributesConfig.nonLocalizedMasterAttributes,
+                    sitePreferences: sitePreferences,
+                    stores: stores,
                 });
 
                 if (recordModel === RECORD_MODEL_TYPES.ATTRIBUTE_SLICED && !empty(variationAttribute)) {
@@ -68,6 +75,8 @@ function createProductConfig(product, recordModel, additionalAttributes) {
                     locale: 'default',
                     attributeList: attributesConfig.masterAttributes,
                     variantAttributes: attributesConfig.variantAttributes,
+                    sitePreferences: sitePreferences,
+                    stores: stores,
                 });
                 productConfig.product = product;
 
@@ -79,6 +88,8 @@ function createProductConfig(product, recordModel, additionalAttributes) {
                 product: product,
                 locale: 'default',
                 attributeList: attributesConfig.variantAttributes,
+                sitePreferences: sitePreferences,
+                stores: stores,
             });
             productConfig.product = product;
             break;
@@ -111,8 +122,16 @@ exports.inventoryUpdate = function (order) {
     });
 
     let ALGOLIA_IN_STOCK_THRESHOLD = algoliaData.getPreference('InStockThreshold') || 1;
+    let INDEX_OUT_OF_STOCK = algoliaData.getPreference('IndexOutOfStock');
     let RECORD_MODEL = algoliaData.getPreference('RecordModel');
     let additionalAttributes = algoliaData.getSetOfArray('AdditionalAttributes');
+
+    // Stock-related inputs built once per order and passed to each AlgoliaLocalizedProduct
+    let sitePreferences = {
+        InStockThreshold: ALGOLIA_IN_STOCK_THRESHOLD,
+        IndexOutOfStock: INDEX_OUT_OF_STOCK,
+    };
+    let stores = (additionalAttributes.indexOf('storeAvailability') !== -1) ? modelHelper.getStoresWithInventory() : [];
 
     try {
         let algoliaOperations = [];
@@ -125,7 +144,8 @@ exports.inventoryUpdate = function (order) {
                 algoliaOperations = algoliaOperations.concat(
                     handleInStorePickupShipment(
                         shipment,
-                        ALGOLIA_IN_STOCK_THRESHOLD,
+                        sitePreferences,
+                        stores,
                         additionalAttributes,
                         RECORD_MODEL
                     )
@@ -134,7 +154,8 @@ exports.inventoryUpdate = function (order) {
                 algoliaOperations = algoliaOperations.concat(
                     handleStandardShipment(
                         shipment,
-                        ALGOLIA_IN_STOCK_THRESHOLD,
+                        sitePreferences,
+                        stores,
                         additionalAttributes,
                         RECORD_MODEL
                     )
@@ -185,14 +206,16 @@ exports.inventoryUpdate = function (order) {
  * Handles logic for updating Algolia records for an in-store pickup shipment.
  *
  * @param {dw.order.Shipment} shipment - The shipment object to process.
- * @param {number} threshold - The in-stock threshold preference.
+ * @param {Object} sitePreferences - Site preferences
+ * @param {Array} stores - Stores with their inventory list forwarded to AlgoliaLocalizedProduct (for storeAvailability).
  * @param {Array} additionalAttributes - A list of additional attributes to manage.
  * @param {string} recordModel - The type of record model (master-level or variant-level).
  * @returns {Array} An array of Algolia operations to be executed.
  */
-function handleInStorePickupShipment(shipment, threshold, additionalAttributes, recordModel) {
+function handleInStorePickupShipment(shipment, sitePreferences, stores, additionalAttributes, recordModel) {
     let algoliaOperations = [];
     let plis = shipment.getProductLineItems();
+    let threshold = sitePreferences.InStockThreshold;
 
     for (let j = 0; j < plis.length; j++) {
         let pli = plis[j];
@@ -206,7 +229,7 @@ function handleInStorePickupShipment(shipment, threshold, additionalAttributes, 
 
                 case RECORD_MODEL_TYPES.ATTRIBUTE_SLICED:
                 case RECORD_MODEL_TYPES.MASTER_LEVEL: {
-                    let productConfig = createProductConfig(product, recordModel, additionalAttributes);
+                    let productConfig = createProductConfig(product, recordModel, additionalAttributes, sitePreferences, stores);
                     productConfig.attributeList = ['variants'];
 
                     let productOps = generateAlgoliaOperations(productConfig);
@@ -214,7 +237,7 @@ function handleInStorePickupShipment(shipment, threshold, additionalAttributes, 
                     break;
                 }
                 case RECORD_MODEL_TYPES.VARIANT_LEVEL: {
-                    let productConfig = createProductConfig(product, recordModel, additionalAttributes);
+                    let productConfig = createProductConfig(product, recordModel, additionalAttributes, sitePreferences, stores);
                     productConfig.attributeList = ['storeAvailability'];
 
                     let productOps = generateAlgoliaOperations(productConfig);
@@ -232,15 +255,17 @@ function handleInStorePickupShipment(shipment, threshold, additionalAttributes, 
  * Handles logic for updating Algolia records for a standard shipment.
  *
  * @param {dw.order.Shipment} shipment - The shipment object to process.
- * @param {number} threshold - The in-stock threshold preference.
+ * @param {Object} sitePreferences - Site preferences
+ * @param {Array} stores - Stores with their inventory list forwarded to AlgoliaLocalizedProduct (for storeAvailability).
  * @param {Array} additionalAttributes - A list of additional attributes to manage.
  * @param {string} recordModel - The type of record model (master-level or variant-level).
  * @returns {Array} An array of Algolia operations to be executed.
  */
-function handleStandardShipment(shipment, threshold, additionalAttributes, recordModel) {
+function handleStandardShipment(shipment, sitePreferences, stores, additionalAttributes, recordModel) {
     let algoliaOperations = [];
     let plis = shipment.getProductLineItems();
-    let indexOutOfStock = algoliaData.getPreference('IndexOutOfStock');
+    let threshold = sitePreferences.InStockThreshold;
+    let indexOutOfStock = sitePreferences.IndexOutOfStock;
 
     for (let j = 0; j < plis.length; j++) {
         let pli = plis[j];
@@ -259,7 +284,7 @@ function handleStandardShipment(shipment, threshold, additionalAttributes, recor
                             attrArray.push('in_stock');
                         }
 
-                        let productConfig = createProductConfig(product, recordModel, additionalAttributes);
+                        let productConfig = createProductConfig(product, recordModel, additionalAttributes, sitePreferences, stores);
                         productConfig.attributeList = attrArray;
 
                         let productOps = generateAlgoliaOperations(productConfig);
@@ -268,7 +293,7 @@ function handleStandardShipment(shipment, threshold, additionalAttributes, recor
                     }
 
                     case RECORD_MODEL_TYPES.VARIANT_LEVEL: {
-                        let productConfig = createProductConfig(product, recordModel, additionalAttributes);
+                        let productConfig = createProductConfig(product, recordModel, additionalAttributes, sitePreferences, stores);
                         productConfig.attributeList = ['in_stock'];
 
                         let productOps = generateAlgoliaOperations(productConfig);
@@ -278,7 +303,7 @@ function handleStandardShipment(shipment, threshold, additionalAttributes, recor
                 }
 
             } else { // Algolia_IndexOutOfStock === false
-                let productConfig = createProductConfig(product, recordModel, additionalAttributes);
+                let productConfig = createProductConfig(product, recordModel, additionalAttributes, sitePreferences, stores);
                 productConfig.attributeList = ['variants'];
 
                 let productOps = generateAlgoliaOperations(productConfig);

--- a/test/unit/int_algolia/scripts/algolia/helper/jobHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/jobHelper.test.js
@@ -40,6 +40,7 @@ describe('Job Helper', function () {
             locales: new ArrayList(['fr']),
             attributeList: ['name', 'categoryPageId', '__primary_category', 'in_stock', 'price', 'url', 'colorVariations'],
             nonLocalizedAttributes: [],
+            sitePreferences: { InStockThreshold: 1, IndexOutOfStock: false },
         });
         expect(variantRecords).toMatchSnapshot();
     });

--- a/test/unit/int_algolia/scripts/algolia/helper/orderHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/orderHelper.test.js
@@ -1,5 +1,13 @@
 'use strict';
 
+// generateAlgoliaOperations builds AlgoliaLocalizedProduct records. When a productConfig requests
+// `storeAvailability` without injecting a `stores` list, the model falls back to scanning all stores
+// via StoreMgr. Mock it as empty so the fallback returns an empty list (matching production, where the
+// order hook injects the list explicitly).
+jest.mock('dw/catalog/StoreMgr', () => ({
+    searchStoresByCoordinates: jest.fn().mockReturnValue({ empty: true })
+}), { virtual: true });
+
 const orderHelper = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/orderHelper');
 const MasterVariantMock = require('../../../../../mocks/dw/catalog/MasterProduct');
 const VariantMock = require('../../../../../mocks/dw/catalog/Variant');

--- a/test/unit/int_algolia/scripts/algolia/helper/orderHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/orderHelper.test.js
@@ -29,7 +29,8 @@ describe('Order Helper', function () {
 
         const productConfig = {
             product: masterProduct,
-            attributeList: ['variants', 'in_stock']
+            attributeList: ['variants', 'in_stock'],
+            sitePreferences: { InStockThreshold: 1, IndexOutOfStock: false }
         };
 
         // Act
@@ -68,7 +69,8 @@ describe('Order Helper', function () {
 
         const productConfig = {
             product: masterProduct,
-            attributeList: ['in_stock']  // Only update the stock status
+            attributeList: ['in_stock'],  // Only update the stock status
+            sitePreferences: { InStockThreshold: 1, IndexOutOfStock: false }
         };
 
         // Act
@@ -104,6 +106,7 @@ describe('Order Helper', function () {
             product: masterProduct,
             attributeList: ['variants'],
             variantAttributes: ['id', 'in_stock', 'storeAvailability'],
+            sitePreferences: { InStockThreshold: 1, IndexOutOfStock: false },
         };
 
         // Act
@@ -124,6 +127,7 @@ describe('Order Helper', function () {
         const productConfig = {
             product: variantProduct,
             attributeList: ['in_stock', 'storeAvailability'],
+            sitePreferences: { InStockThreshold: 1, IndexOutOfStock: false },
         };
 
         // Act

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -243,6 +243,7 @@ describe('algoliaLocalizedProduct', function () {
                 product: product,
                 locale: 'default',
                 attributeList: attributes,
+                sitePreferences: { InStockThreshold: 2 },
             })
         ).toEqual(algoliaProductModel);
     });
@@ -359,6 +360,7 @@ describe('algoliaLocalizedProduct', function () {
                 product: product,
                 locale: 'fr',
                 attributeList: attributes,
+                sitePreferences: { InStockThreshold: 2 },
             })
         ).toEqual(algoliaProductModel);
     });
@@ -559,7 +561,8 @@ describe('storeAvailability Tests', function() {
         const algoliaProduct = new AlgoliaLocalizedProduct({
             product: product,
             locale: 'default',
-            attributeList: ['storeAvailability']
+            attributeList: ['storeAvailability'],
+            sitePreferences: { InStockThreshold: 2 }
         });
 
         expect(algoliaProduct.storeAvailability).toBeDefined();
@@ -577,7 +580,8 @@ describe('storeAvailability Tests', function() {
         const algoliaProduct = new AlgoliaLocalizedProduct({
             product: product,
             locale: 'default',
-            attributeList: ['storeAvailability']
+            attributeList: ['storeAvailability'],
+            sitePreferences: { InStockThreshold: 2 }
         });
 
         expect(algoliaProduct.storeAvailability).toBeDefined();
@@ -594,7 +598,8 @@ describe('storeAvailability Tests', function() {
         const algoliaProduct = new AlgoliaLocalizedProduct({
             product: product,
             locale: 'default',
-            attributeList: ['storeAvailability']
+            attributeList: ['storeAvailability'],
+            sitePreferences: { InStockThreshold: 2 }
         });
 
         expect(algoliaProduct.storeAvailability).toBeDefined();
@@ -610,7 +615,8 @@ describe('storeAvailability Tests', function() {
         const algoliaProduct = new AlgoliaLocalizedProduct({
             product: product,
             locale: 'default',
-            attributeList: ['storeAvailability']
+            attributeList: ['storeAvailability'],
+            sitePreferences: { InStockThreshold: 2 }
         });
 
         expect(algoliaProduct.storeAvailability).toBeDefined();
@@ -626,7 +632,8 @@ describe('storeAvailability Tests', function() {
         const algoliaProduct = new AlgoliaLocalizedProduct({
             product: product,
             locale: 'default',
-            attributeList: ['storeAvailability']
+            attributeList: ['storeAvailability'],
+            sitePreferences: { InStockThreshold: 2 }
         });
 
         expect(algoliaProduct.storeAvailability).toBeDefined();

--- a/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
+++ b/test/unit/int_algolia/scripts/algolia/model/algoliaLocalizedProduct.test.js
@@ -634,3 +634,75 @@ describe('storeAvailability Tests', function() {
         expect(algoliaProduct.storeAvailability.length).toBe(0);
     });
 });
+
+describe('constructor injection of stock preferences', function() {
+    // These tests construct the model several times within a single module load, with different injected
+    // preferences each time; successive constructions can use different values
+    // without reloading the module or relying on test-only setters.
+
+    test('in_stock reflects the injected InStockThreshold', function() {
+        const product = new ProductMock(); // default mock variant has an ATS of 6
+
+        const belowThreshold = new AlgoliaLocalizedProduct({
+            product: product,
+            locale: 'default',
+            attributeList: ['in_stock'],
+            sitePreferences: { InStockThreshold: 7 }
+        });
+
+        const aboveThreshold = new AlgoliaLocalizedProduct({
+            product: product,
+            locale: 'default',
+            attributeList: ['in_stock'],
+            sitePreferences: { InStockThreshold: 5 }
+        });
+
+        expect(belowThreshold.in_stock).toBe(false);
+        expect(aboveThreshold.in_stock).toBe(true);
+    });
+
+    test('storeAvailability reflects the injected InStockThreshold', function() {
+        const product = new ProductMock({ ID: 'product-low-stock' }); // ATS of 1 in store1
+
+        const strictThreshold = new AlgoliaLocalizedProduct({
+            product: product,
+            locale: 'default',
+            attributeList: ['storeAvailability'],
+            sitePreferences: { InStockThreshold: 2 }
+        });
+
+        const lenientThreshold = new AlgoliaLocalizedProduct({
+            product: product,
+            locale: 'default',
+            attributeList: ['storeAvailability'],
+            sitePreferences: { InStockThreshold: 1 }
+        });
+
+        expect(strictThreshold.storeAvailability).toEqual([]);
+        expect(lenientThreshold.storeAvailability).toEqual(['store1']);
+    });
+
+    test('storeAvailability uses the injected stores list instead of scanning all stores', function() {
+        const product = new ProductMock({ ID: 'product-injected' });
+        const injectedStores = [
+            {
+                id: 'injectedStore',
+                storeInventory: {
+                    getRecord: function() {
+                        return { ATS: { value: 5 } };
+                    }
+                }
+            }
+        ];
+
+        const algoliaProduct = new AlgoliaLocalizedProduct({
+            product: product,
+            locale: 'default',
+            attributeList: ['storeAvailability'],
+            sitePreferences: { InStockThreshold: 1 },
+            stores: injectedStores
+        });
+
+        expect(algoliaProduct.storeAvailability).toEqual(['injectedStore']);
+    });
+});

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
@@ -58,7 +58,6 @@ const stepExecution = {
     getStepID: () => 'TestStepID',
 };
 
-const algoliaLocalizedProduct = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct');
 const job = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex');
 
 beforeEach(() => {
@@ -67,6 +66,7 @@ beforeEach(() => {
     mockSendGroupedIngestionAPIRecords.mockReset();
     delete global.customPreferences['Algolia_IndexingAPI'];
     delete global.customPreferences['Algolia_AnalyticsRegion'];
+    delete global.customPreferences['Algolia_InStockThreshold'];
 });
 
 describe('beforeStep', () => {
@@ -151,7 +151,7 @@ describe('process', () => {
     test('attribute-sliced indexing - out of stock', () => {
         global.customPreferences['Algolia_RecordModel'] = 'attribute-sliced';
         mockLocalesForIndexing = ['fr']
-        algoliaLocalizedProduct.__setThreshold(7); // Default mock variant has an ATS of 6
+        global.customPreferences['Algolia_InStockThreshold'] = 7; // Default mock variant has an ATS of 6
         job.beforeStep(parameters, stepExecution);
         expect(mockSetJobInfo).toHaveBeenCalledWith({
             jobID: 'TestJobID',

--- a/test/unit/int_algolia/scripts/hooks/order/algoliaHooks.test.js
+++ b/test/unit/int_algolia/scripts/hooks/order/algoliaHooks.test.js
@@ -24,8 +24,6 @@ let mockConfig = {
     EnableRealTimeInventoryHook: true,
 };
 
-const algoliaLocalizedProduct = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/model/algoliaLocalizedProduct');
-
 jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => ({
     ...jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData'),
     getPreference: jest.fn().mockImplementation((id) => {
@@ -96,11 +94,6 @@ class ShipmentMock {
 
 // Helper function to setup common test data
 function setupTestData() {
-
-    algoliaLocalizedProduct.__setThreshold(mockConfig.InStockThreshold);
-    algoliaLocalizedProduct.__setIndexOutOfStock(mockConfig.IndexOutOfStock);
-    algoliaLocalizedProduct.__setAttributeList(mockConfig.AdditionalAttributes);
-
     const mockMasterProduct = new MasterVariantMock({
         inventoryList: {
             getRecord: jest.fn().mockReturnValue({ ATS: { value: 3 } })
@@ -171,7 +164,8 @@ describe('Algolia Hooks - Out of Stock Tests (InStockThreshold: 10, IndexOutOfSt
         // Act
         const operations = algoliaHooks.handleStandardShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -188,7 +182,8 @@ describe('Algolia Hooks - Out of Stock Tests (InStockThreshold: 10, IndexOutOfSt
 
         const operations = algoliaHooks.handleStandardShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -206,7 +201,8 @@ describe('Algolia Hooks - Out of Stock Tests (InStockThreshold: 10, IndexOutOfSt
         // Act
         const operations = algoliaHooks.handleStandardShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -236,7 +232,8 @@ describe('Algolia Hooks - Out of Stock Tests for BOPIS (InStockThreshold: 5, Ind
         // Act
         const operations = algoliaHooks.handleInStorePickupShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -253,7 +250,8 @@ describe('Algolia Hooks - Out of Stock Tests for BOPIS (InStockThreshold: 5, Ind
 
         const operations = algoliaHooks.handleInStorePickupShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -271,7 +269,8 @@ describe('Algolia Hooks - Out of Stock Tests for BOPIS (InStockThreshold: 5, Ind
         // Act
         const operations = algoliaHooks.handleInStorePickupShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -302,7 +301,8 @@ describe('Algolia Hooks - Out of Stock Tests (InStockThreshold: 10, IndexOutOfSt
         // Act
         const operations = algoliaHooks.handleStandardShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -319,7 +319,8 @@ describe('Algolia Hooks - Out of Stock Tests (InStockThreshold: 10, IndexOutOfSt
 
         const operations = algoliaHooks.handleStandardShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -337,7 +338,8 @@ describe('Algolia Hooks - Out of Stock Tests (InStockThreshold: 10, IndexOutOfSt
         // Act
         const operations = algoliaHooks.handleStandardShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -367,7 +369,8 @@ describe('Algolia Hooks - Out of Stock Tests for BOPIS (InStockThreshold: 5, Ind
         // Act
         const operations = algoliaHooks.handleInStorePickupShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -386,7 +389,8 @@ describe('Algolia Hooks - Out of Stock Tests for BOPIS (InStockThreshold: 5, Ind
         // Act
         const operations = algoliaHooks.handleInStorePickupShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -416,7 +420,8 @@ describe('Algolia Hooks - In Stock Tests (InStockThreshold: 1, IndexOutOfStock: 
         // Act
         const operations = algoliaHooks.handleInStorePickupShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -433,7 +438,8 @@ describe('Algolia Hooks - In Stock Tests (InStockThreshold: 1, IndexOutOfStock: 
 
         const operations = algoliaHooks.handleInStorePickupShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -451,7 +457,8 @@ describe('Algolia Hooks - In Stock Tests (InStockThreshold: 1, IndexOutOfStock: 
         // Act
         const operations = algoliaHooks.handleInStorePickupShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -470,7 +477,8 @@ describe('Algolia Hooks - In Stock Tests (InStockThreshold: 1, IndexOutOfStock: 
         // Act
         const operations = algoliaHooks.handleStandardShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -487,7 +495,8 @@ describe('Algolia Hooks - In Stock Tests (InStockThreshold: 1, IndexOutOfStock: 
 
         const operations = algoliaHooks.handleStandardShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -505,7 +514,8 @@ describe('Algolia Hooks - In Stock Tests (InStockThreshold: 1, IndexOutOfStock: 
         // Act
         const operations = algoliaHooks.handleStandardShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -535,7 +545,8 @@ describe('Algolia Hooks - In Stock Tests (InStockThreshold: 1, IndexOutOfStock: 
         // Act
         const operations = algoliaHooks.handleInStorePickupShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -554,7 +565,8 @@ describe('Algolia Hooks - In Stock Tests (InStockThreshold: 1, IndexOutOfStock: 
         // Act
         const operations = algoliaHooks.handleInStorePickupShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -573,7 +585,8 @@ describe('Algolia Hooks - In Stock Tests (InStockThreshold: 1, IndexOutOfStock: 
         // Act
         const operations = algoliaHooks.handleStandardShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );
@@ -592,7 +605,8 @@ describe('Algolia Hooks - In Stock Tests (InStockThreshold: 1, IndexOutOfStock: 
         // Act
         const operations = algoliaHooks.handleStandardShipment(
             shipment,
-            threshold,
+            { InStockThreshold: threshold, IndexOutOfStock: mockConfig.IndexOutOfStock },
+            [],
             additionalAttributes,
             recordModel
         );


### PR DESCRIPTION
`algoliaLocalizedProduct.js` resolved its stock configuration into module-level variables at `require()` time:

```js
var ALGOLIA_IN_STOCK_THRESHOLD = algoliaData.getPreference('InStockThreshold') || 1;
var INDEX_OUT_OF_STOCK = algoliaData.getPreference('IndexOutOfStock');
var ATTRIBUTE_LIST = algoliaData.getSetOfArray('AdditionalAttributes');
```

These are evaluated once and cached for the module's lifetime, so unit tests can't run successive cases with different preference values without reloading the module. The file carried test-only lines (`__setThreshold`, `__setIndexOutOfStock`, `__setAttributeList`) purely to be able to change their values from tests. The `storeAvailability` store list was built the same way: a whole-catalog `StoreMgr.searchStoresByCoordinates()` scan at module load.

- `AlgoliaLocalizedProduct` now reads `parameters.sitePreferences.{InStockThreshold, IndexOutOfStock}` and `parameters.stores` via `resolveInStockThreshold / resolveIndexOutOfStock / resolveStores`. Each falls back to the previous source (`algoliaData.getPreference(...)` / `modelHelper.getStoresWithInventory()`) when not injected, so existing callers are unchanged - backward compatible.
- `InStockThreshold` is resolved once per construction (cached on the parameters object, not module scope) and reused by the `in_stock`, `variants` and `storeAvailability` handlers.
- Removed the module-level globals, the load-time store scan, and the `__set*` interfaces. The scan moved to `modelHelper.getStoresWithInventory()`.
- Callers build the values once and pass them down:
  - `algoliaProductIndex` / `algoliaProductDeltaIndex`: build `sitePreferences`, and stores only when `storeAvailability` is requested, in `beforeStep`.
  -` jobHelper.generateVariantRecords` / `generateAttributeSlicedRecords`: forward both.
  - `algoliaHooks` order update: build both once, thread through the shipment handlers and `createProductConfig`; renamed local `threshold` -> `InStockThreshold` to be consistent.
- Minor cleanups in the touched code: `empty()` guards in the resolvers, `const/let`, JSDoc.
