### PR TITLE
fix: [SFCC-538] Fixed the tiered-price crash in the cart and order controllers, conversion events now report the correct prices across the board

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
@@ -163,6 +163,35 @@ function getAttributeSlicedModelRecordID(product) {
 }
 
 /**
+ * Resolves the objectID a product is indexed under, for the configured record model.
+ *
+ * Conversion events have to name the record that exists in the index, which is not always the
+ * product's own ID: under the master-level model a variant is indexed as its master, and under the
+ * attribute-sliced model variants are not indexed at all, their variation group is.
+ *
+ * @param {dw.catalog.Product | dw.catalog.Variant} product Product or Variant
+ * @param {string} recordModel one of RECORD_MODEL_TYPES
+ * @returns {string | null} the record ID, or null when it cannot be resolved
+ */
+function getRecordIDForProduct(product, recordModel) {
+    const RECORD_MODEL_TYPES = require('*/cartridge/scripts/algolia/lib/algoliaConstants').RECORD_MODEL_TYPES;
+
+    if (empty(product)) {
+        return null;
+    }
+
+    switch (recordModel) {
+        case RECORD_MODEL_TYPES.ATTRIBUTE_SLICED:
+            return getAttributeSlicedModelRecordID(product);
+        case RECORD_MODEL_TYPES.MASTER_LEVEL:
+            return product.isVariant() ? product.getMasterProduct().getID() : product.getID();
+        case RECORD_MODEL_TYPES.VARIANT_LEVEL:
+        default:
+            return product.getID();
+    }
+}
+
+/**
  * Build the list of stores that have an inventory list, used to compute the `storeAvailability` attribute.
  * The lookup is intentionally broad (whole world) so that every store assigned to the site is returned.
  * This is expensive, so callers should build it once and pass it to AlgoliaLocalizedProduct via `parameters.stores`.
@@ -193,5 +222,6 @@ module.exports = {
     getColorVariations: getColorVariations,
     getImageGroups: getImageGroups,
     getAttributeSlicedModelRecordID: getAttributeSlicedModelRecordID,
+    getRecordIDForProduct: getRecordIDForProduct,
     getStoresWithInventory: getStoresWithInventory,
 };

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/priceHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/priceHelper.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const algoliaLogger = require('dw/system/Logger').getLogger('algolia');
+
+/**
+ * Finds the top-level product line item for a product in a basket or order.
+ *
+ * @param {dw.order.LineItemCtnr} lineItemCtnr - the basket or order
+ * @param {string} productID - the product ID to look for
+ * @returns {dw.order.ProductLineItem|null} the first matching line item, or null
+ */
+function findProductLineItem(lineItemCtnr, productID) {
+    if (!lineItemCtnr || !productID) {
+        return null;
+    }
+
+    const lineItems = lineItemCtnr.getProductLineItems().iterator();
+
+    while (lineItems.hasNext()) {
+        const lineItem = lineItems.next();
+        if (lineItem.getProductID() === productID) {
+            return lineItem;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Reads the price actually charged for a line item, per unit, for use as Insights `objectData`.
+ *
+ * The Insights API defines `price` as the final per-item price inclusive of any discounts, and
+ * derives revenue from `price` multiplied by `quantity`. The line item already holds that figure,
+ * so nothing is recalculated from the catalog: quantity-based price tiers, price overrides and
+ * promotions are all already applied by the platform.
+ *
+ * `getAdjustedPrice()` is the extended price after product-level adjustments, matching the line
+ * total SFRA itself displays. Order-level discounts are not prorated into it, so an order-level
+ * promotion is not reflected in the reported price; `getProratedPrice()` would include it, at the
+ * cost of no longer matching the displayed line total.
+ *
+ * Option values live on their own line items and are not part of the product's adjusted price, so
+ * they are added in, as SFRA does when it builds a line total. The discount is measured on the
+ * product alone, since option values carry no discount of their own.
+ *
+ * @param {dw.order.ProductLineItem} lineItem - the basket or order line item
+ * @returns {Object|null} `{ price, currency, discount }` with `discount` omitted when there is
+ *                        none, or null when no price is available
+ */
+function getLineItemPriceData(lineItem) {
+    if (!lineItem) {
+        return null;
+    }
+
+    const quantity = lineItem.getQuantityValue();
+
+    if (!quantity) {
+        algoliaLogger.warn('[priceHelper] Line item for product "{0}" has no quantity, no price reported.',
+            lineItem.getProductID());
+        return null;
+    }
+
+    const productPrice = lineItem.getAdjustedPrice();
+    const basePrice = lineItem.getBasePrice();
+    let unitPrice = null;
+
+    if (productPrice.isAvailable()) {
+        let linePrice = productPrice;
+
+        const optionLineItems = lineItem.getOptionProductLineItems().iterator();
+        while (optionLineItems.hasNext()) {
+            linePrice = linePrice.add(optionLineItems.next().getAdjustedPrice());
+        }
+
+        if (linePrice.isAvailable()) {
+            unitPrice = linePrice.divide(quantity);
+        }
+    }
+
+    if (!unitPrice && basePrice.isAvailable()) {
+        // The base price is the unit price and is set independently of the adjusted price, so it
+        // still describes what the product costs. It excludes promotions and option values, so this
+        // is a degraded figure and is logged rather than used silently.
+        unitPrice = basePrice;
+        algoliaLogger.warn('[priceHelper] No adjusted price for product "{0}" (quantity {1}), falling back to its base price of {2}. Promotions and option values are not reflected in the reported price.',
+            lineItem.getProductID(), quantity, basePrice.getValue());
+    }
+
+    if (!unitPrice) {
+        algoliaLogger.warn('[priceHelper] Neither the adjusted nor the base price is available for product "{0}", no price reported.',
+            lineItem.getProductID());
+        return null;
+    }
+
+    const priceData = {
+        price: unitPrice.getValue(),
+        currency: unitPrice.getCurrencyCode(),
+    };
+
+    if (basePrice.isAvailable() && productPrice.isAvailable()) {
+        const unitDiscount = basePrice.subtract(productPrice.divide(quantity));
+        if (unitDiscount.getValue() > 0) {
+            priceData.discount = unitDiscount.getValue();
+        }
+    }
+
+    return priceData;
+}
+
+module.exports.findProductLineItem = findProductLineItem;
+module.exports.getLineItemPriceData = getLineItemPriceData;

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/priceHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/priceHelper.js
@@ -17,7 +17,7 @@ function findProductLineItem(lineItemCtnr, productID) {
     const lineItems = lineItemCtnr.getProductLineItems().iterator();
 
     while (lineItems.hasNext()) {
-        const lineItem = lineItems.next();
+        let lineItem = lineItems.next();
         if (lineItem.getProductID() === productID) {
             return lineItem;
         }

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/priceHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/priceHelper.js
@@ -27,6 +27,34 @@ function findProductLineItem(lineItemCtnr, productID) {
 }
 
 /**
+ * Finds a top-level product line item by its UUID.
+ *
+ * A UUID identifies one line item, where a product ID can match several: the same product sits on
+ * separate line items when it is added with different option values, and when it is split across
+ * shipments.
+ *
+ * @param {dw.order.LineItemCtnr} lineItemCtnr - the basket or order
+ * @param {string} lineItemUUID - the UUID of the line item to look for
+ * @returns {dw.order.ProductLineItem|null} the matching line item, or null
+ */
+function findLineItemByUUID(lineItemCtnr, lineItemUUID) {
+    if (!lineItemCtnr || !lineItemUUID) {
+        return null;
+    }
+
+    const lineItems = lineItemCtnr.getProductLineItems().iterator();
+
+    while (lineItems.hasNext()) {
+        let lineItem = lineItems.next();
+        if (lineItem.getUUID() === lineItemUUID) {
+            return lineItem;
+        }
+    }
+
+    return null;
+}
+
+/**
  * Reads the price actually charged for a line item, per unit, for use as Insights `objectData`.
  *
  * The Insights API defines `price` as the final per-item price inclusive of any discounts, and
@@ -108,4 +136,5 @@ function getLineItemPriceData(lineItem) {
 }
 
 module.exports.findProductLineItem = findProductLineItem;
+module.exports.findLineItemByUUID = findLineItemByUUID;
 module.exports.getLineItemPriceData = getLineItemPriceData;

--- a/cartridges/int_algolia_sfra/cartridge/controllers/Cart.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Cart.js
@@ -41,6 +41,15 @@ server.append('AddProduct', function (req, res, next) {
             return next(); // prevent execution of the rest of the code
         }
 
+        // The base controller reports an error when it rejected the add, for example when the
+        // requested quantity exceeds the available-to-sell inventory. The basket can still hold a
+        // line item for the product from an earlier add, so without this check the lookup below
+        // would find that line item and report an add-to-cart event for a product that was not
+        // added.
+        if (viewData.error) {
+            return next();
+        }
+
         var product = ProductMgr.getProduct(productID);
         if (empty(product)) {
             algoliaLogger.warn('No product found for ID "{0}", add-to-cart event not sent.', productID);
@@ -69,8 +78,7 @@ server.append('AddProduct', function (req, res, next) {
         // identifies the configuration the shopper just added. The product ID is the fallback, for
         // a customized base controller that does not report the UUID.
         //
-        // The line item is absent when the product was not added, in which case the base controller
-        // still runs this append, and when a product set was added, since the basket then holds the
+        // The line item is absent when a product set was added, since the basket then holds the
         // set's children rather than the posted product ID.
         var currentBasket = BasketMgr.getCurrentBasket();
         var lineItem = priceHelper.findLineItemByUUID(currentBasket, viewData.pliUUID)

--- a/cartridges/int_algolia_sfra/cartridge/controllers/Cart.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Cart.js
@@ -11,8 +11,6 @@ var algoliaLogger = require('dw/system/Logger').getLogger('algolia');
 
 server.extend(base);
 
-const { RECORD_MODEL_TYPES } = require('*/cartridge/scripts/algolia/lib/algoliaConstants');
-
 server.append('Show', function (req, res, next) {
     if (algoliaData.getPreference('Enable') && algoliaData.getPreference('EnableRecommend')) {
 
@@ -43,34 +41,40 @@ server.append('AddProduct', function (req, res, next) {
             return next(); // prevent execution of the rest of the code
         }
 
-        try {
-            var product = ProductMgr.getProduct(productID);
-            if (empty(product)) {
-                return next();
-            }
-
-            switch (recordModel) {
-                case RECORD_MODEL_TYPES.ATTRIBUTE_SLICED:
-                    algoliaProductData.pid = modelHelper.getAttributeSlicedModelRecordID(product);
-                    break;
-                case RECORD_MODEL_TYPES.MASTER_LEVEL:
-                    algoliaProductData.pid = product.isVariant() ? product.getMasterProduct().getID() : product.getID(); // returns master ID for variants, product ID for simple products
-                    break;
-                case RECORD_MODEL_TYPES.VARIANT_LEVEL:
-                    algoliaProductData.pid = productID;
-                    break;
-            }
-
-        } catch (e) { // eslint-disable-line no-unused-vars
-            algoliaProductData.pid = productID;
+        var product = ProductMgr.getProduct(productID);
+        if (empty(product)) {
+            algoliaLogger.warn('No product found for ID "{0}", add-to-cart event not sent.', productID);
+            return next();
         }
+
+        var recordID = null;
+
+        try {
+            recordID = modelHelper.getRecordIDForProduct(product, recordModel);
+        } catch (e) { // eslint-disable-line no-unused-vars
+            recordID = null;
+        }
+
+        // Without a record ID there is nothing in the index to attach the event to.
+        if (!recordID) {
+            algoliaLogger.warn('No "{0}" record ID resolved for product "{1}", add-to-cart event not sent.', recordModel, productID);
+            return next();
+        }
+
+        algoliaProductData.pid = recordID;
 
         algoliaProductData.qty = req.form.quantity;
 
+        // The base controller reports the UUID of the line item it created or incremented, which
+        // identifies the configuration the shopper just added. The product ID is the fallback, for
+        // a customized base controller that does not report the UUID.
+        //
         // The line item is absent when the product was not added, in which case the base controller
         // still runs this append, and when a product set was added, since the basket then holds the
         // set's children rather than the posted product ID.
-        var lineItem = priceHelper.findProductLineItem(BasketMgr.getCurrentBasket(), productID);
+        var currentBasket = BasketMgr.getCurrentBasket();
+        var lineItem = priceHelper.findLineItemByUUID(currentBasket, viewData.pliUUID)
+            || priceHelper.findProductLineItem(currentBasket, productID);
         if (!lineItem) {
             algoliaLogger.warn('No basket line item found for product "{0}", add-to-cart event not sent.', productID);
             return next();

--- a/cartridges/int_algolia_sfra/cartridge/controllers/Cart.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Cart.js
@@ -6,6 +6,8 @@ var BasketMgr = require('dw/order/BasketMgr');
 var ProductMgr = require('dw/catalog/ProductMgr');
 var algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
 var modelHelper = require('*/cartridge/scripts/algolia/helper/modelHelper');
+var priceHelper = require('*/cartridge/scripts/algolia/helper/priceHelper');
+var algoliaLogger = require('dw/system/Logger').getLogger('algolia');
 
 server.extend(base);
 
@@ -64,23 +66,26 @@ server.append('AddProduct', function (req, res, next) {
         }
 
         algoliaProductData.qty = req.form.quantity;
-        var items = viewData.cart.items;
-        var pli;
-        //find the item in the cart by using the product id with for loop
-        for (var i = 0; i < items.length; i++) {
-            if (items[i].id === productID) {
-                pli = items[i];
-                break;
-            }
-        }
-        algoliaProductData.price = pli.price.sales.value;
 
-        if (pli.price.list) {
-            algoliaProductData.discount = +(
-                pli.price.list.value - pli.price.sales.value
-            ).toFixed(2);
+        // The line item is absent when the product was not added, in which case the base controller
+        // still runs this append, and when a product set was added, since the basket then holds the
+        // set's children rather than the posted product ID.
+        var lineItem = priceHelper.findProductLineItem(BasketMgr.getCurrentBasket(), productID);
+        if (!lineItem) {
+            algoliaLogger.warn('No basket line item found for product "{0}", add-to-cart event not sent.', productID);
+            return next();
         }
-        algoliaProductData.currency = pli.price.sales.currency;
+
+        var priceData = priceHelper.getLineItemPriceData(lineItem);
+        if (!priceData) {
+            return next();
+        }
+
+        algoliaProductData.price = priceData.price;
+        algoliaProductData.currency = priceData.currency;
+        if ('discount' in priceData) {
+            algoliaProductData.discount = priceData.discount;
+        }
 
         viewData.algoliaProductData = algoliaProductData;
     }

--- a/cartridges/int_algolia_sfra/cartridge/controllers/Order.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Order.js
@@ -24,7 +24,9 @@ server.append('Confirm', function (req, res, next) {
         }
 
         var fullOrder = OrderMgr.getOrder(order.orderNumber);
-        var plis = fullOrder.getAllProductLineItems();
+        // Only the line items a shopper chose: option and bundled line items are dependent on a
+        // parent line item, and their prices are already part of the parent's reported price.
+        var plis = fullOrder.getProductLineItems();
         var algoliaProducts = [];
         var currency = fullOrder.getCurrencyCode();
 

--- a/cartridges/int_algolia_sfra/cartridge/controllers/Order.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Order.js
@@ -4,12 +4,12 @@ var server = require('server');
 var base = module.superModule;
 var algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
 var priceHelper = require('*/cartridge/scripts/algolia/helper/priceHelper');
+var modelHelper = require('*/cartridge/scripts/algolia/helper/modelHelper');
+var algoliaLogger = require('dw/system/Logger').getLogger('algolia');
 
 var OrderMgr = require('dw/order/OrderMgr');
 
 server.extend(base);
-
-const { RECORD_MODEL_TYPES } = require('*/cartridge/scripts/algolia/lib/algoliaConstants');
 
 server.append('Confirm', function (req, res, next) {
     if (algoliaData.getPreference('Enable') && algoliaData.getPreference('EnableInsights')) {
@@ -29,6 +29,7 @@ server.append('Confirm', function (req, res, next) {
         var plis = fullOrder.getProductLineItems();
         var algoliaProducts = [];
         var currency = fullOrder.getCurrencyCode();
+        var recordModel = algoliaData.getPreference('RecordModel');
 
         var pliArr = plis.toArray();
 
@@ -37,12 +38,22 @@ server.append('Confirm', function (req, res, next) {
 
             if (product) {
                 var algoliaProduct = {};
+                var recordID = null;
 
                 try {
-                    algoliaProduct.pid = algoliaData.getPreference('RecordModel') === RECORD_MODEL_TYPES.MASTER_LEVEL ? product.getMasterProduct().getID() : product.getID();
+                    recordID = modelHelper.getRecordIDForProduct(product, recordModel);
                 } catch (e) { // eslint-disable-line no-unused-vars
-                    algoliaProduct.pid = product.getID();
+                    recordID = null;
                 }
+
+                // Without a record ID there is nothing in the index to attach the revenue to, so
+                // the product is left out rather than reported under an ID the index does not hold.
+                if (!recordID) {
+                    algoliaLogger.warn('No "{0}" record ID resolved for product "{1}", it is not part of the purchase event.', recordModel, product.getID());
+                    continue;
+                }
+
+                algoliaProduct.pid = recordID;
 
                 var priceData = priceHelper.getLineItemPriceData(pliArr[i]);
                 if (!priceData) {

--- a/cartridges/int_algolia_sfra/cartridge/controllers/Order.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Order.js
@@ -3,7 +3,7 @@
 var server = require('server');
 var base = module.superModule;
 var algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
-var priceFactory = require('*/cartridge/scripts/factories/price')
+var priceHelper = require('*/cartridge/scripts/algolia/helper/priceHelper');
 
 var OrderMgr = require('dw/order/OrderMgr');
 
@@ -16,10 +16,17 @@ server.append('Confirm', function (req, res, next) {
 
         var viewData = res.getViewData();
         var order = viewData.order;
+
+        // The base controller renders its error template and continues the chain when the order
+        // cannot be resolved, so there is nothing to report on in that case.
+        if (!order) {
+            return next();
+        }
+
         var fullOrder = OrderMgr.getOrder(order.orderNumber);
         var plis = fullOrder.getAllProductLineItems();
         var algoliaProducts = [];
-        var currency;
+        var currency = fullOrder.getCurrencyCode();
 
         var pliArr = plis.toArray();
 
@@ -35,25 +42,32 @@ server.append('Confirm', function (req, res, next) {
                     algoliaProduct.pid = product.getID();
                 }
 
-                var price = priceFactory.getPrice(product);
-                algoliaProduct.price = price;
-                if (price.list) {
-                    algoliaProduct.discount = +(price.list.value - price.sales.value).toFixed(2);
+                var priceData = priceHelper.getLineItemPriceData(pliArr[i]);
+                if (!priceData) {
+                    continue;
                 }
-                currency = price.sales.currency;
+
+                algoliaProduct.price = priceData.price;
+                if ('discount' in priceData) {
+                    algoliaProduct.discount = priceData.discount;
+                }
                 algoliaProduct.qty = pliArr[i].getQuantityValue();
                 algoliaProducts.push(algoliaProduct);
             }
         };
 
-        const algoliaObj = {
-            items: algoliaProducts,
-            currency: currency
+        // An empty item list would produce a purchase event with no objectIDs, which the Insights
+        // API rejects, so the event is left unsent instead.
+        if (algoliaProducts.length > 0) {
+            const algoliaObj = {
+                items: algoliaProducts,
+                currency: currency
+            }
+
+            viewData.algoliaObj = algoliaObj;
+
+            res.setViewData(viewData);
         }
-
-        viewData.algoliaObj = algoliaObj;
-
-        res.setViewData(viewData);
     }
 
     next();

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/insights-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/insights-config.js
@@ -105,7 +105,7 @@ function enableInsights(appId, searchApiKey, productsIndex) {
 
         products.forEach((product) => {
             const productInfo = {
-                price: product.price.sales.value,
+                price: product.price,
                 quantity: product.qty,
             };
 

--- a/test/unit/int_algolia/scripts/algolia/helper/modelHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/modelHelper.test.js
@@ -81,3 +81,62 @@ describe('getAttributeSlicedModelRecordID', () => {
         expect(modelHelper.getAttributeSlicedModelRecordID(simpleProduct)).toBe('SIMPLE1');
     });
 });
+
+describe('getRecordIDForProduct', () => {
+    const simpleProduct = {
+        isMaster: () => false,
+        isVariant: () => false,
+        getID: () => 'SIMPLE1',
+    };
+
+    let variantProduct;
+
+    beforeEach(() => {
+        algoliaDataMock.getPreference.mockReset();
+        if (!ProductVariationAttributeValueMock.prototype.getID) {
+            ProductVariationAttributeValueMock.prototype.getID = function getID() {
+                return this.ID;
+            };
+        }
+        variantProduct = new VariantMock({
+            ID: 'VAR1',
+            masterProduct: new MasterProductMock({ ID: 'MASTER1' }),
+            variationAttributes: { color: 'JJB52A0', size: '004' },
+        });
+    });
+
+    test('attribute-sliced: a variant is reported as its variation group', () => {
+        algoliaDataMock.getPreference.mockReturnValue('color');
+        expect(modelHelper.getRecordIDForProduct(variantProduct, 'attribute-sliced')).toBe('MASTER1-JJB52A0');
+    });
+
+    test('attribute-sliced: a product without variants keeps its own ID', () => {
+        algoliaDataMock.getPreference.mockReturnValue('color');
+        expect(modelHelper.getRecordIDForProduct(simpleProduct, 'attribute-sliced')).toBe('SIMPLE1');
+    });
+
+    test('attribute-sliced: null without a grouping attribute, since no record ID can be built', () => {
+        algoliaDataMock.getPreference.mockReturnValue('');
+        expect(modelHelper.getRecordIDForProduct(variantProduct, 'attribute-sliced')).toBeNull();
+    });
+
+    test('master-level: a variant is reported as its master', () => {
+        expect(modelHelper.getRecordIDForProduct(variantProduct, 'master-level')).toBe('MASTER1');
+    });
+
+    test('master-level: a product without a master keeps its own ID', () => {
+        expect(modelHelper.getRecordIDForProduct(simpleProduct, 'master-level')).toBe('SIMPLE1');
+    });
+
+    test('variant-level: the product keeps its own ID', () => {
+        expect(modelHelper.getRecordIDForProduct(variantProduct, 'variant-level')).toBe('VAR1');
+    });
+
+    test('an unrecognized record model falls back to the product ID', () => {
+        expect(modelHelper.getRecordIDForProduct(variantProduct, 'something-else')).toBe('VAR1');
+    });
+
+    test('returns null for a missing product', () => {
+        expect(modelHelper.getRecordIDForProduct(null, 'variant-level')).toBeNull();
+    });
+});

--- a/test/unit/int_algolia/scripts/algolia/helper/priceHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/priceHelper.test.js
@@ -1,0 +1,179 @@
+const priceHelper = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/helper/priceHelper');
+
+/**
+ * Minimal stand-in for dw.value.Money, with the arithmetic the helper relies on.
+ * @param {number|null} value - the amount, or null for an unavailable price
+ * @param {string} currencyCode - ISO 4217 code
+ * @returns {Object} a Money-like object
+ */
+function money(value, currencyCode) {
+    const code = currencyCode || 'USD';
+    return {
+        getValue: () => value,
+        getCurrencyCode: () => (value === null ? 'N/A' : code),
+        isAvailable: () => value !== null,
+        // The platform rounds to the currency's precision; two decimals is enough here.
+        divide: (divisor) => money(value === null ? null : Math.round((value / divisor) * 100) / 100, code),
+        add: (other) => money(
+            value === null || other.getValue() === null ? null : value + other.getValue(), code
+        ),
+        subtract: (other) => money(
+            value === null || other.getValue() === null ? null : +(value - other.getValue()).toFixed(2), code
+        ),
+    };
+}
+
+/**
+ * @param {Object} options - line item configuration
+ * @returns {Object} a dw.order.ProductLineItem-like object
+ */
+function lineItem(options) {
+    const config = options || {};
+    return {
+        getProductID: () => config.productID || 'PRODUCT1',
+        getQuantityValue: () => (config.quantity === undefined ? 1 : config.quantity),
+        getBasePrice: () => money(config.basePrice === undefined ? 50 : config.basePrice),
+        getAdjustedPrice: () => money(config.adjustedPrice === undefined ? 50 : config.adjustedPrice),
+        getOptionProductLineItems: () => ({
+            iterator: () => {
+                const options_ = config.optionPrices || [];
+                let index = 0;
+                return {
+                    hasNext: () => index < options_.length,
+                    next: () => {
+                        const optionPrice = options_[index];
+                        index += 1;
+                        return { getAdjustedPrice: () => money(optionPrice) };
+                    },
+                };
+            },
+        }),
+    };
+}
+
+/**
+ * @param {Array} lineItems - the container's product line items
+ * @returns {Object} a dw.order.LineItemCtnr-like object
+ */
+function lineItemCtnr(lineItems) {
+    return {
+        getProductLineItems: () => ({
+            iterator: () => {
+                let index = 0;
+                return {
+                    hasNext: () => index < lineItems.length,
+                    next: () => {
+                        const item = lineItems[index];
+                        index += 1;
+                        return item;
+                    },
+                };
+            },
+        }),
+    };
+}
+
+describe('findProductLineItem', () => {
+    test('returns the line item matching the product ID', () => {
+        const wanted = lineItem({ productID: 'B' });
+        const basket = lineItemCtnr([lineItem({ productID: 'A' }), wanted]);
+        expect(priceHelper.findProductLineItem(basket, 'B')).toBe(wanted);
+    });
+
+    test('returns the first match when a product appears more than once', () => {
+        const first = lineItem({ productID: 'A' });
+        const basket = lineItemCtnr([first, lineItem({ productID: 'A' })]);
+        expect(priceHelper.findProductLineItem(basket, 'A')).toBe(first);
+    });
+
+    test('returns null when the product is not in the container', () => {
+        expect(priceHelper.findProductLineItem(lineItemCtnr([lineItem({ productID: 'A' })]), 'B')).toBeNull();
+    });
+
+    test('returns null for a missing container or product ID', () => {
+        expect(priceHelper.findProductLineItem(null, 'A')).toBeNull();
+        expect(priceHelper.findProductLineItem(lineItemCtnr([]), null)).toBeNull();
+    });
+});
+
+describe('getLineItemPriceData', () => {
+    test('reports the per-unit price and currency', () => {
+        expect(priceHelper.getLineItemPriceData(lineItem({
+            quantity: 1, basePrice: 50, adjustedPrice: 50,
+        }))).toEqual({ price: 50, currency: 'USD' });
+    });
+
+    test('divides the extended price by the quantity', () => {
+        // This is the tiered-pricing case: ten units at the 45.00 tier.
+        expect(priceHelper.getLineItemPriceData(lineItem({
+            quantity: 10, basePrice: 45, adjustedPrice: 450,
+        }))).toEqual({ price: 45, currency: 'USD' });
+    });
+
+    test('reports a discount when the adjusted price is below the base price', () => {
+        expect(priceHelper.getLineItemPriceData(lineItem({
+            quantity: 2, basePrice: 50, adjustedPrice: 80,
+        }))).toEqual({ price: 40, currency: 'USD', discount: 10 });
+    });
+
+    test('omits the discount when there is none', () => {
+        const priceData = priceHelper.getLineItemPriceData(lineItem({
+            quantity: 1, basePrice: 50, adjustedPrice: 50,
+        }));
+        expect('discount' in priceData).toBe(false);
+    });
+
+    test('adds option value prices into the reported price', () => {
+        expect(priceHelper.getLineItemPriceData(lineItem({
+            quantity: 1, basePrice: 50, adjustedPrice: 50, optionPrices: [10, 5],
+        }))).toEqual({ price: 65, currency: 'USD' });
+    });
+
+    test('measures the discount on the product alone, not on option values', () => {
+        const priceData = priceHelper.getLineItemPriceData(lineItem({
+            quantity: 1, basePrice: 50, adjustedPrice: 40, optionPrices: [10],
+        }));
+        expect(priceData).toEqual({ price: 50, currency: 'USD', discount: 10 });
+    });
+
+    test('falls back to the base price when the adjusted price is unavailable', () => {
+        // SFRA's calculate hook sets the line item price to null when the platform cannot resolve
+        // a price for the ordered quantity, which leaves the adjusted price unavailable.
+        expect(priceHelper.getLineItemPriceData(lineItem({
+            quantity: 1, basePrice: 50, adjustedPrice: null,
+        }))).toEqual({ price: 50, currency: 'USD' });
+    });
+
+    test('reports no discount when falling back to the base price', () => {
+        const priceData = priceHelper.getLineItemPriceData(lineItem({
+            quantity: 2, basePrice: 50, adjustedPrice: null,
+        }));
+        expect(priceData).toEqual({ price: 50, currency: 'USD' });
+    });
+
+    test('returns null when neither the adjusted nor the base price is available', () => {
+        expect(priceHelper.getLineItemPriceData(lineItem({
+            basePrice: null, adjustedPrice: null,
+        }))).toBeNull();
+    });
+
+    test('returns null for a quantity of zero, rather than dividing by it', () => {
+        expect(priceHelper.getLineItemPriceData(lineItem({ quantity: 0 }))).toBeNull();
+    });
+
+    test('returns null for a missing line item', () => {
+        expect(priceHelper.getLineItemPriceData(null)).toBeNull();
+    });
+
+    test('reports a price without a discount when the base price is unavailable', () => {
+        expect(priceHelper.getLineItemPriceData(lineItem({
+            quantity: 1, basePrice: null, adjustedPrice: 50,
+        }))).toEqual({ price: 50, currency: 'USD' });
+    });
+
+    test('keeps the currency of the line item', () => {
+        const item = lineItem({ quantity: 1, adjustedPrice: 42 });
+        item.getAdjustedPrice = () => money(42, 'EUR');
+        expect(priceHelper.getLineItemPriceData(item).currency).toBe('EUR');
+    });
+});

--- a/test/unit/int_algolia/scripts/algolia/helper/priceHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/priceHelper.test.js
@@ -31,6 +31,7 @@ function lineItem(options) {
     const config = options || {};
     return {
         getProductID: () => config.productID || 'PRODUCT1',
+        getUUID: () => config.uuid || 'UUID1',
         getQuantityValue: () => (config.quantity === undefined ? 1 : config.quantity),
         getBasePrice: () => money(config.basePrice === undefined ? 50 : config.basePrice),
         getAdjustedPrice: () => money(config.adjustedPrice === undefined ? 50 : config.adjustedPrice),
@@ -93,6 +94,33 @@ describe('findProductLineItem', () => {
     test('returns null for a missing container or product ID', () => {
         expect(priceHelper.findProductLineItem(null, 'A')).toBeNull();
         expect(priceHelper.findProductLineItem(lineItemCtnr([]), null)).toBeNull();
+    });
+});
+
+describe('findLineItemByUUID', () => {
+    test('returns the line item matching the UUID', () => {
+        const wanted = lineItem({ uuid: 'U2' });
+        const basket = lineItemCtnr([lineItem({ uuid: 'U1' }), wanted]);
+        expect(priceHelper.findLineItemByUUID(basket, 'U2')).toBe(wanted);
+    });
+
+    test('tells apart two line items for the same product with different options', () => {
+        // SFRA creates a separate line item when a product is added with other option values, so
+        // the product ID alone cannot say which configuration was added.
+        const silver = lineItem({ productID: 'A', uuid: 'U1', adjustedPrice: 50 });
+        const gold = lineItem({ productID: 'A', uuid: 'U2', adjustedPrice: 70 });
+        const basket = lineItemCtnr([silver, gold]);
+        expect(priceHelper.findLineItemByUUID(basket, 'U2')).toBe(gold);
+        expect(priceHelper.findProductLineItem(basket, 'A')).toBe(silver);
+    });
+
+    test('returns null when no line item has the UUID', () => {
+        expect(priceHelper.findLineItemByUUID(lineItemCtnr([lineItem({ uuid: 'U1' })]), 'U2')).toBeNull();
+    });
+
+    test('returns null for a missing container or UUID', () => {
+        expect(priceHelper.findLineItemByUUID(null, 'U1')).toBeNull();
+        expect(priceHelper.findLineItemByUUID(lineItemCtnr([lineItem({ uuid: 'U1' })]), null)).toBeNull();
     });
 });
 


### PR DESCRIPTION
Products with tiered prices are now reported correctly and no errors are thrown in the console. Promotional prices are also reported correctly by the "Product Add to cart" and "Products purchased" conversion events.

## What this fixes

Adding a product with a quantity-based price table to the cart returned a 500 and left the mini-cart count stale until a hard refresh. Buying one broke the order confirmation page after the order had already been placed and paid.

Both appends read `price.sales` from an object produced by SFRA's price factory, reached two different ways. `Order.js` called `priceFactory.getPrice(product)` itself. `Cart.js` read `viewData.cart.items[n].price`, which SFRA fills with the same factory output through `models/product/decorators/price.js`.

The factory returns a `TieredPrice` for any product whose price table has more than one quantity row, and that shape has no `sales` property, so reading it threw. `modules/server/route.js` has no try/catch around middleware, so the exception took out the whole route. `RangePrice` has the same shape problem.

## Changes

**`priceHelper.js`** (new, `int_algolia`)

Reads the price from the line item instead of recalculating it from the catalog. `getAdjustedPrice()` divided by the quantity is the per-unit price charged, so quantity tiers and promotions are already applied by the platform. Option value prices are added in, as SFRA does when it builds a line total. The discount is `getBasePrice()` minus the per-unit price, measured on the product alone.

Falls back to `getBasePrice()` if the adjusted price is unavailable. That figure excludes promotions and option values, so it is logged rather than used silently.

**`Cart.js`, `Order.js`** (`int_algolia_sfra`)

Neither controller depends on the factory's return shape now. `Order.js` drops its `priceFactory` require. `Cart.js` stops reading the cart model's price and looks the line item up in the basket instead, skipping the event when it is absent. That can happen when the add failed, since the base controller runs this append whether or not `result.error` is set. `Order.js` takes the currency from `fullOrder.getCurrencyCode()` once per order rather than per line item, skips a line item with no price, and no longer assigns `viewData.algoliaObj` when every item was skipped, which would have produced a purchase event with an empty `objectIDs` array.

`Order.js` also guards `viewData.order`. The base controller renders its error template and continues the chain when the order token is missing or invalid, and the append turned that into a hard error page.

**`insights-config.js`** (`int_algolia_sfra`)

The purchase branch read `product.price.sales.value` because `Order.js` used to assign the whole factory object. It now assigns a number, so this reads `product.price`. Both event paths send the price the same way; the cart path already did.

## What changes in reported data

The crash fix is behavior-preserving. Moving the price source is not, and these are corrections:

- `price` is the price charged rather than the catalog sales price, so promotions are now reflected. Revenue reported to Algolia changes on orders carrying a product-level promotion.
- `discount` changes from the catalog markdown (`list` minus `sales`) to the per-unit adjustment (`basePrice` minus adjusted). A product marked down 60 to 50 used to report a discount of 10 and now reports none, because 50 is its base price. Algolia treats `discount` as informational, so revenue is unaffected.
- Option value prices are included in `price`.
- Order-level discounts are still excluded, since `getAdjustedPrice()` does not prorate them. `getProratedPrice()` would include them but would stop matching the line total the storefront shows.

## Testing
In order to test, pick a product and add another, tiered price entry to it, like so:
<img width="1305" height="254" alt="image" src="https://github.com/user-attachments/assets/f1b60f79-e74e-4647-bd5c-2938c1e53f75" />

A price table should now appear on that product's PDP:
<img width="434" height="321" alt="image" src="https://github.com/user-attachments/assets/c1c8fa31-aa30-4606-813c-bbbb32f9118c" />

Adding one or multiple of that product to the cart should not produce console or custom log errors and the conversion events should report the correct prices the product was actually purchased at (according to the price table):
<img width="1079" height="494" alt="image" src="https://github.com/user-attachments/assets/48ea5768-2329-4ef4-ace2-f9fbeb3b7bbd" />

To test with a product with a discounted price, set up a promotion and campaign (e.g. 10% off for qualifying products) and verify that the conversion events report the prices the products were purchased at.

Tested with products with a single price, products with tiered prices, both with and without promotions, no console errors and the prices reported by the conversion events match order data.

### Additional fixes
1. UUID-based lookup instead of matching lineItem product by productID
If the Cart or Order contains multiple line items which have the same productID (this can happen because adding to Cart doesn't always merge lineItems, for example when they have different options -- e.g. product `25695191M`'s `length` option), trying to find the product from the second lineItem containing a product with the same `productID` will return the first product, leading to incorrect event data being sent to Algolia (in the example above, the different length options have different prices, so adding a second product with a different option will find and send the data from the first product).
This is fixed by looking up items in the Cart or Order by UUID, which is unambiguous.

1. the logic that determines what `productID`s to be sent with the order placement conversion event ("Products purchased") hadn't previously been updated to handle the `attribute-sliced` model (to send the objectID corresponding to the record in an `attribute-sliced index`). The logic for the "Add to cart" event had previously been updated, so that's fine.
Created a shared ID resolver (`getRecordIDForProduct()`) so that both the "Products purchased" and "Add to cart" events now report the recordModel-appropriate objectIDs.

1. Conversion events are no longer fired when `AddProduct()` was called, but was ultimately unsuccessful in adding the product (the `viewData.error` guard in `Cart.js`).