### PR TITLE
feat: [SFCC-463][SFCC-530] Adapted the delta consumer job to price and inventory

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/fileHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/fileHelper.js
@@ -59,16 +59,16 @@ function getChildFolders(folder) {
 }
 
 /**
- * Returns an array of all XML files from the given folder
+ * Returns an array of all XML files from the given folder, sorted by name
  * @param {dw.io.File} folder Folder to list files in
- * @returns {Array} An array of strings
+ * @returns {dw.io.File[]} An array of File objects, one per .xml file directly in the folder
  */
 function getAllXMLFilesInFolder(folder) {
     if (empty(folder) || !folder.isDirectory()) {
         return [];
     } else {
         return folder.listFiles(function(file) {
-            return file.isFile() && file.getName().endsWith('.xml');
+            return file.isFile() && (/\.xml$/).test(file.getName());
         }).toArray().sort();
     }
 }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -255,10 +255,10 @@ exports.beforeStep = function(parameters, stepExecution) {
     // creating working folder (same as the delta export output folder) - if there were no previous changes, the delta export job step won't create it
     l0_deltaExportDir = new File(ALGOLIA_DELTA_EXPORT_BASE_FOLDER + paramConsumer + '/' + paramDeltaExportJobName); // Impex/src/platform/outbox/algolia/productDeltaExport
 
-    // return OK if the folder doesn't exist, this means that the CatalogDeltaExport job step finished OK but didn't have any output (there were no changes)
+    // return OK if the folder doesn't exist, this means the delta export (catalog, price book or inventory list) finished OK but didn't have any output (there were no changes)
     if (!l0_deltaExportDir.exists()) {
         logger.info('Export directory does not exist (' + l0_deltaExportDir.getFullPath() +
-            '). There haven\'t been any changes to the catalog yet or the "consumer" and "deltaExportJobName" parameters do not match for both job steps.');
+            '). There haven\'t been any changes yet, or the "consumer" and "deltaExportJobName" parameters do not match the delta export that produces the archives.');
         return; // return with an empty changedProducts object
     }
 
