### PR TITLE
fix: [SFCC-525] Duplicate attributes while creating the model

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
@@ -843,9 +843,14 @@ function getAttributes(additionalAttributes) {
             algoliaProductConfig.attributeConfig_v2[attribute] ||
             getDefaultAttributeConfig(attribute);
 
+        // variantAttributes/masterAttributes are pre-seeded with the defaults, some of which also
+        // appear in defaultAttributes or the additionalAttributes argument; skip names already
+        // present so each attribute is only categorized (and later fetched) once per record.
         if (attributeConfig.variantAttribute) {
-            variantAttributes.push(attribute);
-        } else {
+            if (variantAttributes.indexOf(attribute) < 0) {
+                variantAttributes.push(attribute);
+            }
+        } else if (masterAttributes.indexOf(attribute) < 0) {
             masterAttributes.push(attribute);
         }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -191,9 +191,14 @@ exports.beforeStep = function(parameters, stepExecution) {
             algoliaProductConfig.attributeConfig_v2[attribute] ||
             jobHelper.getDefaultAttributeConfig(attribute);
 
+        // variantAttributes/masterAttributes are pre-seeded with the defaults, some of which also
+        // appear in attributesToSend or Algolia_AdditionalAttributes; skip names already present so
+        // each attribute is only categorized (and later fetched) once per record.
         if (attributeConfig.variantAttribute) {
-            variantAttributes.push(attribute);
-        } else {
+            if (variantAttributes.indexOf(attribute) < 0) {
+                variantAttributes.push(attribute);
+            }
+        } else if (masterAttributes.indexOf(attribute) < 0) {
             masterAttributes.push(attribute);
         }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductIndex.js
@@ -183,9 +183,14 @@ exports.beforeStep = function(parameters, stepExecution) {
             algoliaProductConfig.attributeConfig_v2[attribute] ||
             jobHelper.getDefaultAttributeConfig(attribute);
 
+        // variantAttributes/masterAttributes are pre-seeded with the defaults, some of which also
+        // appear in attributesToSend or Algolia_AdditionalAttributes; skip names already present so
+        // each attribute is only categorized (and later fetched) once per record.
         if (attributeConfig.variantAttribute) {
-            variantAttributes.push(attribute);
-        } else {
+            if (variantAttributes.indexOf(attribute) < 0) {
+                variantAttributes.push(attribute);
+            }
+        } else if (masterAttributes.indexOf(attribute) < 0) {
             masterAttributes.push(attribute);
         }
 


### PR DESCRIPTION
Previously, I found that `colorVariations`, `in_stock`, `price`, `color`, `size` and `url` ended up in the `masterAttributes` array twice when using attribute-sliced indexing.
This is now fixed, attributes that already exist are no longer added to the list of attributes to be sent.