### PR TITLE
feat: [SFCC-463][SFCC-533] Archive consumption tracker with custom objects

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/consumedArchiveTracker.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/consumedArchiveTracker.js
@@ -1,11 +1,15 @@
 'use strict';
 
 /**
- * Tracks which delta export archives have already been consumed by the current site.
+ * Tracks which delta export archives have already been consumed, per consuming job
+ * and per site.
  *
  * The delta consumer leaves the archives in the outbox instead of moving them to a
  * "_completed" folder, so a single delta export definition can be shared by multiple
- * sites: each site's job skips only the archives its own custom objects list.
+ * consumers: each job skips only the archives its own custom objects list. Consumption
+ * is recorded per job within the site's custom object scope, so both other sites' jobs
+ * and same-site jobs that split the work (e.g. by locale) consume the same archive
+ * independently.
  * The archives themselves are deleted by the platform's /Impex file retention after
  * 30 days, and the custom objects expire via retention-days on the type, so no
  * cleanup step is needed.
@@ -15,39 +19,43 @@ const CUSTOM_OBJECT_TYPE = 'AlgoliaConsumedDeltaArchive';
 
 /**
  * Builds the custom object key for one archive. The storage scope of the custom object
- * type is "site", so the key only needs to be unique within a site.
+ * type is "site", so the key only needs to be unique within a site. The consuming job's
+ * ID is prepended so that the rest of the key mirrors the archive's path in the outbox
+ * (consumer/deltaExportJobName/archiveName).
+ * @param {string} jobID The ID of the consuming job
  * @param {string} consumer The consumer name of the delta export
  * @param {string} deltaExportJobName The name of the delta export
  * @param {string} archiveName The archive file name (e.g. "000042.zip")
  * @returns {string} The custom object key
  */
