### PR TITLE
feat: [SFCC-463][SFCC-534] Minor fixes and optimizations

### DIFF
--- a/cartridges/bm_algolia/cartridge/scripts/helper/BMHelper.js
+++ b/cartridges/bm_algolia/cartridge/scripts/helper/BMHelper.js
@@ -30,9 +30,17 @@ function getLatestCOReportsByJob() {
     let reportsByJob = [];
     for (let i = 0; i < uniqueJobIDs.length; i++) {
         let jobID = uniqueJobIDs[i];
+
+        // Precompute the deep link once per job so the template never calls a platform
+        // API (URLUtils/CSRFProtection) during rendering. An empty string means the link
+        // could not be built and the template renders the job ID as plain text.
+        let jobBMLink = getJobBMLink(jobID);
+
         let reports = CustomObjectMgr.queryCustomObjects('AlgoliaJobReport', 'custom.jobID = {0} ', 'creationDate desc', jobID).asList().toArray();
         let formattedReports = reports.map(function(report) {
-            return new AlgoliaJobReport().formatCustomObject(report);
+            let formattedReport = new AlgoliaJobReport().formatCustomObject(report);
+            formattedReport.bmLink = jobBMLink;
+            return formattedReport;
         });
         reportsByJob.push(formattedReports.slice(0, nrReportsPerJob)); // last three reports only
     }
@@ -41,7 +49,7 @@ function getLatestCOReportsByJob() {
 }
 
 /**
- * Returns the Business Manager link for a job
+ * Returns the Business Manager link for a job, or an empty string if the link cannot be built
  * @param {string} jobID - the ID of the job
  * @returns {string} - the Business Manager link for the job
  */
@@ -49,12 +57,19 @@ function getJobBMLink(jobID) {
     const URLUtils = require('dw/web/URLUtils');
     const CSRFProtection = require('dw/web/CSRFProtection');
 
-    let csrfToken = CSRFProtection.generateToken();
-    let jobURL = URLUtils.https('ViewApplication-BM', 'csrf_token', csrfToken).toString() +
-        '#/?job#editor!id!' + jobID +
-        '!config!' + jobID + '!domain!Sites!tab!schedule-and-history';
+    try {
+        let csrfToken = CSRFProtection.generateToken();
+        let jobURL = URLUtils.https('ViewApplication-BM', 'csrf_token', csrfToken).toString() +
+            '#/?job#editor!id!' + jobID +
+            '!config!' + jobID + '!domain!Sites!tab!schedule-and-history';
 
-    return jobURL;
+        return jobURL;
+    } catch (e) { // eslint-disable-line no-unused-vars
+        // Building the deep link relies on CSRF token generation and URL resolution, both of
+        // which depend on the request context. If either fails, return an empty string so the
+        // caller can render the job ID as plain text instead of aborting the page.
+        return '';
+    }
 }
 
 module.exports = {

--- a/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
+++ b/cartridges/bm_algolia/cartridge/templates/default/algoliabm/dashboard/index.isml
@@ -396,8 +396,6 @@
     <iselse/>
         <iscomment> displaying reports </iscomment>
 
-        <isset name="BMHelper" value="${require('~/cartridge/scripts/helper/BMHelper.js')}" scope="page"/>
-
         <isloop items="${pdict.latestReports}" var="job">
             <table border="1" cellpadding="0" cellspacing="0" id="algolia-report-table">
                 <tbody>
@@ -406,9 +404,13 @@
                         <isif condition="${status.first}">
                             <tr>
                                 <td class="table_header center tab-title" colspan="7">
-                                    <a href="${BMHelper.getJobBMLink(log.jobID)}" target="_blank">
+                                    <isif condition="${!empty(log.bmLink)}">
+                                        <a href="${log.bmLink}" target="_blank" rel="noreferrer">
+                                            <isprint value="${log.jobID}" encoding="jshtml" />
+                                        </a>
+                                    <iselse/>
                                         <isprint value="${log.jobID}" encoding="jshtml" />
-                                    </a>
+                                    </isif>
                                 </td>
                                 <td class="table_header center tab-title" colspan="1">
                                     ${Resource.msg('algolia.label.jobtype', 'algolia', null)} <isprint value="${log.jobType}" encoding="jshtml" />

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -270,13 +270,21 @@ exports.beforeStep = function(parameters, stepExecution) {
     // (the platform deletes them after 30 days) so that other consumers of the same delta export
     // definition (other sites' jobs, or same-site jobs splitting the work e.g. by locale)
     // can consume them independently
+    var alreadyConsumedArchives = [];
     deltaExportZips = allDeltaExportZips.filter(function(filename) {
         if (consumedArchiveTracker.isConsumed(jobReport.jobID, paramConsumer, paramDeltaExportJobName, filename)) {
-            logger.info('Skipping ' + filename + ' (already consumed by this job)');
+            alreadyConsumedArchives.push(filename);
             return false;
         }
         return true;
     });
+
+    // consumed archives accumulate in the outbox until the platform deletes them, so log them
+    // as a single summary line to keep the log readable
+    if (alreadyConsumedArchives.length > 0) {
+        logger.info('Skipping ' + alreadyConsumedArchives.length + ' archive(s) already consumed by this job');
+        logger.debug('Archives already consumed by this job: ' + alreadyConsumedArchives.join(', '));
+    }
 
     // if there are no files to process, there's no point in continuing
     if (empty(deltaExportZips)) {
@@ -286,9 +294,12 @@ exports.beforeStep = function(parameters, stepExecution) {
     logger.info('Delta exports found: ' + deltaExportZips);
 
     // creating empty temporary "_processing" dir
-    // the folder name is site-specific: sites sharing one delta export definition read the same
-    // outbox folder, so a shared "_processing" dir could be wiped by a concurrently starting site job
-    l1_processingDir = new File(l0_deltaExportDir, '_processing_' + Site.getCurrent().getID());
+    // the folder name is site- and job-specific: consumers of a shared delta export definition
+    // (other sites' jobs, or same-site jobs splitting the work) read the same outbox folder, so a
+    // shared "_processing" dir could be wiped by a concurrently starting consumer job. The job ID
+    // is sanitized because job IDs can contain characters that are not safe in folder names.
+    var sanitizedJobID = jobReport.jobID.replace(/[^a-zA-Z0-9._-]/g, '_');
+    l1_processingDir = new File(l0_deltaExportDir, '_processing_' + Site.getCurrent().getID() + '_' + sanitizedJobID);
     if (l1_processingDir.exists()) {
         fileHelper.removeFolderRecursively(l1_processingDir);
     }
@@ -306,9 +317,11 @@ exports.beforeStep = function(parameters, stepExecution) {
 
         // this will create a structure like so: "l0_deltaExportDir/_processing/000001.zip/ebff9c4e-ac8c-4954-8303-8e68ec8b190d/catalogs/...
         var l2_tempZipDir = new File(l1_processingDir, filename);
-        if (l2_tempZipDir.mkdir()) { // mkdir() returns a success boolean
-            currentZipFile.unzip(l2_tempZipDir);
+        if (!l2_tempZipDir.mkdir()) { // mkdir() returns a success boolean
+            // fail loudly here - a silently skipped unzip would only fail further down with a misleading error
+            throw new Error('Could not create the temporary directory "' + l2_tempZipDir.getFullPath() + '" for extracting ' + filename);
         }
+        currentZipFile.unzip(l2_tempZipDir);
 
         // there's a folder with a UUID as a name one level down, we need to open that
         var l3_uuidDir = fileHelper.getFirstChildFolder(l2_tempZipDir); // _processing/000001.zip/ebff9c4e-ac8c-4954-8303-8e68ec8b190d/

--- a/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/steps/algoliaProductDeltaIndex.js
@@ -318,7 +318,6 @@ exports.beforeStep = function(parameters, stepExecution) {
         // this will create a structure like so: "l0_deltaExportDir/_processing/000001.zip/ebff9c4e-ac8c-4954-8303-8e68ec8b190d/catalogs/...
         var l2_tempZipDir = new File(l1_processingDir, filename);
         if (!l2_tempZipDir.mkdir()) { // mkdir() returns a success boolean
-            // fail loudly here - a silently skipped unzip would only fail further down with a misleading error
             throw new Error('Could not create the temporary directory "' + l2_tempZipDir.getFullPath() + '" for extracting ' + filename);
         }
         currentZipFile.unzip(l2_tempZipDir);

--- a/test/unit/bm_algolia/scripts/helper/BMHelper.test.js
+++ b/test/unit/bm_algolia/scripts/helper/BMHelper.test.js
@@ -2,6 +2,16 @@ const CustomObjectMgr = require('dw/object/CustomObjectMgr');
 const AlgoliaJobReport = require('*/cartridge/scripts/algolia/helper/AlgoliaJobReport');
 const BMHelper = require('../../../../../cartridges/bm_algolia/cartridge/scripts/helper/BMHelper');
 
+/**
+ * Builds the BM deep link the mocked URLUtils/CSRFProtection produce for a job ID.
+ * @param {string} jobID the job ID
+ * @returns {string} the expected link
+ */
+function expectedBMLink(jobID) {
+    return 'https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/ViewApplication-BM?csrf_token=csrfToken#/?job#editor!id!' +
+        jobID + '!config!' + jobID + '!domain!Sites!tab!schedule-and-history';
+}
+
 describe('getLatestCOReportsByJob', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -52,17 +62,18 @@ describe('getLatestCOReportsByJob', () => {
             };
         });
 
+        // every formatted report carries the deep link of its job, precomputed by the helper
         const job1Reports = [
-            { custom: { jobID: 'job1' }, creationDate: new Date('2023-01-01') },
-            { custom: { jobID: 'job1' }, creationDate: new Date('2023-01-02') },
-            { custom: { jobID: 'job1' }, creationDate: new Date('2023-01-03') },
+            { custom: { jobID: 'job1' }, creationDate: new Date('2023-01-01'), bmLink: expectedBMLink('job1') },
+            { custom: { jobID: 'job1' }, creationDate: new Date('2023-01-02'), bmLink: expectedBMLink('job1') },
+            { custom: { jobID: 'job1' }, creationDate: new Date('2023-01-03'), bmLink: expectedBMLink('job1') },
         ];
         const job2Reports = [
-            { custom: { jobID: 'job2' }, creationDate: new Date('2023-01-01') },
-            { custom: { jobID: 'job2' }, creationDate: new Date('2023-01-02') },
+            { custom: { jobID: 'job2' }, creationDate: new Date('2023-01-01'), bmLink: expectedBMLink('job2') },
+            { custom: { jobID: 'job2' }, creationDate: new Date('2023-01-02'), bmLink: expectedBMLink('job2') },
         ];
         const job3Reports = [
-            { custom: { jobID: 'job3' }, creationDate: new Date('2023-01-01') },
+            { custom: { jobID: 'job3' }, creationDate: new Date('2023-01-01'), bmLink: expectedBMLink('job3') },
         ];
         AlgoliaJobReport.prototype.formatCustomObject = jest.fn((report) => report);
 
@@ -102,9 +113,22 @@ describe('getLatestCOReportsByJob', () => {
 });
 
 describe('getJobBMLink', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
     it('should return the Business Manager link for a job', () => {
         const result = BMHelper.getJobBMLink('AlgoliaProductIndex_v2');
 
-        expect(result).toBe('https://test.commercecloud.salesforce.com/on/demandware.store/Sites-Algolia_SFRA-Site/default/ViewApplication-BM?csrf_token=csrfToken#/?job#editor!id!AlgoliaProductIndex_v2!config!AlgoliaProductIndex_v2!domain!Sites!tab!schedule-and-history');
+        expect(result).toBe(expectedBMLink('AlgoliaProductIndex_v2'));
+    });
+
+    it('should return an empty string when the link cannot be built', () => {
+        const CSRFProtection = require('dw/web/CSRFProtection');
+        jest.spyOn(CSRFProtection, 'generateToken').mockImplementation(() => {
+            throw new Error('No request context');
+        });
+
+        expect(BMHelper.getJobBMLink('AlgoliaProductIndex_v2')).toBe('');
     });
 });

--- a/test/unit/int_algolia/scripts/algolia/helper/consumedArchiveTracker.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/consumedArchiveTracker.test.js
@@ -7,6 +7,13 @@ const consumedArchiveTracker = require('../../../../../../cartridges/int_algolia
 
 const CUSTOM_OBJECT_TYPE = 'AlgoliaConsumedDeltaArchive';
 
+// implementations set with mockReturnValue/mockImplementation survive clearMocks,
+// so restore them here instead of at the end of the test bodies (where a failing
+// assertion would skip the restore and leak state into the following tests)
+afterEach(() => {
+    CustomObjectMgr.getCustomObject.mockReset();
+});
+
 describe('isConsumed', () => {
     test('returns false when no custom object exists for the archive', () => {
         CustomObjectMgr.getCustomObject.mockReturnValueOnce(null);
@@ -26,11 +33,15 @@ describe('markConsumed', () => {
     test('creates one custom object per archive with the expected key and attributes', () => {
         CustomObjectMgr.getCustomObject.mockReturnValue(null);
         const createdCustomObjects = [];
-        CustomObjectMgr.createCustomObject.mockImplementation(() => {
+        const recordCreatedCustomObject = () => {
             const customObject = { custom: {} };
             createdCustomObjects.push(customObject);
             return customObject;
-        });
+        };
+        // "Once" implementations (one per expected create) don't outlive this test
+        CustomObjectMgr.createCustomObject
+            .mockImplementationOnce(recordCreatedCustomObject)
+            .mockImplementationOnce(recordCreatedCustomObject);
 
         const success = consumedArchiveTracker.markConsumed('AlgoliaInventoryDeltaIndex', 'algolia', 'inventoryDeltaExport', ['000001.zip', '000002.zip']);
 
@@ -44,8 +55,6 @@ describe('markConsumed', () => {
             archiveName: '000001.zip',
             jobID: 'AlgoliaInventoryDeltaIndex',
         });
-
-        CustomObjectMgr.getCustomObject.mockReset();
     });
 
     test('skips archives that are already recorded', () => {
@@ -68,8 +77,6 @@ describe('markConsumed', () => {
         expect(CustomObjectMgr.createCustomObject).toHaveBeenCalledTimes(2);
         expect(CustomObjectMgr.createCustomObject).toHaveBeenNthCalledWith(1, CUSTOM_OBJECT_TYPE, 'AlgoliaPriceDeltaIndex_locales1__algolia__pricebookDeltaExport__000001.zip');
         expect(CustomObjectMgr.createCustomObject).toHaveBeenNthCalledWith(2, CUSTOM_OBJECT_TYPE, 'AlgoliaPriceDeltaIndex_locales2__algolia__pricebookDeltaExport__000001.zip');
-
-        CustomObjectMgr.getCustomObject.mockReset();
     });
 
     test('a failure on one archive does not stop the others from being recorded', () => {
@@ -93,7 +100,5 @@ describe('markConsumed', () => {
             archiveName: '000002.zip',
             jobID: 'AlgoliaPriceDeltaIndex',
         });
-
-        CustomObjectMgr.getCustomObject.mockReset();
     });
 });

--- a/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
+++ b/test/unit/int_algolia/scripts/algolia/steps/algoliaProductDeltaIndex.test.js
@@ -81,6 +81,9 @@ const job = require('../../../../../../cartridges/int_algolia/cartridge/scripts/
 beforeEach(() => {
     mockLocalesForIndexing = [];
     mockZipList = [];
+    // return values set with mockReturnValue survive clearMocks, so restore the default
+    // here instead of at the end of the test bodies that override it
+    mockIsConsumed.mockReturnValue(false);
     mockGroupRecordsForIngestionAPI.mockReset();
     mockSendGroupedIngestionAPIRecords.mockReset();
     delete global.customPreferences['Algolia_IndexingAPI'];
@@ -281,8 +284,6 @@ describe('archive consumption tracking', () => {
         // all archives were filtered out, so a successful run has nothing new to record
         job.afterStep(true);
         expect(mockMarkConsumed).not.toHaveBeenCalled();
-
-        mockIsConsumed.mockReturnValue(false);
     });
 
     test('afterStep records the consumed archives on success', () => {


### PR DESCRIPTION
Minor fixes and optimizations found during testing. No functional change to the tracking itself.

## Changes

- **Per-job `_processing` directory to avoid collisions.** The temp extraction dir is now `_processing_<siteID>_<jobID>` (job ID sanitized for folder-name safety). With consumption tracked per job, two same-site jobs sharing one delta export definition (e.g. locale-split indexing) can run concurrently; a shared dir could be wiped by the second job mid-extraction.
- **Summary log line for skipped archives.** Consumed archives stay in the outbox for up to 30 days, so the per-archive "Skipping ..." info line is replaced by a single summary line with the count; the individual names move to debug level. Previously the logs would have been inundated with log lines just informing the user of skipped files as the number of archives grows.
- **Loud failure on temp dir creation.** A failed `mkdir` for an archive's extraction dir now throws with the path and archive name instead of silently skipping the unzip and failing later with a misleading error.
- **BM dashboard job links.** `getLatestCOReportsByJob` precomputes each job's BM deep link once and attaches it to the report (`bmLink`); `getJobBMLink` returns an empty string if the link cannot be built and the template then renders the job ID as plain text. The template no longer calls URLUtils/CSRFProtection during rendering.

## Tests

- BMHelper: expectations updated for `bmLink`, new case for the empty-link fallback.
- Mock restores moved from test bodies to `afterEach`/`beforeEach`, persistent `mockImplementation` replaced with `mockImplementationOnce`, so a failing assertion no longer leaks mock state into later tests.