### PR TITLE
feat: [SFCC-463][SFCC-532] Record-level roll-up and fan-out for price and inventory deltas

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper.js
@@ -521,15 +521,68 @@ function getObjectsArrayLength(objectsArray) {
 }
 
 /**
+ * The price and inventory delta exports contain the IDs of the products that were
+ * affected by the change (variant or master). This function resolves each ID to the
+ * set of IDs that correspond to actual indexed records under the current record
+ * model, so the consumer rebuilds the records a full index would hold rather than the
+ * raw object the delta happened to name.
+ * The record level the model indexes at (see `recordLevel` parameter) decides how
+ * that ID maps to records:
+ * - 'master' (`master-level` and `attribute-sliced` record models, or `variant-level`
+ * with attributes computed from the base product): the indexed record is the master,
+ * so a changed variant is rolled up to its master; masters and standalone products
+ * pass through.
+ * - 'variant' (`variant-level`): the indexed records are the variants, so a changed
+ * master is fanned out to its variants; variants and standalone products pass through.
+ * An ID that resolves to no product passes through so the consumer can issue a delete.
+ * @param {string} productID Product ID read from a delta archive entry
+ * @param {string} recordLevel The record level the model indexes at: 'master' or 'variant'
+ * @returns {string[]} array of IDs to record as changed for this entry
+ */
+function _resolveRecordIDs(productID, recordLevel) {
+    var ProductMgr = require('dw/catalog/ProductMgr');
+    var product = ProductMgr.getProduct(productID);
+
+    if (!product) {
+        return [productID];
+    }
+
+    if (recordLevel === 'master') {
+        if (product.isVariant()) {
+            var master = product.getMasterProduct();
+            return master ? [master.getID()] : [productID];
+        }
+        return [productID];
+    }
+
+    // 'variant' record level: a changed master fans out to its variants, so the inheriting variant records are rebuilt
+    if (product.isMaster()) {
+        var variants = product.getVariants();
+        var variantIDs = [];
+        if (variants) {
+            for (var i = 0; i < variants.size(); i++) {
+                variantIDs.push(variants[i].getID());
+            }
+        }
+        return variantIDs.length > 0 ? variantIDs : [productID];
+    }
+    return [productID];
+}
+
+/**
  * Retrieves the IDs of the products which have changed since the last update
  * (an attribute of the product's, its inventory levels or its price)
  * from the supplied XML and adds them to the changedProducts structure.
  * @param {dw.io.File} xmlFile The path to the XML file.
  * @param {Array} changedProducts An array of objects containing the changed products
  * @param {string} resourceType Type of export file: "catalog" | "inventory" | "pricebook"
+ * @param {string} [recordLevel] Record level used to normalize each price book or inventory entry to the
+ *        indexed records (see `_resolveRecordIDs`): 'master' rolls variants up to their master,
+ *        'variant' fans a master out to its variants. Not consulted for the catalog path, because
+ *        CatalogDeltaExport already emits both master and variants (MasterProductExport).
  * @returns {Object} The result object containing `success` (boolean) and `nrProductsRead` (number)
  */