@@ -308,7 +308,7 @@ exports.beforeStep = function(parameters, stepExecution) {
         if (l4_catalogsDir.exists() && l4_catalogsDir.isDirectory()) {
 
             // getting child catalog folders, there can be more than one - folder name is the ID of the catalog
-            var l5_catalogDirList = fileHelper.getChildFolders(l4_catalogsDir);
+            let l5_catalogDirList = fileHelper.getChildFolders(l4_catalogsDir);
 
             // processing catalog.xml files in each folder
             l5_catalogDirList.forEach(function(l5_catalogDir) {
@@ -317,6 +317,53 @@ exports.beforeStep = function(parameters, stepExecution) {
 
                 // adding productsIDs from the XML to the list of changed productIDs
                 let result = jobHelper.updateCPObjectFromXML(catalogFile, changedProducts, 'catalog');
+
+                if (result.success) {
+                    jobReport.processedItems += result.nrProductsRead;
+                } else {
+                    // Mark the job in error if an error occurred while reading from any of the delta export zips
+                    jobReport.error = true;
+                    jobReport.errorMessage = result.errorMessage;
+                }
+            });
+        }
+
+        // -------------------- processing price book XMLs --------------------
+        // A Price Book delta export packs one XML per affected price book directly under "pricebooks/".
+        // A catalog archive has no such folder, so this block is a no-op for the catalog delta job.
+
+        let l4_pricebooksDir = new File(l3_uuidDir, 'pricebooks'); // _processing/000001.zip/<uuid>/pricebooks/
+
+        if (l4_pricebooksDir.exists() && l4_pricebooksDir.isDirectory()) {
+            // one <priceBookID>.xml per affected price book
+            let pricebookFiles = fileHelper.getAllXMLFilesInFolder(l4_pricebooksDir);
+            pricebookFiles.forEach(function(pricebookFile) {
+                // adding productIDs from the XML to the list of changed productIDs
+                let result = jobHelper.updateCPObjectFromXML(pricebookFile, changedProducts, 'pricebook');
+
+                if (result.success) {
+                    jobReport.processedItems += result.nrProductsRead;
+                } else {
+                    // Mark the job in error if an error occurred while reading from any of the delta export zips
+                    jobReport.error = true;
+                    jobReport.errorMessage = result.errorMessage;
+                }
+            });
+        }
+
+        // -------------------- processing inventory list XMLs --------------------
+        // An Inventory List delta export packs one XML per affected inventory list directly under "inventory-lists/".
+        // A catalog archive has no such folder, so this block is a no-op for the catalog delta job.
+
+        let l4_inventoryListsDir = new File(l3_uuidDir, 'inventory-lists'); // _processing/000001.zip/<uuid>/inventory-lists/
+
+        if (l4_inventoryListsDir.exists() && l4_inventoryListsDir.isDirectory()) {
+            // one <listID>.xml per affected inventory list
+            let inventoryListFiles = fileHelper.getAllXMLFilesInFolder(l4_inventoryListsDir);
+            inventoryListFiles.forEach(function(inventoryListFile) {
+
+                // adding productIDs from the XML to the list of changed productIDs
+                let result = jobHelper.updateCPObjectFromXML(inventoryListFile, changedProducts, 'inventory');
 
                 if (result.success) {
                     jobReport.processedItems += result.nrProductsRead;

--- a/test/mocks/dw/io/FileReader.js
+++ b/test/mocks/dw/io/FileReader.js
@@ -1,0 +1,16 @@
+// Minimal dw.io.FileReader mock. Test fixtures pass a file-like object that carries the raw
+// XML string on `__xmlContent`; this reader exposes that string to the XMLStreamReader mock.
+class MockedFileReader {
+    constructor(file) {
+        this._content = (file && typeof file.__xmlContent === 'string') ? file.__xmlContent : '';
+    }
+    getString() {
+        return this._content;
+    }
+    readString() {
+        return this._content;
+    }
+    close() {}
+}
+
+module.exports = MockedFileReader;

--- a/test/mocks/dw/io/XMLStreamConstants.js
+++ b/test/mocks/dw/io/XMLStreamConstants.js
@@ -1,0 +1,20 @@
+// Mirrors the event-type constants of dw.io.XMLStreamConstants (javax.xml.stream.XMLStreamConstants).
+// Only START_ELEMENT, END_ELEMENT and CHARACTERS are exercised by the delta export extraction, but
+// the full set is included so the mock matches the real numeric values.
+module.exports = {
+    START_ELEMENT: 1,
+    END_ELEMENT: 2,
+    PROCESSING_INSTRUCTION: 3,
+    CHARACTERS: 4,
+    COMMENT: 5,
+    SPACE: 6,
+    START_DOCUMENT: 7,
+    END_DOCUMENT: 8,
+    ENTITY_REFERENCE: 9,
+    ATTRIBUTE: 10,
+    DTD: 11,
+    CDATA: 12,
+    NAMESPACE: 13,
+    NOTATION_DECLARATION: 14,
+    ENTITY_DECLARATION: 15,
+};

--- a/test/mocks/dw/io/XMLStreamReader.js
+++ b/test/mocks/dw/io/XMLStreamReader.js
@@ -1,0 +1,107 @@
+const XMLStreamConstants = require('./XMLStreamConstants');
+
+/**
+ * Removes a namespace prefix from an element or attribute name (e.g. "ns:name" -> "name").
+ * @param {string} name element or attribute name
+ * @returns {string} the local part of the name
+ */
+function stripPrefix(name) {
+    const idx = name.indexOf(':');
+    return idx === -1 ? name : name.slice(idx + 1);
+}
+
+/**
+ * Parses the attribute portion of a start tag into a map keyed by the attribute name as written.
+ * @param {string} attrString the text after the element name, e.g. 'product-id="X" mode="delete"'
+ * @returns {Object} map of attribute name to value
+ */
+function parseAttributes(attrString) {
+    const attributes = {};
+    const attrRegex = /([\w:.-]+)\s*=\s*"([^"]*)"/g;
+    let m;
+    while ((m = attrRegex.exec(attrString)) !== null) {
+        attributes[m[1]] = m[2];
+    }
+    return attributes;
+}
+
+/**
+ * Tokenizes an XML string into a flat list of StAX-style (Streaming API for XML) events. Handles the element, attribute
+ * and text shapes used by the delta export fixtures; it is not a general-purpose XML parser.
+ * @param {string} xml the raw XML string
+ * @returns {Array} an array of { type, localName?, attributes? } events
+ */
+function tokenize(xml) {
+    const events = [];
+    const tagRegex = /<[^>]+>/g;
+    let match;
+    let lastIndex = 0;
+
+    while ((match = tagRegex.exec(xml)) !== null) {
+        const text = xml.slice(lastIndex, match.index);
+        if (text.trim().length > 0) {
+            events.push({ type: XMLStreamConstants.CHARACTERS });
+        }
+        lastIndex = tagRegex.lastIndex;
+
+        const tag = match[0];
+        if (tag.startsWith('<?') || tag.startsWith('<!')) {
+            continue; // XML declaration, comment or doctype
+        }
+
+        if (tag.startsWith('</')) {
+            events.push({ type: XMLStreamConstants.END_ELEMENT, localName: stripPrefix(tag.slice(2, -1).trim()) });
+        } else {
+            const selfClosing = tag.endsWith('/>');
+            const inner = tag.slice(1, selfClosing ? -2 : -1).trim();
+            const spaceIdx = inner.search(/\s/);
+            const rawName = spaceIdx === -1 ? inner : inner.slice(0, spaceIdx);
+            const attrString = spaceIdx === -1 ? '' : inner.slice(spaceIdx + 1);
+            const localName = stripPrefix(rawName);
+
+            events.push({ type: XMLStreamConstants.START_ELEMENT, localName: localName, attributes: parseAttributes(attrString) });
+            if (selfClosing) {
+                events.push({ type: XMLStreamConstants.END_ELEMENT, localName: localName });
+            }
+        }
+    }
+
+    return events;
+}
+
+/**
+ * Minimal dw.io.XMLStreamReader mock. Converts an XML string (read from the supplied FileReader
+ * mock) into a stream of START_ELEMENT / END_ELEMENT / CHARACTERS events, exposing the subset of
+ * the StAX API the delta export extraction relies on.
+ */
+class XMLStreamReader {
+    constructor(reader) {
+        const xml = reader && typeof reader.getString === 'function' ? reader.getString() : String(reader || '');
+        this._events = tokenize(xml);
+        this._index = -1;
+        this._current = null;
+    }
+    hasNext() {
+        return this._index < this._events.length - 1;
+    }
+    next() {
+        this._index += 1;
+        this._current = this._events[this._index];
+        return this._current.type;
+    }
+    getLocalName() {
+        return this._current ? this._current.localName : null;
+    }
+    getAttributeValue(uri, localName) {
+        if (this._current && this._current.attributes && Object.prototype.hasOwnProperty.call(this._current.attributes, localName)) {
+            return this._current.attributes[localName];
+        }
+        return null;
+    }
+    readXMLObject() {
+        return null;
+    }
+    close() {}
+}
+
+module.exports = XMLStreamReader;

--- a/test/unit/int_algolia/scripts/algolia/helper/updateCPObjectFromXML.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/updateCPObjectFromXML.test.js
@@ -1,0 +1,159 @@
+// StAX mocks so the real updateCPObjectFromXML parsing path runs against in-memory XML fixtures.
+jest.mock('dw/io/XMLStreamConstants', () => jest.requireActual('../../../../../mocks/dw/io/XMLStreamConstants'), { virtual: true });
+jest.mock('dw/io/FileReader', () => jest.requireActual('../../../../../mocks/dw/io/FileReader'), { virtual: true });
+jest.mock('dw/io/XMLStreamReader', () => jest.requireActual('../../../../../mocks/dw/io/XMLStreamReader'), { virtual: true });
+
+const jobHelper = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper');
+
+/**
+ * Builds a file-like object carrying the raw XML string, as expected by the FileReader mock.
+ * updateCPObjectFromXML only calls exists()/getFullPath() on it and hands it to FileReader.
+ * @param {string} content the raw XML the FileReader mock should expose
+ * @returns {Object} a file-like stand-in for dw.io.File
+ */
+function xmlFile(content) {
+    return {
+        exists: function () { return true; },
+        getFullPath: function () { return '/mock/outbox/delta.xml'; },
+        __xmlContent: content,
+    };
+}
+
+/**
+ * Flattens the array-of-objects changedProducts structure into a single plain object.
+ * @param {Array} changedProducts the accumulator updateCPObjectFromXML writes into
+ * @returns {Object} a map of product id to availability flag
+ */
+function flatten(changedProducts) {
+    return changedProducts.reduce(function (acc, obj) { return Object.assign(acc, obj); }, {});
+}
+
+// A price book delta names the object whose price-table changed, one <price-table> per entry, under a
+// <pricebooks> root. This one carries two distinct SKUs, matching a Price Books delta export archive.
+const PRICEBOOK_LIST = `<?xml version="1.0" encoding="UTF-8"?>
+<pricebooks xmlns="http://www.demandware.com/xml/impex/pricebook/2006-10-31">
+    <pricebook>
+        <header pricebook-id="cny-m-list-prices">
+            <currency>CNY</currency>
+            <display-name xml:lang="x-default">List Prices</display-name>
+            <online-flag>true</online-flag>
+        </header>
+        <price-tables>
+            <price-table product-id="701644457976M">
+                <amount quantity="1">303.00</amount>
+            </price-table>
+            <price-table product-id="701644457983M">
+                <amount quantity="1">299.00</amount>
+            </price-table>
+        </price-tables>
+    </pricebook>
+</pricebooks>`;
+
+// A second price book (a sale book inheriting from the list book) that re-lists one of the SKUs above.
+const PRICEBOOK_SALE = `<?xml version="1.0" encoding="UTF-8"?>
+<pricebooks xmlns="http://www.demandware.com/xml/impex/pricebook/2006-10-31">
+    <pricebook>
+        <header pricebook-id="cny-m-sale-prices">
+            <currency>CNY</currency>
+            <parent>cny-m-list-prices</parent>
+        </header>
+        <price-tables>
+            <price-table product-id="701644457976M">
+                <amount quantity="1">280.00</amount>
+            </price-table>
+        </price-tables>
+    </pricebook>
+</pricebooks>`;
+
+// An inventory list delta names the object whose stock record changed, one <record> per entry, under an
+// <inventory> root closed by </inventory> (the terminator the extraction keys on).
+const INVENTORY = `<?xml version="1.0" encoding="UTF-8"?>
+<inventory xmlns="http://www.demandware.com/xml/impex/inventory/2007-05-31">
+    <inventory-list>
+        <header list-id="inventory_m">
+            <default-instock>false</default-instock>
+        </header>
+        <records>
+            <record product-id="701644457976M">
+                <allocation>100.0</allocation>
+                <ats>100.0</ats>
+            </record>
+            <record product-id="701644457983M">
+                <ats>0.0</ats>
+            </record>
+        </records>
+    </inventory-list>
+</inventory>`;
+
+// A catalog delta (produced by CatalogDeltaExport) marks deletions with mode="delete".
+const CATALOG = `<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="http://www.demandware.com/xml/impex/catalog/2006-10-31" catalog-id="storefront-catalog">
+    <product product-id="701644457976M">
+        <online-flag>true</online-flag>
+    </product>
+    <product product-id="701644457983M" mode="delete">
+    </product>
+</catalog>`;
+
+describe('updateCPObjectFromXML', () => {
+    describe('price book extraction', () => {
+        test('reads every price-table product-id and marks it available', () => {
+            const changedProducts = [];
+            const result = jobHelper.updateCPObjectFromXML(xmlFile(PRICEBOOK_LIST), changedProducts, 'pricebook');
+
+            expect(result.success).toBe(true);
+            expect(result.nrProductsRead).toBe(2);
+            expect(flatten(changedProducts)).toEqual({ '701644457976M': true, '701644457983M': true });
+        });
+
+        test('accumulates across archives and deduplicates a SKU changed in more than one price book', () => {
+            const changedProducts = [];
+            const first = jobHelper.updateCPObjectFromXML(xmlFile(PRICEBOOK_LIST), changedProducts, 'pricebook');
+            const second = jobHelper.updateCPObjectFromXML(xmlFile(PRICEBOOK_SALE), changedProducts, 'pricebook');
+
+            expect(first.success).toBe(true);
+            expect(second.success).toBe(true);
+            // three <price-table> entries read across the two files, but 701644457976M appears in both
+            expect(first.nrProductsRead + second.nrProductsRead).toBe(3);
+            expect(flatten(changedProducts)).toEqual({ '701644457976M': true, '701644457983M': true });
+            expect(jobHelper.getObjectsArrayLength(changedProducts)).toBe(2);
+        });
+    });
+
+    describe('inventory list extraction', () => {
+        test('reads every record product-id and marks it available', () => {
+            const changedProducts = [];
+            const result = jobHelper.updateCPObjectFromXML(xmlFile(INVENTORY), changedProducts, 'inventory');
+
+            expect(result.success).toBe(true);
+            expect(result.nrProductsRead).toBe(2);
+            expect(flatten(changedProducts)).toEqual({ '701644457976M': true, '701644457983M': true });
+        });
+    });
+
+    describe('catalog extraction', () => {
+        test('reads product-ids and honors mode="delete"', () => {
+            const changedProducts = [];
+            const result = jobHelper.updateCPObjectFromXML(xmlFile(CATALOG), changedProducts, 'catalog');
+
+            expect(result.success).toBe(true);
+            expect(result.nrProductsRead).toBe(2);
+            expect(flatten(changedProducts)).toEqual({ '701644457976M': true, '701644457983M': false });
+        });
+    });
+
+    describe('error handling', () => {
+        test('returns success=false with an error message when reading throws', () => {
+            const badFile = {
+                exists: function () { return true; },
+                getFullPath: function () { return '/mock/outbox/broken.xml'; },
+                get __xmlContent() { throw new Error('read failure'); },
+            };
+            const changedProducts = [];
+            const result = jobHelper.updateCPObjectFromXML(badFile, changedProducts, 'pricebook');
+
+            expect(result.success).toBe(false);
+            expect(result.errorMessage).toContain('Error while reading from file');
+        });
+    });
+});


### PR DESCRIPTION
This pull request extends the existing product delta consumer step (`custom.algoliaProductDeltaIndex`) so it also consumes **Price Book** and **Inventory List** delta export archives, in addition to catalog archives. The consumer now scans `pricebooks/` and `inventory-lists/` under the archive's UUID directory and routes each XML to the `pricebook` / `inventory` parse cases already present in `jobHelper.updateCPObjectFromXML`.

## Changes
- **`steps/algoliaProductDeltaIndex.js`** - after the existing `catalogs/` block, `beforeStep` now processes two more layouts per archive:
  - `pricebooks/<priceBookID>.xml` -> `updateCPObjectFromXML(file, changedProducts, 'pricebook')`
  - `inventory-lists/<listID>.xml` -> `updateCPObjectFromXML(file, changedProducts, 'inventory')`
  Both blocks are guarded by `exists() && isDirectory()`, so they are no-ops for a catalog archive (which has neither folder).
- **`helper/fileHelper.js`** - `getAllXMLFilesInFolder` matches the `.xml` extension with a regex instead of `String.prototype.endsWith`, which is not available in compatibility mode 18.10 (Rhino). This function had no callers before, so the fix is precautionary.
- **Tests** - new `test/unit/.../helper/updateCPObjectFromXML.test.js` covering price book, inventory and catalog extraction, cross-archive accumulation with deduplication, and the read-error path. New `test/mocks/dw/io/` StAX mocks (`XMLStreamReader`, `XMLStreamConstants`, `FileReader`) run the real parser against in-memory XML fixtures.