-function getArchiveKey(consumer, deltaExportJobName, archiveName) {
-    return consumer + '__' + deltaExportJobName + '__' + archiveName;
+function getArchiveKey(jobID, consumer, deltaExportJobName, archiveName) {
+    return jobID + '__' + consumer + '__' + deltaExportJobName + '__' + archiveName;
 }
 
 /**
- * Returns whether the given archive has already been consumed by the current site.
+ * Returns whether the given archive has already been consumed by the given job on the current site.
+ * @param {string} jobID The ID of the consuming job
  * @param {string} consumer The consumer name of the delta export
  * @param {string} deltaExportJobName The name of the delta export
  * @param {string} archiveName The archive file name (e.g. "000042.zip")
- * @returns {boolean} true if the archive is recorded as consumed for the current site
+ * @returns {boolean} true if the archive is recorded as consumed for the given job on the current site
  */
-function isConsumed(consumer, deltaExportJobName, archiveName) {
+function isConsumed(jobID, consumer, deltaExportJobName, archiveName) {
     const CustomObjectMgr = require('dw/object/CustomObjectMgr');
-    const consumedArchiveCO = CustomObjectMgr.getCustomObject(CUSTOM_OBJECT_TYPE, getArchiveKey(consumer, deltaExportJobName, archiveName));
+    const consumedArchiveCO = CustomObjectMgr.getCustomObject(CUSTOM_OBJECT_TYPE, getArchiveKey(jobID, consumer, deltaExportJobName, archiveName));
     return !empty(consumedArchiveCO);
 }
 
 /**
- * Records the given archives as consumed by the current site.
+ * Records the given archives as consumed by the given job on the current site.
  * An archive that is already recorded (e.g. by a rerun racing an earlier record) is skipped.
+ * @param {string} jobID The ID of the consuming job
  * @param {string} consumer The consumer name of the delta export
  * @param {string} deltaExportJobName The name of the delta export
  * @param {string[]} archiveNames The archive file names to record
- * @param {string} jobID The ID of the job run that consumed the archives
  * @returns {boolean} true if all archives were recorded successfully
  */
-function markConsumed(consumer, deltaExportJobName, archiveNames, jobID) {
+function markConsumed(jobID, consumer, deltaExportJobName, archiveNames) {
     const CustomObjectMgr = require('dw/object/CustomObjectMgr');
     const Transaction = require('dw/system/Transaction');
     const logger = require('*/cartridge/scripts/algolia/helper/jobHelper').getAlgoliaLogger();
@@ -55,7 +63,7 @@ function markConsumed(consumer, deltaExportJobName, archiveNames, jobID) {
     let success = true;
 
     archiveNames.forEach(function(archiveName) {
-        const archiveKey = getArchiveKey(consumer, deltaExportJobName, archiveName);
+        const archiveKey = getArchiveKey(jobID, consumer, deltaExportJobName, archiveName);
         try {
             Transaction.wrap(function() {
                 if (!empty(CustomObjectMgr.getCustomObject(CUSTOM_OBJECT_TYPE, archiveKey))) {

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/consumedArchiveTracker.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/consumedArchiveTracker.js
@@ -1,0 +1,82 @@
+'use strict';
+
+/**
+ * Tracks which delta export archives have already been consumed by the current site.
+ *
+ * The delta consumer leaves the archives in the outbox instead of moving them to a
+ * "_completed" folder, so a single delta export definition can be shared by multiple
+ * sites: each site's job skips only the archives its own custom objects list.
+ * The archives themselves are deleted by the platform's /Impex file retention after
+ * 30 days, and the custom objects expire via retention-days on the type, so no
+ * cleanup step is needed.
+ */
+
+const CUSTOM_OBJECT_TYPE = 'AlgoliaConsumedDeltaArchive';
+
+/**
+ * Builds the custom object key for one archive. The storage scope of the custom object
+ * type is "site", so the key only needs to be unique within a site.
+ * @param {string} consumer The consumer name of the delta export
+ * @param {string} deltaExportJobName The name of the delta export
+ * @param {string} archiveName The archive file name (e.g. "000042.zip")
+ * @returns {string} The custom object key
+ */
+function getArchiveKey(consumer, deltaExportJobName, archiveName) {
+    return consumer + '__' + deltaExportJobName + '__' + archiveName;
+}
+
+/**
+ * Returns whether the given archive has already been consumed by the current site.
+ * @param {string} consumer The consumer name of the delta export
+ * @param {string} deltaExportJobName The name of the delta export
+ * @param {string} archiveName The archive file name (e.g. "000042.zip")
+ * @returns {boolean} true if the archive is recorded as consumed for the current site
+ */
+function isConsumed(consumer, deltaExportJobName, archiveName) {
+    const CustomObjectMgr = require('dw/object/CustomObjectMgr');
+    const consumedArchiveCO = CustomObjectMgr.getCustomObject(CUSTOM_OBJECT_TYPE, getArchiveKey(consumer, deltaExportJobName, archiveName));
+    return !empty(consumedArchiveCO);
+}
+
+/**
+ * Records the given archives as consumed by the current site.
+ * An archive that is already recorded (e.g. by a rerun racing an earlier record) is skipped.
+ * @param {string} consumer The consumer name of the delta export
+ * @param {string} deltaExportJobName The name of the delta export
+ * @param {string[]} archiveNames The archive file names to record
+ * @param {string} jobID The ID of the job run that consumed the archives
+ * @returns {boolean} true if all archives were recorded successfully
+ */
+function markConsumed(consumer, deltaExportJobName, archiveNames, jobID) {
+    const CustomObjectMgr = require('dw/object/CustomObjectMgr');
+    const Transaction = require('dw/system/Transaction');
+    const logger = require('*/cartridge/scripts/algolia/helper/jobHelper').getAlgoliaLogger();
+
+    let success = true;
+
+    archiveNames.forEach(function(archiveName) {
+        const archiveKey = getArchiveKey(consumer, deltaExportJobName, archiveName);
+        try {
+            Transaction.wrap(function() {
+                if (!empty(CustomObjectMgr.getCustomObject(CUSTOM_OBJECT_TYPE, archiveKey))) {
+                    return; // already recorded
+                }
+                const consumedArchiveCO = CustomObjectMgr.createCustomObject(CUSTOM_OBJECT_TYPE, archiveKey);
+                consumedArchiveCO.custom.consumer = consumer;
+                consumedArchiveCO.custom.deltaExportJobName = deltaExportJobName;
+                consumedArchiveCO.custom.archiveName = archiveName;
+                consumedArchiveCO.custom.jobID = jobID;
+            });
+        } catch (e) {
+            logger.error('Failed to record consumed delta archive "' + archiveKey + '": ' + e.message);
+            success = false;
+        }
+    });
+
+    return success;
+}
+
+module.exports = {
+    isConsumed: isConsumed,
+    markConsumed: markConsumed,
+};

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -266,12 +266,13 @@ exports.beforeStep = function(parameters, stepExecution) {
     // list all the delta export zips in the folder
     var allDeltaExportZips = fileHelper.getDeltaExportZipList(l0_deltaExportDir);
 
-    // skip the archives this site has already consumed - the archives are left in the outbox
-    // (the platform deletes them after 30 days) so that other sites sharing the same delta export
-    // definition can consume them independently
+    // skip the archives this job has already consumed - the archives are left in the outbox
+    // (the platform deletes them after 30 days) so that other consumers of the same delta export
+    // definition (other sites' jobs, or same-site jobs splitting the work e.g. by locale)
+    // can consume them independently
     deltaExportZips = allDeltaExportZips.filter(function(filename) {
-        if (consumedArchiveTracker.isConsumed(paramConsumer, paramDeltaExportJobName, filename)) {
-            logger.info('Skipping ' + filename + ' (already consumed by this site)');
+        if (consumedArchiveTracker.isConsumed(jobReport.jobID, paramConsumer, paramDeltaExportJobName, filename)) {
+            logger.info('Skipping ' + filename + ' (already consumed by this job)');
             return false;
         }
         return true;
@@ -814,11 +815,11 @@ exports.afterStep = function(success, parameters, stepExecution) {
             jobReport.error = false;
             jobReport.errorMessage = '';
 
-            // after the products have successfully been sent, record the consumed archives for this site
-            // (the archives are left in the outbox for other sites, the platform deletes them after 30 days)
+            // after the products have successfully been sent, record the consumed archives for this job
+            // (the archives are left in the outbox for other consumers, the platform deletes them after 30 days)
             if (!empty(deltaExportZips)) {
                 logger.info('Recording the consumed delta export archives: ' + deltaExportZips);
-                consumedArchiveTracker.markConsumed(paramConsumer, paramDeltaExportJobName, deltaExportZips, jobReport.jobID);
+                consumedArchiveTracker.markConsumed(jobReport.jobID, paramConsumer, paramDeltaExportJobName, deltaExportZips);
             }
         } else {
             jobReport.error = true;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -12,12 +12,12 @@ var recordModel;
 
 // Algolia requires
 var algoliaData, AlgoliaLocalizedProduct, algoliaProductConfig, algoliaIndexingAPI, productFilter, CPObjectIterator, AlgoliaJobReport;
-var fileHelper, jobHelper, requestHelper, modelHelper;
+var fileHelper, jobHelper, requestHelper, modelHelper, consumedArchiveTracker;
 
 // logging-related variables and constants
 var jobReport;
 
-var l0_deltaExportDir, l1_processingDir, l1_completedDir, l1_failedDir;
+var l0_deltaExportDir, l1_processingDir;
 var changedProducts = [], changedProductsIterator;
 var deltaExportZips, siteLocales, attributesToSend;
 var masterAttributes = [], variantAttributes = [];
@@ -79,6 +79,7 @@ exports.beforeStep = function(parameters, stepExecution) {
     jobHelper = require('*/cartridge/scripts/algolia/helper/jobHelper');
     fileHelper = require('*/cartridge/scripts/algolia/helper/fileHelper');
     requestHelper = require('*/cartridge/scripts/algolia/helper/requestHelper');
+    consumedArchiveTracker = require('*/cartridge/scripts/algolia/helper/consumedArchiveTracker');
     algoliaIndexingAPI = require('*/cartridge/scripts/algoliaIndexingAPI');
     logger = jobHelper.getAlgoliaLogger();
     productFilter = require('*/cartridge/scripts/algolia/filters/productFilter');
@@ -263,28 +264,34 @@ exports.beforeStep = function(parameters, stepExecution) {
     }
 
     // list all the delta export zips in the folder
-    deltaExportZips = fileHelper.getDeltaExportZipList(l0_deltaExportDir);
+    var allDeltaExportZips = fileHelper.getDeltaExportZipList(l0_deltaExportDir);
+
+    // skip the archives this site has already consumed - the archives are left in the outbox
+    // (the platform deletes them after 30 days) so that other sites sharing the same delta export
+    // definition can consume them independently
+    deltaExportZips = allDeltaExportZips.filter(function(filename) {
+        if (consumedArchiveTracker.isConsumed(paramConsumer, paramDeltaExportJobName, filename)) {
+            logger.info('Skipping ' + filename + ' (already consumed by this site)');
+            return false;
+        }
+        return true;
+    });
 
     // if there are no files to process, there's no point in continuing
     if (empty(deltaExportZips)) {
-        logger.info('No delta exports found at ' + l0_deltaExportDir.getFullPath());
+        logger.info('No new delta exports to consume at ' + l0_deltaExportDir.getFullPath());
         return; // return with an empty changedProducts object
     }
     logger.info('Delta exports found: ' + deltaExportZips);
 
     // creating empty temporary "_processing" dir
-    l1_processingDir = new File(l0_deltaExportDir, '_processing');
+    // the folder name is site-specific: sites sharing one delta export definition read the same
+    // outbox folder, so a shared "_processing" dir could be wiped by a concurrently starting site job
+    l1_processingDir = new File(l0_deltaExportDir, '_processing_' + Site.getCurrent().getID());
     if (l1_processingDir.exists()) {
         fileHelper.removeFolderRecursively(l1_processingDir);
     }
     l1_processingDir.mkdir();
-
-    // creating "_completed" dir
-    l1_completedDir = new File(l0_deltaExportDir, '_completed');
-    l1_completedDir.mkdir(); // creating "_completed" folder -- does no harm if it already exists
-
-    l1_failedDir = new File(l0_deltaExportDir, '_failed');
-    l1_failedDir.mkdir();
 
     // A price book or inventory list delta contains the IDs of the products that were affected by the change (variant or master). The extraction normalizes each ID to the expected record level: at the 'master' level a changed variant is rolled up to its master, at the 'variant' level a changed master is fanned out to its variants so the inheriting variant records are rebuilt. The catalog path is left untouched because CatalogDeltaExport already emits both master and variants due to its MasterProductExport parameter set to true.
     var recordLevel = (recordModel === RECORD_MODEL_TYPES.MASTER_LEVEL ||
@@ -391,10 +398,9 @@ exports.beforeStep = function(parameters, stepExecution) {
     if (!jobReport.error) {
         changedProductsIterator = new CPObjectIterator(changedProducts);
         logger.info(jobReport.processedItems + ' updated products found. Starting indexing...');
-    } else {
-        logger.info('Moving the Delta export files to the "' + l1_failedDir.getName() + '" directory...');
-        fileHelper.moveDeltaExportFiles(deltaExportZips, l0_deltaExportDir, l1_failedDir);
     }
+    // on extraction error the archives are left in place and not recorded as consumed,
+    // so the next run retries them (an archive caught mid-write parses fine on retry)
 }
 
 /**
@@ -808,10 +814,11 @@ exports.afterStep = function(success, parameters, stepExecution) {
             jobReport.error = false;
             jobReport.errorMessage = '';
 
-            // cleanup: after the products have successfully been sent, move the delta zips from which the productIDs have successfully been extracted and the corresponding products sent to "_completed"
+            // after the products have successfully been sent, record the consumed archives for this site
+            // (the archives are left in the outbox for other sites, the platform deletes them after 30 days)
             if (!empty(deltaExportZips)) {
-                logger.info('Moving the Delta export files to the "_completed" directory...');
-                fileHelper.moveDeltaExportFiles(deltaExportZips, l0_deltaExportDir, l1_completedDir);
+                logger.info('Recording the consumed delta export archives: ' + deltaExportZips);
+                consumedArchiveTracker.markConsumed(paramConsumer, paramDeltaExportJobName, deltaExportZips, jobReport.jobID);
             }
         } else {
             jobReport.error = true;
@@ -845,3 +852,4 @@ exports.__getLocalesForIndexing = function() {
 }
 exports.__INDEXING_APIS = INDEXING_APIS;
 exports.__setIndexingAPI = function(api) { indexingAPI = api; }
+exports.__setDeltaExportZips = function(zips) { deltaExportZips = zips; }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -295,6 +295,9 @@ jest.mock('*/cartridge/scripts/algolia/helper/CPObjectIterator', () => {
 jest.mock('*/cartridge/scripts/algolia/helper/orderHelper', () => {
     return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/helper/orderHelper')
 }, { virtual: true });
+jest.mock('*/cartridge/scripts/algolia/helper/consumedArchiveTracker', () => {
+    return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/helper/consumedArchiveTracker');
+}, {virtual: true});
 jest.mock('*/cartridge/scripts/algolia/helper/fileHelper', () => {
     return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/helper/fileHelper');
 }, {virtual: true});

--- a/metadata/algolia/meta/custom-objecttype-definitions.xml
+++ b/metadata/algolia/meta/custom-objecttype-definitions.xml
@@ -3,10 +3,10 @@
 
     <custom-type type-id="AlgoliaConsumedDeltaArchive">
         <display-name xml:lang="x-default">AlgoliaConsumedDeltaArchive</display-name>
-        <description xml:lang="x-default">Records a delta export archive that has been consumed by an Algolia delta indexing job for the current site. Archives are left in the outbox (the platform deletes them after 30 days), so this record is what prevents the same archive from being processed twice by the same site while letting other sites consume it independently.</description>
+        <description xml:lang="x-default">Records a delta export archive that has been consumed by an Algolia delta indexing job for the current site. Archives are left in the outbox (the platform deletes them after 30 days), so this record is what prevents the same archive from being processed twice by the same site while letting other sites consume it independently. The retention is longer than the platform's 30-day outbox retention so that a record always outlives its archive; an expired record with the archive still present would cause the archive to be reprocessed.</description>
         <staging-mode>no-staging</staging-mode>
         <storage-scope>site</storage-scope>
-        <retention-days>30</retention-days>
+        <retention-days>33</retention-days>
         <key-definition attribute-id="ID">
             <display-name xml:lang="x-default">Custom Object ID</display-name>
             <type>string</type>
@@ -54,6 +54,7 @@
             <attribute-group group-id="consumedArchive">
                 <display-name xml:lang="x-default">Consumed archive</display-name>
                 <description xml:lang="x-default">Information about the consumed delta export archive</description>
+                <attribute attribute-id="ID"/>
                 <attribute attribute-id="consumer"/>
                 <attribute attribute-id="deltaExportJobName"/>
                 <attribute attribute-id="archiveName"/>

--- a/metadata/algolia/meta/custom-objecttype-definitions.xml
+++ b/metadata/algolia/meta/custom-objecttype-definitions.xml
@@ -3,7 +3,7 @@
 
     <custom-type type-id="AlgoliaConsumedDeltaArchive">
         <display-name xml:lang="x-default">AlgoliaConsumedDeltaArchive</display-name>
-        <description xml:lang="x-default">Records a delta export archive that has been consumed by an Algolia delta indexing job for the current site. Archives are left in the outbox (the platform deletes them after 30 days), so this record is what prevents the same archive from being processed twice by the same site while letting other sites consume it independently. The retention is longer than the platform's 30-day outbox retention so that a record always outlives its archive; an expired record with the archive still present would cause the archive to be reprocessed.</description>
+        <description xml:lang="x-default">Records a delta export archive that has been consumed by an Algolia delta indexing job for the current site. Archives are left in the outbox (the platform deletes them after 30 days), so this record is what prevents the same archive from being processed twice by the same job while letting other consumers (other sites' jobs, or same-site jobs splitting the work) consume it independently. The retention is longer than the platform's 30-day outbox retention so that a record always outlives its archive; an expired record with the archive still present would cause the archive to be reprocessed.</description>
         <staging-mode>no-staging</staging-mode>
         <storage-scope>site</storage-scope>
         <retention-days>33</retention-days>
@@ -42,7 +42,7 @@
             </attribute-definition>
             <attribute-definition attribute-id="jobID">
                 <display-name xml:lang="x-default">Job ID</display-name>
-                <description xml:lang="x-default">The ID of the job run that consumed the archive.</description>
+                <description xml:lang="x-default">The ID of the job that consumed the archive. Part of the custom object key: consumption is tracked per job, so several jobs on the same site can consume the same delta export independently.</description>
                 <type>string</type>
                 <localizable-flag>false</localizable-flag>
                 <mandatory-flag>false</mandatory-flag>

--- a/metadata/algolia/meta/custom-objecttype-definitions.xml
+++ b/metadata/algolia/meta/custom-objecttype-definitions.xml
@@ -1,6 +1,67 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://www.demandware.com/xml/impex/metadata/2006-10-31">
 
+    <custom-type type-id="AlgoliaConsumedDeltaArchive">
+        <display-name xml:lang="x-default">AlgoliaConsumedDeltaArchive</display-name>
+        <description xml:lang="x-default">Records a delta export archive that has been consumed by an Algolia delta indexing job for the current site. Archives are left in the outbox (the platform deletes them after 30 days), so this record is what prevents the same archive from being processed twice by the same site while letting other sites consume it independently.</description>
+        <staging-mode>no-staging</staging-mode>
+        <storage-scope>site</storage-scope>
+        <retention-days>30</retention-days>
+        <key-definition attribute-id="ID">
+            <display-name xml:lang="x-default">Custom Object ID</display-name>
+            <type>string</type>
+            <min-length>0</min-length>
+        </key-definition>
+        <attribute-definitions>
+            <attribute-definition attribute-id="archiveName">
+                <display-name xml:lang="x-default">Archive name</display-name>
+                <description xml:lang="x-default">The file name of the consumed delta export archive (e.g. 000042.zip).</description>
+                <type>string</type>
+                <localizable-flag>false</localizable-flag>
+                <mandatory-flag>true</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <min-length>0</min-length>
+            </attribute-definition>
+            <attribute-definition attribute-id="consumer">
+                <display-name xml:lang="x-default">Consumer</display-name>
+                <description xml:lang="x-default">The consumer name of the delta export the archive belongs to. Determines the WebDAV outbox folder together with the delta export job name.</description>
+                <type>string</type>
+                <localizable-flag>false</localizable-flag>
+                <mandatory-flag>true</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <min-length>0</min-length>
+            </attribute-definition>
+            <attribute-definition attribute-id="deltaExportJobName">
+                <display-name xml:lang="x-default">Delta export job name</display-name>
+                <description xml:lang="x-default">The name of the delta export the archive belongs to. Determines the WebDAV outbox folder together with the consumer name.</description>
+                <type>string</type>
+                <localizable-flag>false</localizable-flag>
+                <mandatory-flag>true</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <min-length>0</min-length>
+            </attribute-definition>
+            <attribute-definition attribute-id="jobID">
+                <display-name xml:lang="x-default">Job ID</display-name>
+                <description xml:lang="x-default">The ID of the job run that consumed the archive.</description>
+                <type>string</type>
+                <localizable-flag>false</localizable-flag>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <min-length>0</min-length>
+            </attribute-definition>
+        </attribute-definitions>
+        <group-definitions>
+            <attribute-group group-id="consumedArchive">
+                <display-name xml:lang="x-default">Consumed archive</display-name>
+                <description xml:lang="x-default">Information about the consumed delta export archive</description>
+                <attribute attribute-id="consumer"/>
+                <attribute attribute-id="deltaExportJobName"/>
+                <attribute attribute-id="archiveName"/>
+                <attribute attribute-id="jobID"/>
+            </attribute-group>
+        </group-definitions>
+    </custom-type>
+
     <custom-type type-id="AlgoliaJobReport">
         <display-name xml:lang="x-default">AlgoliaJobReport</display-name>
         <description xml:lang="x-default">Contains a report for a single Algolia job run.</description>

--- a/test/unit/int_algolia/scripts/algolia/helper/consumedArchiveTracker.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/consumedArchiveTracker.test.js
@@ -1,0 +1,76 @@
+const GlobalMock = require('../../../../../mocks/global');
+global.empty = GlobalMock.empty;
+
+const CustomObjectMgr = require('dw/object/CustomObjectMgr');
+
+const consumedArchiveTracker = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/consumedArchiveTracker');
+
+const CUSTOM_OBJECT_TYPE = 'AlgoliaConsumedDeltaArchive';
+
+describe('isConsumed', () => {
+    test('returns false when no custom object exists for the archive', () => {
+        CustomObjectMgr.getCustomObject.mockReturnValueOnce(null);
+
+        expect(consumedArchiveTracker.isConsumed('algolia', 'pricebookDeltaExport', '000001.zip')).toBe(false);
+        expect(CustomObjectMgr.getCustomObject).toHaveBeenCalledWith(CUSTOM_OBJECT_TYPE, 'algolia__pricebookDeltaExport__000001.zip');
+    });
+
+    test('returns true when a custom object exists for the archive', () => {
+        CustomObjectMgr.getCustomObject.mockReturnValueOnce({ custom: {} });
+
+        expect(consumedArchiveTracker.isConsumed('algolia', 'pricebookDeltaExport', '000001.zip')).toBe(true);
+    });
+});
+
+describe('markConsumed', () => {
+    test('creates one custom object per archive with the expected key and attributes', () => {
+        CustomObjectMgr.getCustomObject.mockReturnValue(null);
+        const createdCustomObjects = [];
+        CustomObjectMgr.createCustomObject.mockImplementation(() => {
+            const customObject = { custom: {} };
+            createdCustomObjects.push(customObject);
+            return customObject;
+        });
+
+        const success = consumedArchiveTracker.markConsumed('algolia', 'inventoryDeltaExport', ['000001.zip', '000002.zip'], 'TestJobID');
+
+        expect(success).toBe(true);
+        expect(CustomObjectMgr.createCustomObject).toHaveBeenCalledTimes(2);
+        expect(CustomObjectMgr.createCustomObject).toHaveBeenNthCalledWith(1, CUSTOM_OBJECT_TYPE, 'algolia__inventoryDeltaExport__000001.zip');
+        expect(CustomObjectMgr.createCustomObject).toHaveBeenNthCalledWith(2, CUSTOM_OBJECT_TYPE, 'algolia__inventoryDeltaExport__000002.zip');
+        expect(createdCustomObjects[0].custom).toEqual({
+            consumer: 'algolia',
+            deltaExportJobName: 'inventoryDeltaExport',
+            archiveName: '000001.zip',
+            jobID: 'TestJobID',
+        });
+
+        CustomObjectMgr.getCustomObject.mockReset();
+    });
+
+    test('skips archives that are already recorded', () => {
+        CustomObjectMgr.getCustomObject.mockReturnValueOnce({ custom: {} }); // 000001.zip already recorded
+        CustomObjectMgr.getCustomObject.mockReturnValueOnce(null);
+
+        const success = consumedArchiveTracker.markConsumed('algolia', 'pricebookDeltaExport', ['000001.zip', '000002.zip'], 'TestJobID');
+
+        expect(success).toBe(true);
+        expect(CustomObjectMgr.createCustomObject).toHaveBeenCalledTimes(1);
+        expect(CustomObjectMgr.createCustomObject).toHaveBeenCalledWith(CUSTOM_OBJECT_TYPE, 'algolia__pricebookDeltaExport__000002.zip');
+    });
+
+    test('returns false when creating a custom object fails, but still records the others', () => {
+        CustomObjectMgr.getCustomObject.mockReturnValue(null);
+        CustomObjectMgr.createCustomObject.mockImplementationOnce(() => {
+            throw new Error('duplicate key');
+        });
+        CustomObjectMgr.createCustomObject.mockImplementationOnce(() => ({ custom: {} }));
+
+        const success = consumedArchiveTracker.markConsumed('algolia', 'pricebookDeltaExport', ['000001.zip', '000002.zip'], 'TestJobID');
+
+        expect(success).toBe(false);
+        expect(CustomObjectMgr.createCustomObject).toHaveBeenCalledTimes(2);
+
+        CustomObjectMgr.getCustomObject.mockReset();
+    });
+});

--- a/test/unit/int_algolia/scripts/algolia/helper/consumedArchiveTracker.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/consumedArchiveTracker.test.js
@@ -11,14 +11,14 @@ describe('isConsumed', () => {
     test('returns false when no custom object exists for the archive', () => {
         CustomObjectMgr.getCustomObject.mockReturnValueOnce(null);
 
-        expect(consumedArchiveTracker.isConsumed('algolia', 'pricebookDeltaExport', '000001.zip')).toBe(false);
-        expect(CustomObjectMgr.getCustomObject).toHaveBeenCalledWith(CUSTOM_OBJECT_TYPE, 'algolia__pricebookDeltaExport__000001.zip');
+        expect(consumedArchiveTracker.isConsumed('AlgoliaPriceDeltaIndex', 'algolia', 'pricebookDeltaExport', '000001.zip')).toBe(false);
+        expect(CustomObjectMgr.getCustomObject).toHaveBeenCalledWith(CUSTOM_OBJECT_TYPE, 'AlgoliaPriceDeltaIndex__algolia__pricebookDeltaExport__000001.zip');
     });
 
     test('returns true when a custom object exists for the archive', () => {
         CustomObjectMgr.getCustomObject.mockReturnValueOnce({ custom: {} });
 
-        expect(consumedArchiveTracker.isConsumed('algolia', 'pricebookDeltaExport', '000001.zip')).toBe(true);
+        expect(consumedArchiveTracker.isConsumed('AlgoliaPriceDeltaIndex', 'algolia', 'pricebookDeltaExport', '000001.zip')).toBe(true);
     });
 });
 
@@ -32,17 +32,17 @@ describe('markConsumed', () => {
             return customObject;
         });
 
-        const success = consumedArchiveTracker.markConsumed('algolia', 'inventoryDeltaExport', ['000001.zip', '000002.zip'], 'TestJobID');
+        const success = consumedArchiveTracker.markConsumed('AlgoliaInventoryDeltaIndex', 'algolia', 'inventoryDeltaExport', ['000001.zip', '000002.zip']);
 
         expect(success).toBe(true);
         expect(CustomObjectMgr.createCustomObject).toHaveBeenCalledTimes(2);
-        expect(CustomObjectMgr.createCustomObject).toHaveBeenNthCalledWith(1, CUSTOM_OBJECT_TYPE, 'algolia__inventoryDeltaExport__000001.zip');
-        expect(CustomObjectMgr.createCustomObject).toHaveBeenNthCalledWith(2, CUSTOM_OBJECT_TYPE, 'algolia__inventoryDeltaExport__000002.zip');
+        expect(CustomObjectMgr.createCustomObject).toHaveBeenNthCalledWith(1, CUSTOM_OBJECT_TYPE, 'AlgoliaInventoryDeltaIndex__algolia__inventoryDeltaExport__000001.zip');
+        expect(CustomObjectMgr.createCustomObject).toHaveBeenNthCalledWith(2, CUSTOM_OBJECT_TYPE, 'AlgoliaInventoryDeltaIndex__algolia__inventoryDeltaExport__000002.zip');
         expect(createdCustomObjects[0].custom).toEqual({
             consumer: 'algolia',
             deltaExportJobName: 'inventoryDeltaExport',
             archiveName: '000001.zip',
-            jobID: 'TestJobID',
+            jobID: 'AlgoliaInventoryDeltaIndex',
         });
 
         CustomObjectMgr.getCustomObject.mockReset();
@@ -52,11 +52,24 @@ describe('markConsumed', () => {
         CustomObjectMgr.getCustomObject.mockReturnValueOnce({ custom: {} }); // 000001.zip already recorded
         CustomObjectMgr.getCustomObject.mockReturnValueOnce(null);
 
-        const success = consumedArchiveTracker.markConsumed('algolia', 'pricebookDeltaExport', ['000001.zip', '000002.zip'], 'TestJobID');
+        const success = consumedArchiveTracker.markConsumed('AlgoliaPriceDeltaIndex', 'algolia', 'pricebookDeltaExport', ['000001.zip', '000002.zip']);
 
         expect(success).toBe(true);
         expect(CustomObjectMgr.createCustomObject).toHaveBeenCalledTimes(1);
-        expect(CustomObjectMgr.createCustomObject).toHaveBeenCalledWith(CUSTOM_OBJECT_TYPE, 'algolia__pricebookDeltaExport__000002.zip');
+        expect(CustomObjectMgr.createCustomObject).toHaveBeenCalledWith(CUSTOM_OBJECT_TYPE, 'AlgoliaPriceDeltaIndex__algolia__pricebookDeltaExport__000002.zip');
+    });
+
+    test('records the same archive independently for different consuming jobs', () => {
+        CustomObjectMgr.getCustomObject.mockReturnValue(null);
+
+        consumedArchiveTracker.markConsumed('AlgoliaPriceDeltaIndex_locales1', 'algolia', 'pricebookDeltaExport', ['000001.zip']);
+        consumedArchiveTracker.markConsumed('AlgoliaPriceDeltaIndex_locales2', 'algolia', 'pricebookDeltaExport', ['000001.zip']);
+
+        expect(CustomObjectMgr.createCustomObject).toHaveBeenCalledTimes(2);
+        expect(CustomObjectMgr.createCustomObject).toHaveBeenNthCalledWith(1, CUSTOM_OBJECT_TYPE, 'AlgoliaPriceDeltaIndex_locales1__algolia__pricebookDeltaExport__000001.zip');
+        expect(CustomObjectMgr.createCustomObject).toHaveBeenNthCalledWith(2, CUSTOM_OBJECT_TYPE, 'AlgoliaPriceDeltaIndex_locales2__algolia__pricebookDeltaExport__000001.zip');
+
+        CustomObjectMgr.getCustomObject.mockReset();
     });
 
     test('returns false when creating a custom object fails, but still records the others', () => {
@@ -66,7 +79,7 @@ describe('markConsumed', () => {
         });
         CustomObjectMgr.createCustomObject.mockImplementationOnce(() => ({ custom: {} }));
 
-        const success = consumedArchiveTracker.markConsumed('algolia', 'pricebookDeltaExport', ['000001.zip', '000002.zip'], 'TestJobID');
+        const success = consumedArchiveTracker.markConsumed('AlgoliaPriceDeltaIndex', 'algolia', 'pricebookDeltaExport', ['000001.zip', '000002.zip']);
 
         expect(success).toBe(false);
         expect(CustomObjectMgr.createCustomObject).toHaveBeenCalledTimes(2);

--- a/test/unit/int_algolia/scripts/algolia/helper/consumedArchiveTracker.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/consumedArchiveTracker.test.js
@@ -72,17 +72,27 @@ describe('markConsumed', () => {
         CustomObjectMgr.getCustomObject.mockReset();
     });
 
-    test('returns false when creating a custom object fails, but still records the others', () => {
+    test('a failure on one archive does not stop the others from being recorded', () => {
         CustomObjectMgr.getCustomObject.mockReturnValue(null);
         CustomObjectMgr.createCustomObject.mockImplementationOnce(() => {
             throw new Error('duplicate key');
         });
-        CustomObjectMgr.createCustomObject.mockImplementationOnce(() => ({ custom: {} }));
+        const survivingCustomObject = { custom: {} };
+        CustomObjectMgr.createCustomObject.mockImplementationOnce(() => survivingCustomObject);
 
         const success = consumedArchiveTracker.markConsumed('AlgoliaPriceDeltaIndex', 'algolia', 'pricebookDeltaExport', ['000001.zip', '000002.zip']);
 
+        // the archive that failed to record is reflected in the return value...
         expect(success).toBe(false);
+        // ...but the one after it is still recorded, with the correct key and attributes
         expect(CustomObjectMgr.createCustomObject).toHaveBeenCalledTimes(2);
+        expect(CustomObjectMgr.createCustomObject).toHaveBeenNthCalledWith(2, CUSTOM_OBJECT_TYPE, 'AlgoliaPriceDeltaIndex__algolia__pricebookDeltaExport__000002.zip');
+        expect(survivingCustomObject.custom).toEqual({
+            consumer: 'algolia',
+            deltaExportJobName: 'pricebookDeltaExport',
+            archiveName: '000002.zip',
+            jobID: 'AlgoliaPriceDeltaIndex',
+        });
 
         CustomObjectMgr.getCustomObject.mockReset();
     });

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
@@ -22,6 +22,24 @@ jest.mock('*/cartridge/scripts/algolia/helper/requestHelper', () => {
     }
 }, {virtual: true});
 
+let mockZipList = [];
+jest.mock('*/cartridge/scripts/algolia/helper/fileHelper', () => {
+    const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/fileHelper');
+    return {
+        ...originalModule,
+        getDeltaExportZipList: jest.fn(() => mockZipList),
+    }
+}, {virtual: true});
+
+const mockIsConsumed = jest.fn(() => false);
+const mockMarkConsumed = jest.fn(() => true);
+jest.mock('*/cartridge/scripts/algolia/helper/consumedArchiveTracker', () => {
+    return {
+        isConsumed: mockIsConsumed,
+        markConsumed: mockMarkConsumed,
+    }
+}, {virtual: true});
+
 let mockLocalesForIndexing;
 jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => {
     const originalModule = jest.requireActual('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaData');
@@ -62,6 +80,7 @@ const job = require('../../../../../../cartridges/int_algolia/cartridge/scripts/
 
 beforeEach(() => {
     mockLocalesForIndexing = [];
+    mockZipList = [];
     mockGroupRecordsForIngestionAPI.mockReset();
     mockSendGroupedIngestionAPIRecords.mockReset();
     delete global.customPreferences['Algolia_IndexingAPI'];
@@ -246,6 +265,51 @@ describe('send', () => {
         job.send(makeChunk(1));
 
         expect(mockSendGroupedIngestionAPIRecords).toHaveBeenCalledWith({});
+    });
+});
+
+describe('archive consumption tracking', () => {
+    test('beforeStep skips archives already consumed by this site', () => {
+        mockZipList = ['000001.zip', '000002.zip'];
+        mockIsConsumed.mockReturnValue(true);
+
+        job.beforeStep(parameters, stepExecution);
+
+        expect(mockIsConsumed).toHaveBeenCalledWith('algolia', 'productDeltaExport', '000001.zip');
+        expect(mockIsConsumed).toHaveBeenCalledWith('algolia', 'productDeltaExport', '000002.zip');
+
+        // all archives were filtered out, so a successful run has nothing new to record
+        job.afterStep(true);
+        expect(mockMarkConsumed).not.toHaveBeenCalled();
+
+        mockIsConsumed.mockReturnValue(false);
+    });
+
+    test('afterStep records the consumed archives on success', () => {
+        job.beforeStep(parameters, stepExecution);
+        job.__setDeltaExportZips(['000001.zip', '000002.zip']);
+
+        job.afterStep(true);
+
+        expect(mockMarkConsumed).toHaveBeenCalledWith('algolia', 'productDeltaExport', ['000001.zip', '000002.zip'], 'TestJobID');
+    });
+
+    test('afterStep does not record the archives when the failure threshold is exceeded', () => {
+        job.beforeStep(parameters, stepExecution);
+        job.__setDeltaExportZips(['000001.zip']);
+        job.__getJobReport().recordsFailed = 6;
+        job.__getJobReport().recordsToSend = 100;
+
+        expect(() => job.afterStep(true)).toThrow();
+        expect(mockMarkConsumed).not.toHaveBeenCalled();
+    });
+
+    test('afterStep does not record the archives when a previous step phase failed', () => {
+        job.beforeStep(parameters, stepExecution);
+        job.__setDeltaExportZips(['000001.zip']);
+
+        expect(() => job.afterStep(false)).toThrow();
+        expect(mockMarkConsumed).not.toHaveBeenCalled();
     });
 });
 

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
@@ -269,14 +269,14 @@ describe('send', () => {
 });
 
 describe('archive consumption tracking', () => {
-    test('beforeStep skips archives already consumed by this site', () => {
+    test('beforeStep skips archives already consumed by this job', () => {
         mockZipList = ['000001.zip', '000002.zip'];
         mockIsConsumed.mockReturnValue(true);
 
         job.beforeStep(parameters, stepExecution);
 
-        expect(mockIsConsumed).toHaveBeenCalledWith('algolia', 'productDeltaExport', '000001.zip');
-        expect(mockIsConsumed).toHaveBeenCalledWith('algolia', 'productDeltaExport', '000002.zip');
+        expect(mockIsConsumed).toHaveBeenCalledWith('TestJobID', 'algolia', 'productDeltaExport', '000001.zip');
+        expect(mockIsConsumed).toHaveBeenCalledWith('TestJobID', 'algolia', 'productDeltaExport', '000002.zip');
 
         // all archives were filtered out, so a successful run has nothing new to record
         job.afterStep(true);
@@ -291,7 +291,7 @@ describe('archive consumption tracking', () => {
 
         job.afterStep(true);
 
-        expect(mockMarkConsumed).toHaveBeenCalledWith('algolia', 'productDeltaExport', ['000001.zip', '000002.zip'], 'TestJobID');
+        expect(mockMarkConsumed).toHaveBeenCalledWith('TestJobID', 'algolia', 'productDeltaExport', ['000001.zip', '000002.zip']);
     });
 
     test('afterStep does not record the archives when the failure threshold is exceeded', () => {


### PR DESCRIPTION
Replaces the delta consumer's `_completed` / `_failed` archive moves with a custom-object record of which archives each job has consumed, leaving the archives in the outbox for the platform's 30-day `/Impex` retention to purge. This lets one delta export definition be consumed independently by multiple sites and by multiple jobs on the same site, which the move-based approach could not do: the first job to move an archive hid it from every other consumer. This should also solve [SFCC-505](https://algolia.atlassian.net/browse/SFCC-505) (need to confirm on that ticket).

## Why
Price and inventory delta exports are standalone scheduled Delta Export definitions with a single archive stream. When a price book or inventory list is shared across sites (or a merchant splits indexing across jobs, e.g. by locale via `localesForIndexing`), every consumer needs to read the same archives. The `_completed` move removed an archive after the first consumer, so the others silently indexed stale data.

## Changes

- **New helper `consumedArchiveTracker.js`** - `isConsumed()` and `markConsumed()` over a new `AlgoliaConsumedDeltaArchive` custom object. Key is `<jobID>__<consumer>__<deltaExportJobName>__<archiveName>`: the job ID is prepended so the tail still mirrors the archive's outbox path, and it is what separates consumers within a site (site storage scope separates sites). `markConsumed()` skips already-recorded keys and logs-but-continues on a create failure.
- **New custom object type `AlgoliaConsumedDeltaArchive`** (mirrors `AlgoliaJobReport`): `storage-scope = site`, `no-staging`, `retention-days = 33`. The retention deliberately exceeds the 30-day outbox window so a record always outlives its archive; the key `ID` is included in the attribute group so BM's New form renders the field.
- **`algoliaProductDeltaIndex.js`** - `beforeStep` filters the zip list through `isConsumed`; `afterStep` calls `markConsumed` under the same success condition that previously triggered the `_completed` move. Removed the `_completed`/`_failed` directories and the move-to-`_failed` on extraction error - a failed archive now stays in place, unrecorded, and is retried next run. The temp dir is now `_processing_<siteID>` to prevent one site's run from wiping another's work area in a shared outbox.
- **Tests** - `consumedArchiveTracker.test.js` (key construction, hit/miss, per-archive creation, already-recorded skip, independent recording across jobs, create-failure tolerance) and a new tracking block in the step test (skip-consumed in `beforeStep`, record-on-success and no-record-on-failure in `afterStep`). `jest.setup.js` maps the new helper.

## Behavior changes worth noting for review

- **Failure semantics:** an unparseable/mid-write archive now keeps the job in error and is retried every run until it parses or the platform purges it (was: moved to `_failed`, silently dropped). Transient failures self-heal; genuinely corrupt archives fail loudly and are cleared by deleting the file over WebDAV.
- **Job rename:** because records are keyed by job ID, renaming a consuming job orphans its records and it reprocesses whatever is still in the outbox once - redundant but convergent, since records are rebuilt from live database state (`fullRecordUpdate`).

## Deployment note

The `AlgoliaConsumedDeltaArchive` type must be imported (site metadata import of `custom-objecttype-definitions.xml`) before the job runs, otherwise `markConsumed` throws in `afterStep` and the run reports an error even though indexing succeeded (archives are then reprocessed next run).

[SFCC-505]: https://algolia.atlassian.net/browse/SFCC-505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