-function updateCPObjectFromXML(xmlFile, changedProducts, resourceType) {
+function updateCPObjectFromXML(xmlFile, changedProducts, resourceType, recordLevel) {
     var XMLStreamReader = require('dw/io/XMLStreamReader');
     var XMLStreamConstants = require('dw/io/XMLStreamConstants');
     var FileReader = require('dw/io/FileReader');
@@ -576,8 +629,11 @@ function updateCPObjectFromXML(xmlFile, changedProducts, resourceType) {
                             if (xmlStreamReader.getLocalName() === 'record') { // <record> start element
                                 let productID = xmlStreamReader.getAttributeValue(null, 'product-id'); // <record product-id="">
 
-                                // adding new productID to structure or updating it if key already exists, always true
-                                _updateOrAddValue(changedProducts, productID, true);
+                                // normalize the changed SKU to the records the model indexes, then add each
+                                let resolvedIDs = _resolveRecordIDs(productID, recordLevel);
+                                for (let i = 0; i < resolvedIDs.length; i++) {
+                                    _updateOrAddValue(changedProducts, resolvedIDs[i], true);
+                                }
 
                                 resultObj.nrProductsRead++;
                             }
@@ -594,10 +650,13 @@ function updateCPObjectFromXML(xmlFile, changedProducts, resourceType) {
 
                         if (xmlEvent === XMLStreamConstants.START_ELEMENT) {
                             if (xmlStreamReader.getLocalName() === 'price-table') { // <price-table> start element
-                                var productID = xmlStreamReader.getAttributeValue(null, 'product-id'); // <price-table product-id="">
+                                let productID = xmlStreamReader.getAttributeValue(null, 'product-id'); // <price-table product-id="">
 
-                                // adding new productID to structure or updating it if key already exists, always true
-                                _updateOrAddValue(changedProducts, productID, true);
+                                // normalize the changed SKU to the records the model indexes, then add each
+                                let resolvedIDs = _resolveRecordIDs(productID, recordLevel);
+                                for (let r = 0; r < resolvedIDs.length; r++) {
+                                    _updateOrAddValue(changedProducts, resolvedIDs[r], true);
+                                }
 
                                 resultObj.nrProductsRead++;
                             }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -286,6 +286,11 @@ exports.beforeStep = function(parameters, stepExecution) {
     l1_failedDir = new File(l0_deltaExportDir, '_failed');
     l1_failedDir.mkdir();
 
+    // A price book or inventory list delta contains the IDs of the products that were affected by the change (variant or master). The extraction normalizes each ID to the expected record level: at the 'master' level a changed variant is rolled up to its master, at the 'variant' level a changed master is fanned out to its variants so the inheriting variant records are rebuilt. The catalog path is left untouched because CatalogDeltaExport already emits both master and variants due to its MasterProductExport parameter set to true.
+    var recordLevel = (recordModel === RECORD_MODEL_TYPES.MASTER_LEVEL ||
+        recordModel === RECORD_MODEL_TYPES.ATTRIBUTE_SLICED ||
+        attributesComputedFromBaseProduct.length > 0) ? 'master' : 'variant';
+
     // process each export zip one by one
     deltaExportZips.forEach(function(filename) {
         logger.info('Processing ' + filename + '...');
@@ -339,7 +344,7 @@ exports.beforeStep = function(parameters, stepExecution) {
             let pricebookFiles = fileHelper.getAllXMLFilesInFolder(l4_pricebooksDir);
             pricebookFiles.forEach(function(pricebookFile) {
                 // adding productIDs from the XML to the list of changed productIDs
-                let result = jobHelper.updateCPObjectFromXML(pricebookFile, changedProducts, 'pricebook');
+                let result = jobHelper.updateCPObjectFromXML(pricebookFile, changedProducts, 'pricebook', recordLevel);
 
                 if (result.success) {
                     jobReport.processedItems += result.nrProductsRead;
@@ -363,7 +368,7 @@ exports.beforeStep = function(parameters, stepExecution) {
             inventoryListFiles.forEach(function(inventoryListFile) {
 
                 // adding productIDs from the XML to the list of changed productIDs
-                let result = jobHelper.updateCPObjectFromXML(inventoryListFile, changedProducts, 'inventory');
+                let result = jobHelper.updateCPObjectFromXML(inventoryListFile, changedProducts, 'inventory', recordLevel);
 
                 if (result.success) {
                     jobReport.processedItems += result.nrProductsRead;

--- a/test/unit/int_algolia/scripts/algolia/helper/updateCPObjectFromXML.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/updateCPObjectFromXML.test.js
@@ -3,6 +3,28 @@ jest.mock('dw/io/XMLStreamConstants', () => jest.requireActual('../../../../../m
 jest.mock('dw/io/FileReader', () => jest.requireActual('../../../../../mocks/dw/io/FileReader'), { virtual: true });
 jest.mock('dw/io/XMLStreamReader', () => jest.requireActual('../../../../../mocks/dw/io/XMLStreamReader'), { virtual: true });
 
+// Controlled product catalog for the record-level normalization:
+// - variantA, variantB are variants of masterX, and masterX lists them as its variants
+// - standaloneP is a true standalone product (reports neither master nor variant)
+// - any other id (e.g. 'ghost') resolves to no product
+jest.mock('dw/catalog/ProductMgr', () => {
+    const Variant = jest.requireActual('../../../../../mocks/dw/catalog/Variant');
+    const MasterProduct = jest.requireActual('../../../../../mocks/dw/catalog/MasterProduct');
+    const collectionHelper = jest.requireActual('../../../../../mocks/helpers/collectionHelper');
+    const masterX = new MasterProduct({ ID: 'masterX' });
+    const variantA = new Variant({ ID: 'variantA', masterProduct: masterX });
+    const variantB = new Variant({ ID: 'variantB', masterProduct: masterX });
+    masterX.variants = collectionHelper.createCollection([variantA, variantB]);
+    const standaloneP = new MasterProduct({ ID: 'standaloneP' });
+    standaloneP.master = false; // true standalone: reports neither master nor variant
+    const products = { variantA: variantA, variantB: variantB, masterX: masterX, standaloneP: standaloneP };
+    return {
+        getProduct: jest.fn(function (id) {
+            return Object.prototype.hasOwnProperty.call(products, id) ? products[id] : null;
+        }),
+    };
+}, { virtual: true });
+
 const jobHelper = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/jobHelper');
 
 /**
@@ -29,37 +51,68 @@ function flatten(changedProducts) {
 }
 
 // A price book delta names the object whose price-table changed, one <price-table> per entry, under a
-// <pricebooks> root. This one carries two distinct SKUs, matching a Price Books delta export archive.
-const PRICEBOOK_LIST = `<?xml version="1.0" encoding="UTF-8"?>
+// <pricebooks> root closed by </pricebooks> (the terminator the extraction keys on).
+const PRICEBOOK_ONE_VARIANT = `<?xml version="1.0" encoding="UTF-8"?>
 <pricebooks xmlns="http://www.demandware.com/xml/impex/pricebook/2006-10-31">
     <pricebook>
-        <header pricebook-id="cny-m-list-prices">
-            <currency>CNY</currency>
+        <header pricebook-id="usd-list-prices">
+            <currency>USD</currency>
             <display-name xml:lang="x-default">List Prices</display-name>
             <online-flag>true</online-flag>
         </header>
         <price-tables>
-            <price-table product-id="701644457976M">
-                <amount quantity="1">303.00</amount>
-            </price-table>
-            <price-table product-id="701644457983M">
-                <amount quantity="1">299.00</amount>
+            <price-table product-id="variantA">
+                <amount quantity="1">46.00</amount>
             </price-table>
         </price-tables>
     </pricebook>
 </pricebooks>`;
 
-// A second price book (a sale book inheriting from the list book) that re-lists one of the SKUs above.
-const PRICEBOOK_SALE = `<?xml version="1.0" encoding="UTF-8"?>
+const PRICEBOOK_TWO_VARIANTS_AND_STANDALONE = `<?xml version="1.0" encoding="UTF-8"?>
 <pricebooks xmlns="http://www.demandware.com/xml/impex/pricebook/2006-10-31">
     <pricebook>
-        <header pricebook-id="cny-m-sale-prices">
-            <currency>CNY</currency>
-            <parent>cny-m-list-prices</parent>
+        <header pricebook-id="usd-sale-prices">
+            <currency>USD</currency>
+            <parent>usd-list-prices</parent>
         </header>
         <price-tables>
-            <price-table product-id="701644457976M">
-                <amount quantity="1">280.00</amount>
+            <price-table product-id="variantA">
+                <amount quantity="1">46.00</amount>
+            </price-table>
+            <price-table product-id="variantB">
+                <amount quantity="1">45.00</amount>
+            </price-table>
+            <price-table product-id="standaloneP">
+                <amount quantity="1">19.99</amount>
+            </price-table>
+        </price-tables>
+    </pricebook>
+</pricebooks>`;
+
+// A merchant edited a master-level price-table that variants inherit; the delta names the master.
+const PRICEBOOK_MASTER_ENTRY = `<?xml version="1.0" encoding="UTF-8"?>
+<pricebooks xmlns="http://www.demandware.com/xml/impex/pricebook/2006-10-31">
+    <pricebook>
+        <header pricebook-id="usd-list-prices">
+            <currency>USD</currency>
+        </header>
+        <price-tables>
+            <price-table product-id="masterX">
+                <amount quantity="1">50.00</amount>
+            </price-table>
+        </price-tables>
+    </pricebook>
+</pricebooks>`;
+
+const PRICEBOOK_UNKNOWN_ID = `<?xml version="1.0" encoding="UTF-8"?>
+<pricebooks xmlns="http://www.demandware.com/xml/impex/pricebook/2006-10-31">
+    <pricebook>
+        <header pricebook-id="usd-list-prices">
+            <currency>USD</currency>
+        </header>
+        <price-tables>
+            <price-table product-id="ghost">
+                <amount quantity="1">1.00</amount>
             </price-table>
         </price-tables>
     </pricebook>
@@ -67,18 +120,32 @@ const PRICEBOOK_SALE = `<?xml version="1.0" encoding="UTF-8"?>
 
 // An inventory list delta names the object whose stock record changed, one <record> per entry, under an
 // <inventory> root closed by </inventory> (the terminator the extraction keys on).
-const INVENTORY = `<?xml version="1.0" encoding="UTF-8"?>
+const INVENTORY_ONE_VARIANT = `<?xml version="1.0" encoding="UTF-8"?>
 <inventory xmlns="http://www.demandware.com/xml/impex/inventory/2007-05-31">
     <inventory-list>
         <header list-id="inventory_m">
             <default-instock>false</default-instock>
         </header>
         <records>
-            <record product-id="701644457976M">
+            <record product-id="variantA">
                 <allocation>100.0</allocation>
                 <ats>100.0</ats>
             </record>
-            <record product-id="701644457983M">
+        </records>
+    </inventory-list>
+</inventory>`;
+
+const INVENTORY_TWO_VARIANTS = `<?xml version="1.0" encoding="UTF-8"?>
+<inventory xmlns="http://www.demandware.com/xml/impex/inventory/2007-05-31">
+    <inventory-list>
+        <header list-id="inventory_m">
+            <default-instock>false</default-instock>
+        </header>
+        <records>
+            <record product-id="variantA">
+                <ats>100.0</ats>
+            </record>
+            <record product-id="variantB">
                 <ats>0.0</ats>
             </record>
         </records>
@@ -88,57 +155,124 @@ const INVENTORY = `<?xml version="1.0" encoding="UTF-8"?>
 // A catalog delta (produced by CatalogDeltaExport) marks deletions with mode="delete".
 const CATALOG = `<?xml version="1.0" encoding="UTF-8"?>
 <catalog xmlns="http://www.demandware.com/xml/impex/catalog/2006-10-31" catalog-id="storefront-catalog">
-    <product product-id="701644457976M">
+    <product product-id="variantA">
         <online-flag>true</online-flag>
     </product>
-    <product product-id="701644457983M" mode="delete">
+    <product product-id="variantB" mode="delete">
     </product>
 </catalog>`;
 
 describe('updateCPObjectFromXML', () => {
     describe('price book extraction', () => {
-        test('reads every price-table product-id and marks it available', () => {
+        test('reads the price-table product-ids', () => {
             const changedProducts = [];
-            const result = jobHelper.updateCPObjectFromXML(xmlFile(PRICEBOOK_LIST), changedProducts, 'pricebook');
+            const result = jobHelper.updateCPObjectFromXML(xmlFile(PRICEBOOK_ONE_VARIANT), changedProducts, 'pricebook', 'variant');
 
             expect(result.success).toBe(true);
-            expect(result.nrProductsRead).toBe(2);
-            expect(flatten(changedProducts)).toEqual({ '701644457976M': true, '701644457983M': true });
+            expect(result.nrProductsRead).toBe(1);
+            expect(flatten(changedProducts)).toEqual({ variantA: true });
         });
 
         test('accumulates across archives and deduplicates a SKU changed in more than one price book', () => {
             const changedProducts = [];
-            const first = jobHelper.updateCPObjectFromXML(xmlFile(PRICEBOOK_LIST), changedProducts, 'pricebook');
-            const second = jobHelper.updateCPObjectFromXML(xmlFile(PRICEBOOK_SALE), changedProducts, 'pricebook');
+            const first = jobHelper.updateCPObjectFromXML(xmlFile(PRICEBOOK_ONE_VARIANT), changedProducts, 'pricebook', 'variant');
+            const second = jobHelper.updateCPObjectFromXML(xmlFile(PRICEBOOK_TWO_VARIANTS_AND_STANDALONE), changedProducts, 'pricebook', 'variant');
 
             expect(first.success).toBe(true);
             expect(second.success).toBe(true);
-            // three <price-table> entries read across the two files, but 701644457976M appears in both
-            expect(first.nrProductsRead + second.nrProductsRead).toBe(3);
-            expect(flatten(changedProducts)).toEqual({ '701644457976M': true, '701644457983M': true });
+            // four <price-table> entries read across the two files, but variantA appears in both
+            expect(first.nrProductsRead + second.nrProductsRead).toBe(4);
+            expect(flatten(changedProducts)).toEqual({ variantA: true, variantB: true, standaloneP: true });
+            expect(jobHelper.getObjectsArrayLength(changedProducts)).toBe(3);
+        });
+
+        test('when recordLevel is master, rolls changed variants up to their master, collapsing duplicates', () => {
+            const changedProducts = [];
+            const result = jobHelper.updateCPObjectFromXML(xmlFile(PRICEBOOK_TWO_VARIANTS_AND_STANDALONE), changedProducts, 'pricebook', 'master');
+
+            expect(result.success).toBe(true);
+            expect(result.nrProductsRead).toBe(3); // three <price-table> entries read
+            // variantA + variantB collapse onto masterX; the standalone passes through
+            expect(flatten(changedProducts)).toEqual({ masterX: true, standaloneP: true });
             expect(jobHelper.getObjectsArrayLength(changedProducts)).toBe(2);
+        });
+
+        test('when recordLevel is master, passes a master id through unchanged', () => {
+            const changedProducts = [];
+            jobHelper.updateCPObjectFromXML(xmlFile(PRICEBOOK_MASTER_ENTRY), changedProducts, 'pricebook', 'master');
+
+            expect(flatten(changedProducts)).toEqual({ masterX: true });
+        });
+
+        test('when recordLevel is variant, leaves variants and standalones unchanged', () => {
+            const changedProducts = [];
+            jobHelper.updateCPObjectFromXML(xmlFile(PRICEBOOK_TWO_VARIANTS_AND_STANDALONE), changedProducts, 'pricebook', 'variant');
+
+            expect(flatten(changedProducts)).toEqual({ variantA: true, variantB: true, standaloneP: true });
+        });
+
+        test('when recordLevel is variant, fans a changed master out to its variants', () => {
+            const changedProducts = [];
+            const result = jobHelper.updateCPObjectFromXML(xmlFile(PRICEBOOK_MASTER_ENTRY), changedProducts, 'pricebook', 'variant');
+
+            expect(result.success).toBe(true);
+            expect(result.nrProductsRead).toBe(1); // one <price-table> entry read
+            // the master is not an indexed record; its inheriting variants are rebuilt instead
+            expect(flatten(changedProducts)).toEqual({ variantA: true, variantB: true });
+            expect(jobHelper.getObjectsArrayLength(changedProducts)).toBe(2);
+        });
+
+        test('passes an id that resolves to no product through unchanged', () => {
+            const changedProducts = [];
+            jobHelper.updateCPObjectFromXML(xmlFile(PRICEBOOK_UNKNOWN_ID), changedProducts, 'pricebook', 'master');
+
+            expect(flatten(changedProducts)).toEqual({ ghost: true });
         });
     });
 
     describe('inventory list extraction', () => {
-        test('reads every record product-id and marks it available', () => {
+        test('reads the record product-ids', () => {
             const changedProducts = [];
-            const result = jobHelper.updateCPObjectFromXML(xmlFile(INVENTORY), changedProducts, 'inventory');
+            const result = jobHelper.updateCPObjectFromXML(xmlFile(INVENTORY_ONE_VARIANT), changedProducts, 'inventory', 'variant');
+
+            expect(result.success).toBe(true);
+            expect(result.nrProductsRead).toBe(1);
+            expect(flatten(changedProducts)).toEqual({ variantA: true });
+        });
+
+        test('when recordLevel is master, rolls changed variants up to their master', () => {
+            const changedProducts = [];
+            const result = jobHelper.updateCPObjectFromXML(xmlFile(INVENTORY_TWO_VARIANTS), changedProducts, 'inventory', 'master');
 
             expect(result.success).toBe(true);
             expect(result.nrProductsRead).toBe(2);
-            expect(flatten(changedProducts)).toEqual({ '701644457976M': true, '701644457983M': true });
+            expect(flatten(changedProducts)).toEqual({ masterX: true });
+            expect(jobHelper.getObjectsArrayLength(changedProducts)).toBe(1);
+        });
+
+        test('when recordLevel is variant, leaves the changed variants unchanged', () => {
+            const changedProducts = [];
+            jobHelper.updateCPObjectFromXML(xmlFile(INVENTORY_TWO_VARIANTS), changedProducts, 'inventory', 'variant');
+
+            expect(flatten(changedProducts)).toEqual({ variantA: true, variantB: true });
         });
     });
 
-    describe('catalog extraction', () => {
+    describe('catalog extraction (unchanged)', () => {
         test('reads product-ids and honors mode="delete"', () => {
             const changedProducts = [];
             const result = jobHelper.updateCPObjectFromXML(xmlFile(CATALOG), changedProducts, 'catalog');
 
             expect(result.success).toBe(true);
             expect(result.nrProductsRead).toBe(2);
-            expect(flatten(changedProducts)).toEqual({ '701644457976M': true, '701644457983M': false });
+            expect(flatten(changedProducts)).toEqual({ variantA: true, variantB: false });
+        });
+
+        test('ignores recordLevel, so the catalog path is untouched', () => {
+            const changedProducts = [];
+            jobHelper.updateCPObjectFromXML(xmlFile(CATALOG), changedProducts, 'catalog', 'master');
+
+            expect(flatten(changedProducts)).toEqual({ variantA: true, variantB: false });
         });
     });
 


### PR DESCRIPTION
A price book or inventory list delta names the object whose price-table or inventory record changed - usually a variant SKU, but a master when a merchant edits a master-level price-table that variants inherit. This change normalizes each extracted ID to the records the current record model actually indexes, so the delta consumer rebuilds the same records a full reindex would hold.

## Changes
- **`helper/jobHelper.js`** - new `_resolveRecordIDs(productID, recordLevel)`:
  - `master` (master-level, attribute-sliced, or variant-level with attributes computed from the base product, such as `colorVariations`): a changed variant is rolled up to its master; masters and simple (standalone) products pass through.
  - `variant` (plain variant-level): a changed master is fanned out to its inheriting variants; variants and simple products pass through.
  - An ID that resolves to no product passes through so a delete can still be issued (no-op at worst, drift correction at best)
  `updateCPObjectFromXML` takes an optional `recordLevel` and routes the `inventory` and `pricebook` cases through the resolver. The `catalog` path is untouched (CatalogDeltaExport already emits master and variants due to its `MasterProductExport` parameter).
- **`steps/algoliaProductDeltaIndex.js`** - `beforeStep` computes `recordLevel` from the record model once and passes it to the price book and inventory calls.
- **`updateCPObjectFromXML.test.js`** - roll-up/fan-out coverage over a controlled ProductMgr catalog (variant->master collapse with dedup, master->variants fan-out, master/standalone/unknown pass-through, and that `catalog` ignores `recordLevel`).

## Why full records, not partial nested updates
Algolia partial updates only touch top-level attributes, so a variant's price/inventory change in a `master-level` or `attribute-sliced` model requires recomputing the whole record anyway; normalizing at extraction time lets the existing full-record process path do exactly that.
