### PR TITLE
fix: [SFCC-539] Recommend anchors now use the objectID the product is indexed under

### DIFF
--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
@@ -125,11 +125,17 @@ function getImageGroups(imagesList, viewtype) {
 /**
  * Build the attribute-sliced record product ID for a product.
  * @param {dw.catalog.Product | dw.catalog.Variant} product Product or Variant
+ * @param {string} [groupingAttribute] the grouping attribute the records are sliced by. Read from
+ *                                     the `Algolia_AttributeSlicedRecordModel_GroupingAttribute`
+ *                                     site preference when omitted; pass it in to avoid one
+ *                                     preference read per product.
  * @returns {string | null} Attribute-sliced product ID
  */
-function getAttributeSlicedModelRecordID(product) {
+function getAttributeSlicedModelRecordID(product, groupingAttribute) {
     const algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
-    let variationAttributeForAttributeSlicedRecordModel = algoliaData.getPreference('AttributeSlicedRecordModel_GroupingAttribute');
+    let variationAttributeForAttributeSlicedRecordModel = empty(groupingAttribute)
+        ? algoliaData.getPreference('AttributeSlicedRecordModel_GroupingAttribute')
+        : groupingAttribute;
 
     let recordID = null;
 
@@ -167,17 +173,20 @@ function getAttributeSlicedModelRecordID(product) {
  *
  * Conversion events and Recommend anchors have to name the record that exists in the index, which
  * is not always the product's own ID: under the master-level model a variant is indexed as its
- * master, and under the attribute-sliced model variants are not indexed at all, their variation
- * group is.
+ * master, and under the attribute-sliced model a variant is indexed as one slice of its master,
+ * the one holding its grouping attribute value, with an objectID of `masterID-variationValueID`.
+ * Variation groups get a record of their own under none of the three models.
  *
  * Callers that can pass a master or a variation group, which are only indexed under the
  * master-level model, are responsible for substituting an indexed product first.
  *
  * @param {dw.catalog.Product | dw.catalog.Variant} product Product or Variant
  * @param {string} recordModel one of RECORD_MODEL_TYPES
+ * @param {string} [groupingAttribute] the grouping attribute, forwarded to
+ *                                     getAttributeSlicedModelRecordID() for the attribute-sliced model
  * @returns {string | null} the record ID, or null when it cannot be resolved
  */
-function getRecordIDForProduct(product, recordModel) {
+function getRecordIDForProduct(product, recordModel, groupingAttribute) {
     const RECORD_MODEL_TYPES = require('*/cartridge/scripts/algolia/lib/algoliaConstants').RECORD_MODEL_TYPES;
 
     if (empty(product)) {
@@ -186,7 +195,7 @@ function getRecordIDForProduct(product, recordModel) {
 
     switch (recordModel) {
         case RECORD_MODEL_TYPES.ATTRIBUTE_SLICED:
-            return getAttributeSlicedModelRecordID(product);
+            return getAttributeSlicedModelRecordID(product, groupingAttribute);
         case RECORD_MODEL_TYPES.MASTER_LEVEL:
             // a variation group is not indexed either, its master carries the record
             return (product.isVariant() || product.isVariationGroup())

--- a/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper.js
@@ -165,9 +165,13 @@ function getAttributeSlicedModelRecordID(product) {
 /**
  * Resolves the objectID a product is indexed under, for the configured record model.
  *
- * Conversion events have to name the record that exists in the index, which is not always the
- * product's own ID: under the master-level model a variant is indexed as its master, and under the
- * attribute-sliced model variants are not indexed at all, their variation group is.
+ * Conversion events and Recommend anchors have to name the record that exists in the index, which
+ * is not always the product's own ID: under the master-level model a variant is indexed as its
+ * master, and under the attribute-sliced model variants are not indexed at all, their variation
+ * group is.
+ *
+ * Callers that can pass a master or a variation group, which are only indexed under the
+ * master-level model, are responsible for substituting an indexed product first.
  *
  * @param {dw.catalog.Product | dw.catalog.Variant} product Product or Variant
  * @param {string} recordModel one of RECORD_MODEL_TYPES
@@ -184,7 +188,10 @@ function getRecordIDForProduct(product, recordModel) {
         case RECORD_MODEL_TYPES.ATTRIBUTE_SLICED:
             return getAttributeSlicedModelRecordID(product);
         case RECORD_MODEL_TYPES.MASTER_LEVEL:
-            return product.isVariant() ? product.getMasterProduct().getID() : product.getID();
+            // a variation group is not indexed either, its master carries the record
+            return (product.isVariant() || product.isVariationGroup())
+                ? product.getMasterProduct().getID()
+                : product.getID();
         case RECORD_MODEL_TYPES.VARIANT_LEVEL:
         default:
             return product.getID();

--- a/cartridges/int_algolia/cartridge/scripts/algolia/recommend/utils.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/recommend/utils.js
@@ -2,39 +2,42 @@
 
 const { RECORD_MODEL_TYPES } = require('*/cartridge/scripts/algolia/lib/algoliaConstants');
 
-/**
- * Get the product type
- * @param {dw.catalog.Product} product - Product
- * @returns {string} The product type
- */
-function getProductType(product) {
-    if (product.isVariationGroup()) {
-        return 'Variation Group';
-    } else if (product.isVariant()) {
-        return 'Variant';
-    } else {
-        return 'Master';
-    }
-}
+// Algolia bills one request per anchor objectID and blends every anchor's results into a single
+// list of four, so one anchor per cart line item costs more without showing more. A multi-query
+// above 50 entries is also rejected outright, which would fail the whole widget.
+const MAX_ANCHOR_PRODUCTS = 5;
 
 /**
- * Get the appropriate product
- * @param {dw.catalog.Product} product - Product
- * @param {string} recordModel - Record model
- * @returns {dw.catalog.Product} The appropriate product
+ * Resolves the objectID that recommendations for a product should be anchored on.
+ *
+ * The anchor has to name a record that exists in the index, which is not always the product's own
+ * ID: under the master-level model a variant is indexed as its master, and under the
+ * attribute-sliced model as the slice holding its grouping attribute value. Masters and variation
+ * groups are only indexed under the master-level model, so under the other two they resolve to
+ * their default variant, which is.
+ *
+ * @param {dw.catalog.Product} product Product, variant or variation group, may be null
+ * @param {string} recordModel one of RECORD_MODEL_TYPES
+ * @returns {string | null} the objectID to anchor on, or null when the product has no record
  */
-function getAppropriateProduct(product, recordModel) {
-    const productType = getProductType(product);
-    if (recordModel === RECORD_MODEL_TYPES.MASTER_LEVEL && productType !== 'Master') {
-        return product.getMasterProduct(); // @TODO: refactor to be safer: only Variants and Variation Groups have the `masterProduct` property, add checks
-    } else if (recordModel === RECORD_MODEL_TYPES.MASTER_LEVEL && (productType === 'Master' || productType === 'Variation Group')) {
-        return product;
-    } else if (recordModel !== RECORD_MODEL_TYPES.MASTER_LEVEL && (productType === 'Master' || productType === 'Variation Group')) {
-        return product.getVariationModel().getDefaultVariant();
-    } else if (recordModel !== RECORD_MODEL_TYPES.MASTER_LEVEL && productType === 'Variant') {
-        return product;
+function getAnchorRecordID(product, recordModel) {
+    const modelHelper = require('*/cartridge/scripts/algolia/helper/modelHelper');
+
+    if (empty(product)) {
+        return null;
     }
-    return product;
+
+    let anchorProduct = product;
+
+    if (recordModel !== RECORD_MODEL_TYPES.MASTER_LEVEL && (product.isMaster() || product.isVariationGroup())) {
+        anchorProduct = product.getVariationModel().getDefaultVariant();
+
+        if (empty(anchorProduct)) {
+            return null;
+        }
+    }
+
+    return modelHelper.getRecordIDForProduct(anchorProduct, recordModel);
 }
 
 /**
@@ -65,13 +68,15 @@ function getAnchorProductIDs(slotcontent) {
 
     const anchorProductIDsArr = [];
 
-    for (let i = 0; i < productIDs.length; i++) {
-        var productId = productIDs[i];
-        var product = productMgr.getProduct(productId);
-        var appropriateProduct = getAppropriateProduct(product, recordModel);
+    for (let i = 0; i < productIDs.length && anchorProductIDsArr.length < MAX_ANCHOR_PRODUCTS; i++) {
+        let product = productMgr.getProduct(productIDs[i]);
+        let anchorRecordID = getAnchorRecordID(product, recordModel);
 
-        if (appropriateProduct) {
-            anchorProductIDsArr.push(appropriateProduct.getID());
+        // Several products can resolve to the same record, for example two sizes of one color
+        // under the attribute-sliced model. Sending a duplicate anchor costs a request and returns
+        // the same recommendations.
+        if (anchorRecordID && anchorProductIDsArr.indexOf(anchorRecordID) === -1) {
+            anchorProductIDsArr.push(anchorRecordID);
         }
     }
 

--- a/cartridges/int_algolia/cartridge/scripts/algolia/recommend/utils.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/recommend/utils.js
@@ -2,9 +2,130 @@
 
 const { RECORD_MODEL_TYPES } = require('*/cartridge/scripts/algolia/lib/algoliaConstants');
 
-// Since the number of distinct products in a cart can be high, we limit the number
-// of anchor products to 5 to avoid high costs for virtually no benefit.
+// Every anchor objectID is one Recommend request against the plan, and the widgets show at most
+// `maxRecommendations` items however many anchors they were given, so more anchors cost more
+// without showing more. Algolia also rejects a multi-query with more than 50 entries
+// ("Too many queries in multi query request", status 400), which fails the whole widget, so this
+// has to stay well below 50.
 const MAX_ANCHOR_PRODUCTS = 5;
+
+/**
+ * Returns the product that owns the record the given product is indexed under.
+ *
+ * Under the master-level model the master carries the record, so variants and variation groups
+ * resolve to their master. Under the other two models masters and variation groups are not indexed
+ * at all, so they resolve to their default variant. Every other product type carries its own
+ * record under all three models.
+ *
+ * @param {dw.catalog.Product} product a catalog product, master and variation group included
+ * @param {string} recordModel one of RECORD_MODEL_TYPES
+ * @returns {dw.catalog.Product | null} the product whose record is the anchor, or null when the
+ *                                     master has no default variant to fall back to
+ */
+function getIndexedProduct(product, recordModel) {
+    if (recordModel === RECORD_MODEL_TYPES.MASTER_LEVEL) {
+        return (product.isVariant() || product.isVariationGroup()) ? product.getMasterProduct() : product;
+    }
+
+    if (product.isMaster() || product.isVariationGroup()) {
+        return product.getVariationModel().getDefaultVariant();
+    }
+
+    return product;
+}
+
+/**
+ * Reports whether a product passes the three catalog filters the indexing jobs apply to a master
+ * product. `productFilter.isInclude()` cannot be used for that, because it rejects every master by
+ * design.
+ *
+ * @param {dw.catalog.Product} product a master product
+ * @returns {boolean} whether the master is online, searchable and in an online category
+ */
+function passesMasterFilters(product) {
+    const productFilter = require('*/cartridge/scripts/algolia/filters/productFilter');
+
+    return productFilter.isOnline(product) && productFilter.isSearchable(product) && productFilter.hasOnlineCategory(product);
+}
+
+/**
+ * Reports whether a master product has at least one variant that the indexing jobs would put in
+ * its `variants` array, which is what decides whether the master's record is written at all.
+ *
+ * This mirrors the two conditions the `variants` handler in `algoliaLocalizedProduct.js` applies to
+ * each variant. It stops at the first variant that passes, so a master with stock costs one
+ * variant; only a master with nothing indexable is walked in full.
+ *
+ * @param {dw.catalog.Product} master a master product
+ * @param {number} inStockThreshold minimum ATS for a variant to count as in stock
+ * @returns {boolean} whether the master has at least one indexable, in-stock variant
+ */
+function hasIndexableVariantInStock(master, inStockThreshold) {
+    const productFilter = require('*/cartridge/scripts/algolia/filters/productFilter');
+    const variantsIt = master.getVariants().iterator();
+
+    while (variantsIt.hasNext()) {
+        let variant = variantsIt.next();
+
+        if (productFilter.isInclude(variant) && productFilter.isInStock(variant, inStockThreshold)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Reports whether a product has a record in the index, applying the same filters the indexing jobs
+ * apply when they decide whether to write one.
+ *
+ * Anchoring on an objectID that has no record is not answered with an empty result set, so this
+ * errs on the side of dropping an anchor rather than keeping a doubtful one. The remaining
+ * imprecision is in that direction: under the attribute-sliced model an anchor is dropped when the
+ * anchor variant itself is not indexable, even though a sibling variant of the same grouping value
+ * may have kept the slice in the index.
+ *
+ * @param {dw.catalog.Product} product the product that owns the record, from getIndexedProduct()
+ * @param {string} recordModel one of RECORD_MODEL_TYPES
+ * @param {Object} sitePreferences stock-related preference values
+ * @param {number} sitePreferences.InStockThreshold minimum ATS for a product to count as in stock
+ * @param {boolean} sitePreferences.IndexOutOfStock whether out-of-stock products are indexed
+ * @returns {boolean} whether the product's record exists in the index
+ */
+function hasIndexedRecord(product, recordModel, sitePreferences) {
+    const productFilter = require('*/cartridge/scripts/algolia/filters/productFilter');
+
+    // Under the attribute-sliced model every slice is built from the master, so the master has to
+    // pass the catalog filters before any of its slices exists.
+    if (recordModel === RECORD_MODEL_TYPES.ATTRIBUTE_SLICED && product.isVariant() && !passesMasterFilters(product.getMasterProduct())) {
+        return false;
+    }
+
+    if (product.isMaster()) {
+        return passesMasterFilters(product)
+            && (sitePreferences.IndexOutOfStock || hasIndexableVariantInStock(product, sitePreferences.InStockThreshold));
+    }
+
+    return productFilter.isInclude(product)
+        && (sitePreferences.IndexOutOfStock || productFilter.isInStock(product, sitePreferences.InStockThreshold));
+}
+
+/**
+ * Reads the site preference values the anchor resolution depends on. Callers that resolve more than
+ * one anchor should read them once and pass them along.
+ *
+ * @returns {Object} preference values, in the shape getAnchorRecordID() expects
+ */
+function readSitePreferences() {
+    const algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
+
+    return {
+        // mirrors the fallback in algoliaProductIndex.js, which is what an unset preference resolves to there
+        InStockThreshold: algoliaData.getPreference('InStockThreshold') || 1,
+        IndexOutOfStock: algoliaData.getPreference('IndexOutOfStock'),
+        AttributeSlicedRecordModel_GroupingAttribute: algoliaData.getPreference('AttributeSlicedRecordModel_GroupingAttribute'),
+    };
+}
 
 /**
  * Resolves the objectID that recommendations for a product should be anchored on.
@@ -16,34 +137,41 @@ const MAX_ANCHOR_PRODUCTS = 5;
  * Masters and variation groups only get a record of their own under the master-level model. Under
  * the other two they are not indexed at all, so this anchors on their default variant instead.
  *
+ * A product that has no record in the index is not anchored on at all, so that the widget does not
+ * spend a request on an objectID that matches nothing.
+ *
  * @param {dw.catalog.Product} product any catalog product, masters and VariationGroups included; may be null
  * @param {string} recordModel one of RECORD_MODEL_TYPES
+ * @param {Object} [sitePreferences] preference values, read from the site preferences when omitted
+ * @param {number} sitePreferences.InStockThreshold minimum ATS for a product to count as in stock
+ * @param {boolean} sitePreferences.IndexOutOfStock whether out-of-stock products are indexed
+ * @param {string} [sitePreferences.AttributeSlicedRecordModel_GroupingAttribute] the grouping attribute, for the attribute-sliced model
  * @returns {string | null} the objectID to anchor on, or null when the product has no record
  */
-function getAnchorRecordID(product, recordModel) {
+function getAnchorRecordID(product, recordModel, sitePreferences) {
     const modelHelper = require('*/cartridge/scripts/algolia/helper/modelHelper');
 
     if (empty(product)) {
         return null;
     }
 
-    let anchorProduct = product;
+    const preferences = sitePreferences || readSitePreferences();
+    const indexedProduct = getIndexedProduct(product, recordModel);
 
-    if (recordModel !== RECORD_MODEL_TYPES.MASTER_LEVEL && (product.isMaster() || product.isVariationGroup())) {
-        anchorProduct = product.getVariationModel().getDefaultVariant();
-
-        if (empty(anchorProduct)) {
-            return null;
-        }
+    if (empty(indexedProduct) || !hasIndexedRecord(indexedProduct, recordModel, preferences)) {
+        return null;
     }
 
-    return modelHelper.getRecordIDForProduct(anchorProduct, recordModel);
+    return modelHelper.getRecordIDForProduct(indexedProduct, recordModel, preferences.AttributeSlicedRecordModel_GroupingAttribute);
 }
 
 /**
- * Get the anchor product IDs
- * @param {Object} slotcontent - Slot content
- * @returns {string} The anchor product IDs
+ * Builds the list of objectIDs the Recommend widgets in a slot anchor on, from the product IDs in
+ * `session.privacy.algoliaAnchorProducts` or, when that is not set, from the products configured on
+ * the slot itself.
+ *
+ * @param {dw.campaign.SlotContent} [slotcontent] slot content, used when the session holds no anchor products
+ * @returns {string} a JSON array of objectIDs, or an empty string when there is nothing to anchor on
  */
 function getAnchorProductIDs(slotcontent) {
     const anchorProductIDs = session.privacy.algoliaAnchorProducts;
@@ -51,10 +179,9 @@ function getAnchorProductIDs(slotcontent) {
 
     if (anchorProductIDs) {
         productIDs = JSON.parse(anchorProductIDs);
-    } else {
+    } else if (slotcontent && slotcontent.content) {
         for (let i = 0; i < slotcontent.content.length; i++) {
-            let product = slotcontent.content[i];
-            productIDs.push(product.getID());
+            productIDs.push(slotcontent.content[i].getID());
         }
     }
 
@@ -64,13 +191,14 @@ function getAnchorProductIDs(slotcontent) {
 
     const productMgr = require('dw/catalog/ProductMgr');
     const algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
+
     const recordModel = algoliaData.getPreference('RecordModel');
+    const sitePreferences = readSitePreferences();
 
     const anchorProductIDsArr = [];
 
     for (let i = 0; i < productIDs.length && anchorProductIDsArr.length < MAX_ANCHOR_PRODUCTS; i++) {
-        let product = productMgr.getProduct(productIDs[i]);
-        let anchorRecordID = getAnchorRecordID(product, recordModel);
+        let anchorRecordID = getAnchorRecordID(productMgr.getProduct(productIDs[i]), recordModel, sitePreferences);
 
         // Several products can resolve to the same record, for example two sizes of one color
         // under the attribute-sliced model. Sending a duplicate anchor costs a request and returns
@@ -80,9 +208,13 @@ function getAnchorProductIDs(slotcontent) {
         }
     }
 
-    return JSON.stringify(anchorProductIDsArr);
+    // An empty array is truthy in `recommend-config.js`, which would build a widget with no
+    // objectIDs. An empty attribute value makes it skip the widget instead.
+    return anchorProductIDsArr.length > 0 ? JSON.stringify(anchorProductIDsArr) : '';
 }
 
 module.exports = {
+    MAX_ANCHOR_PRODUCTS: MAX_ANCHOR_PRODUCTS,
+    getAnchorRecordID: getAnchorRecordID,
     getAnchorProductIDs: getAnchorProductIDs
 };

--- a/cartridges/int_algolia/cartridge/scripts/algolia/recommend/utils.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/recommend/utils.js
@@ -2,21 +2,21 @@
 
 const { RECORD_MODEL_TYPES } = require('*/cartridge/scripts/algolia/lib/algoliaConstants');
 
-// Algolia bills one request per anchor objectID and blends every anchor's results into a single
-// list of four, so one anchor per cart line item costs more without showing more. A multi-query
-// above 50 entries is also rejected outright, which would fail the whole widget.
+// Since the number of distinct products in a cart can be high, we limit the number
+// of anchor products to 5 to avoid high costs for virtually no benefit.
 const MAX_ANCHOR_PRODUCTS = 5;
 
 /**
  * Resolves the objectID that recommendations for a product should be anchored on.
  *
  * The anchor has to name a record that exists in the index, which is not always the product's own
- * ID: under the master-level model a variant is indexed as its master, and under the
- * attribute-sliced model as the slice holding its grouping attribute value. Masters and variation
- * groups are only indexed under the master-level model, so under the other two they resolve to
- * their default variant, which is.
+ * ID. Under the master-level model a variant is indexed as its master. Under the attribute-sliced
+ * model it is indexed as the slice that holds its grouping attribute value.
  *
- * @param {dw.catalog.Product} product Product, variant or variation group, may be null
+ * Masters and variation groups only get a record of their own under the master-level model. Under
+ * the other two they are not indexed at all, so this anchors on their default variant instead.
+ *
+ * @param {dw.catalog.Product} product any catalog product, masters and VariationGroups included; may be null
  * @param {string} recordModel one of RECORD_MODEL_TYPES
  * @returns {string | null} the objectID to anchor on, or null when the product has no record
  */

--- a/cartridges/int_algolia/cartridge/scripts/algolia/recommend/utils.js
+++ b/cartridges/int_algolia/cartridge/scripts/algolia/recommend/utils.js
@@ -3,7 +3,7 @@
 const { RECORD_MODEL_TYPES } = require('*/cartridge/scripts/algolia/lib/algoliaConstants');
 
 // Every anchor objectID is one Recommend request against the plan, and the widgets show at most
-// `maxRecommendations` items however many anchors they were given, so more anchors cost more
+// `maxRecommendations` items no matter how many anchors they were given, so more anchors cost more
 // without showing more. Algolia also rejects a multi-query with more than 50 entries
 // ("Too many queries in multi query request", status 400), which fails the whole widget, so this
 // has to stay well below 50.
@@ -17,10 +17,16 @@ const MAX_ANCHOR_PRODUCTS = 5;
  * at all, so they resolve to their default variant. Every other product type carries its own
  * record under all three models.
  *
+ * `getDefaultVariant()` returns an arbitrary variant when the master has no default variant
+ * defined, so a master always resolves to a variant as long as it has one. Which variant it is
+ * does not affect whether the anchor is valid: under the variant-level model every variant has its
+ * own record, and under the attribute-sliced model the slices are cut from the master rather than
+ * from the variation group, so any variant of the master resolves to a record that exists.
+ *
  * @param {dw.catalog.Product} product a catalog product, master and variation group included
  * @param {string} recordModel one of RECORD_MODEL_TYPES
  * @returns {dw.catalog.Product | null} the product whose record is the anchor, or null when the
- *                                     master has no default variant to fall back to
+ *                                     variation model has no variants to fall back to
  */
 function getIndexedProduct(product, recordModel) {
     if (recordModel === RECORD_MODEL_TYPES.MASTER_LEVEL) {
@@ -35,134 +41,41 @@ function getIndexedProduct(product, recordModel) {
 }
 
 /**
- * Reports whether a product passes the three catalog filters the indexing jobs apply to a master
- * product. `productFilter.isInclude()` cannot be used for that, because it rejects every master by
- * design.
- *
- * @param {dw.catalog.Product} product a master product
- * @returns {boolean} whether the master is online, searchable and in an online category
- */
-function passesMasterFilters(product) {
-    const productFilter = require('*/cartridge/scripts/algolia/filters/productFilter');
-
-    return productFilter.isOnline(product) && productFilter.isSearchable(product) && productFilter.hasOnlineCategory(product);
-}
-
-/**
- * Reports whether a master product has at least one variant that the indexing jobs would put in
- * its `variants` array, which is what decides whether the master's record is written at all.
- *
- * This mirrors the two conditions the `variants` handler in `algoliaLocalizedProduct.js` applies to
- * each variant. It stops at the first variant that passes, so a master with stock costs one
- * variant; only a master with nothing indexable is walked in full.
- *
- * @param {dw.catalog.Product} master a master product
- * @param {number} inStockThreshold minimum ATS for a variant to count as in stock
- * @returns {boolean} whether the master has at least one indexable, in-stock variant
- */
-function hasIndexableVariantInStock(master, inStockThreshold) {
-    const productFilter = require('*/cartridge/scripts/algolia/filters/productFilter');
-    const variantsIt = master.getVariants().iterator();
-
-    while (variantsIt.hasNext()) {
-        let variant = variantsIt.next();
-
-        if (productFilter.isInclude(variant) && productFilter.isInStock(variant, inStockThreshold)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-/**
- * Reports whether a product has a record in the index, applying the same filters the indexing jobs
- * apply when they decide whether to write one.
- *
- * Anchoring on an objectID that has no record is not answered with an empty result set, so this
- * errs on the side of dropping an anchor rather than keeping a doubtful one. The remaining
- * imprecision is in that direction: under the attribute-sliced model an anchor is dropped when the
- * anchor variant itself is not indexable, even though a sibling variant of the same grouping value
- * may have kept the slice in the index.
- *
- * @param {dw.catalog.Product} product the product that owns the record, from getIndexedProduct()
- * @param {string} recordModel one of RECORD_MODEL_TYPES
- * @param {Object} sitePreferences stock-related preference values
- * @param {number} sitePreferences.InStockThreshold minimum ATS for a product to count as in stock
- * @param {boolean} sitePreferences.IndexOutOfStock whether out-of-stock products are indexed
- * @returns {boolean} whether the product's record exists in the index
- */
-function hasIndexedRecord(product, recordModel, sitePreferences) {
-    const productFilter = require('*/cartridge/scripts/algolia/filters/productFilter');
-
-    // Under the attribute-sliced model every slice is built from the master, so the master has to
-    // pass the catalog filters before any of its slices exists.
-    if (recordModel === RECORD_MODEL_TYPES.ATTRIBUTE_SLICED && product.isVariant() && !passesMasterFilters(product.getMasterProduct())) {
-        return false;
-    }
-
-    if (product.isMaster()) {
-        return passesMasterFilters(product)
-            && (sitePreferences.IndexOutOfStock || hasIndexableVariantInStock(product, sitePreferences.InStockThreshold));
-    }
-
-    return productFilter.isInclude(product)
-        && (sitePreferences.IndexOutOfStock || productFilter.isInStock(product, sitePreferences.InStockThreshold));
-}
-
-/**
- * Reads the site preference values the anchor resolution depends on. Callers that resolve more than
- * one anchor should read them once and pass them along.
- *
- * @returns {Object} preference values, in the shape getAnchorRecordID() expects
- */
-function readSitePreferences() {
-    const algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
-
-    return {
-        // mirrors the fallback in algoliaProductIndex.js, which is what an unset preference resolves to there
-        InStockThreshold: algoliaData.getPreference('InStockThreshold') || 1,
-        IndexOutOfStock: algoliaData.getPreference('IndexOutOfStock'),
-        AttributeSlicedRecordModel_GroupingAttribute: algoliaData.getPreference('AttributeSlicedRecordModel_GroupingAttribute'),
-    };
-}
-
-/**
  * Resolves the objectID that recommendations for a product should be anchored on.
  *
- * The anchor has to name a record that exists in the index, which is not always the product's own
- * ID. Under the master-level model a variant is indexed as its master. Under the attribute-sliced
- * model it is indexed as the slice that holds its grouping attribute value.
+ * The anchor has to name the record the product is indexed under, which is not always the product's
+ * own ID. Under the master-level model a variant is indexed as its master. Under the
+ * attribute-sliced model it is indexed as the slice that holds its grouping attribute value.
  *
  * Masters and variation groups only get a record of their own under the master-level model. Under
  * the other two they are not indexed at all, so this anchors on their default variant instead.
  *
- * A product that has no record in the index is not anchored on at all, so that the widget does not
- * spend a request on an objectID that matches nothing.
+ * Whether the resolved record is actually in the index is left to Algolia. A product can be in the
+ * catalog but out of the index, for example after going out of stock or offline, but the inventory
+ * hook and the delta jobs keep that window short, and the storefront search is out of sync for the
+ * same window.
  *
  * @param {dw.catalog.Product} product any catalog product, masters and VariationGroups included; may be null
  * @param {string} recordModel one of RECORD_MODEL_TYPES
- * @param {Object} [sitePreferences] preference values, read from the site preferences when omitted
- * @param {number} sitePreferences.InStockThreshold minimum ATS for a product to count as in stock
- * @param {boolean} sitePreferences.IndexOutOfStock whether out-of-stock products are indexed
- * @param {string} [sitePreferences.AttributeSlicedRecordModel_GroupingAttribute] the grouping attribute, for the attribute-sliced model
- * @returns {string | null} the objectID to anchor on, or null when the product has no record
+ * @param {string} [groupingAttribute] the grouping attribute of the attribute-sliced model, read
+ *                                     from the site preferences when omitted
+ * @returns {string | null} the objectID to anchor on, or null when it cannot be resolved
  */
-function getAnchorRecordID(product, recordModel, sitePreferences) {
+function getAnchorRecordID(product, recordModel, groupingAttribute) {
     const modelHelper = require('*/cartridge/scripts/algolia/helper/modelHelper');
 
     if (empty(product)) {
         return null;
     }
 
-    const preferences = sitePreferences || readSitePreferences();
+    // null for a master with no variants, which has no record under any model
     const indexedProduct = getIndexedProduct(product, recordModel);
 
-    if (empty(indexedProduct) || !hasIndexedRecord(indexedProduct, recordModel, preferences)) {
+    if (empty(indexedProduct)) {
         return null;
     }
 
-    return modelHelper.getRecordIDForProduct(indexedProduct, recordModel, preferences.AttributeSlicedRecordModel_GroupingAttribute);
+    return modelHelper.getRecordIDForProduct(indexedProduct, recordModel, groupingAttribute);
 }
 
 /**
@@ -193,12 +106,16 @@ function getAnchorProductIDs(slotcontent) {
     const algoliaData = require('*/cartridge/scripts/algolia/lib/algoliaData');
 
     const recordModel = algoliaData.getPreference('RecordModel');
-    const sitePreferences = readSitePreferences();
+
+    // read once here instead of once per product inside getAttributeSlicedModelRecordID()
+    const groupingAttribute = recordModel === RECORD_MODEL_TYPES.ATTRIBUTE_SLICED
+        ? algoliaData.getPreference('AttributeSlicedRecordModel_GroupingAttribute')
+        : null;
 
     const anchorProductIDsArr = [];
 
     for (let i = 0; i < productIDs.length && anchorProductIDsArr.length < MAX_ANCHOR_PRODUCTS; i++) {
-        let anchorRecordID = getAnchorRecordID(productMgr.getProduct(productIDs[i]), recordModel, sitePreferences);
+        let anchorRecordID = getAnchorRecordID(productMgr.getProduct(productIDs[i]), recordModel, groupingAttribute);
 
         // Several products can resolve to the same record, for example two sizes of one color
         // under the attribute-sliced model. Sending a duplicate anchor costs a request and returns

--- a/cartridges/int_algolia_sfra/cartridge/controllers/Cart.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Cart.js
@@ -14,13 +14,23 @@ server.extend(base);
 server.append('Show', function (req, res, next) {
     if (algoliaData.getPreference('Enable') && algoliaData.getPreference('EnableRecommend')) {
 
+        var recommendUtils = require('*/cartridge/scripts/algolia/recommend/utils');
         var algoliaAnchorProducts = [];
         var basket = BasketMgr.getCurrentOrNewBasket();
         var plisArr = basket.productLineItems.toArray();
 
-        plisArr.forEach(function(pli) {
-            algoliaAnchorProducts.push(pli.productID);
-        });
+        // Several line items can reference the same product, for example the same product added
+        // twice with different options, and the widgets anchor on at most MAX_ANCHOR_PRODUCTS
+        // objectIDs anyway. Writing only the distinct product IDs up to that number keeps the
+        // session string short, which matters because a `session.privacy` value is capped at 2000
+        // characters, and bounds the work the slot templates do when they resolve the anchors.
+        for (var i = 0; i < plisArr.length && algoliaAnchorProducts.length < recommendUtils.MAX_ANCHOR_PRODUCTS; i++) {
+            var lineItemProductID = plisArr[i].getProductID();
+
+            if (algoliaAnchorProducts.indexOf(lineItemProductID) === -1) {
+                algoliaAnchorProducts.push(lineItemProductID);
+            }
+        }
 
         session.privacy.algoliaAnchorProducts = JSON.stringify(algoliaAnchorProducts);
     }

--- a/cartridges/int_algolia_sfra/cartridge/controllers/Product.js
+++ b/cartridges/int_algolia_sfra/cartridge/controllers/Product.js
@@ -36,7 +36,11 @@ server.append('Variation', function (req, res, next) {
 
         if (viewData.product) {
             session.privacy.algoliaAnchorProducts = JSON.stringify([viewData.product.id]);
-            viewData.algoliaAnchorProduct = JSON.parse(recommendUtils.getAnchorProductIDs())[0];
+
+            // An empty string means the selected variation has no record to anchor on, so there is
+            // nothing to re-render the widgets with. It is not valid JSON, so it cannot be parsed.
+            var anchorProductIDs = recommendUtils.getAnchorProductIDs();
+            viewData.algoliaAnchorProduct = anchorProductIDs ? JSON.parse(anchorProductIDs)[0] : null;
             res.setViewData(viewData);
         }
     }

--- a/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/recommend-config.js
+++ b/cartridges/int_algolia_sfra/cartridge/static/default/js/algolia/recommend-config.js
@@ -110,7 +110,12 @@ function getObjectIds(container) {
         const objectIDs = container.getAttribute('data-object-ids');
         if (!objectIDs) return null;
         var dataObjectIds = objectIDs.replace(/'/g, '"');
-        return JSON.parse(dataObjectIds);
+        var parsedObjectIds = JSON.parse(dataObjectIds);
+
+        // An empty array is truthy, so return null for it as well. The widgets that require an
+        // anchor check the return value and skip rendering, instead of issuing a request with no
+        // objectIDs.
+        return parsedObjectIds && parsedObjectIds.length ? parsedObjectIds : null;
     } catch (e) {
         console.error('Parsing error on objectIDs:', e);
         return null;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -332,9 +332,6 @@ jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => {
 jest.mock('*/cartridge/scripts/algolia/lib/algoliaProductConfig', () => {
     return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig');
 }, {virtual: true});
-jest.mock('*/cartridge/scripts/algolia/helper/modelHelper', () => {
-    return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper');
-}, {virtual: true});
 jest.mock('*/cartridge/scripts/algolia/lib/utils', () => {
     return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/lib/utils');
 }, {virtual: true});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -332,6 +332,9 @@ jest.mock('*/cartridge/scripts/algolia/lib/algoliaData', () => {
 jest.mock('*/cartridge/scripts/algolia/lib/algoliaProductConfig', () => {
     return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/lib/algoliaProductConfig');
 }, {virtual: true});
+jest.mock('*/cartridge/scripts/algolia/helper/modelHelper', () => {
+    return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/helper/modelHelper');
+}, {virtual: true});
 jest.mock('*/cartridge/scripts/algolia/lib/utils', () => {
     return jest.requireActual('./cartridges/int_algolia/cartridge/scripts/algolia/lib/utils');
 }, {virtual: true});

--- a/test/unit/int_algolia/scripts/algolia/helper/modelHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/modelHelper.test.js
@@ -86,7 +86,16 @@ describe('getRecordIDForProduct', () => {
     const simpleProduct = {
         isMaster: () => false,
         isVariant: () => false,
+        isVariationGroup: () => false,
         getID: () => 'SIMPLE1',
+    };
+
+    const variationGroupProduct = {
+        isMaster: () => false,
+        isVariant: () => false,
+        isVariationGroup: () => true,
+        getMasterProduct: () => ({ getID: () => 'MASTER1' }),
+        getID: () => 'VG1',
     };
 
     let variantProduct;
@@ -126,6 +135,10 @@ describe('getRecordIDForProduct', () => {
 
     test('master-level: a product without a master keeps its own ID', () => {
         expect(modelHelper.getRecordIDForProduct(simpleProduct, 'master-level')).toBe('SIMPLE1');
+    });
+
+    test('master-level: a variation group is reported as its master, since it is not indexed', () => {
+        expect(modelHelper.getRecordIDForProduct(variationGroupProduct, 'master-level')).toBe('MASTER1');
     });
 
     test('variant-level: the product keeps its own ID', () => {

--- a/test/unit/int_algolia/scripts/algolia/helper/modelHelper.test.js
+++ b/test/unit/int_algolia/scripts/algolia/helper/modelHelper.test.js
@@ -80,6 +80,17 @@ describe('getAttributeSlicedModelRecordID', () => {
         };
         expect(modelHelper.getAttributeSlicedModelRecordID(simpleProduct)).toBe('SIMPLE1');
     });
+
+    test('uses the grouping attribute passed in instead of reading the preference', () => {
+        const masterProduct = new MasterProductMock({ ID: 'MASTER1' });
+        const variantProduct = new VariantMock({
+            ID: 'VAR1',
+            masterProduct,
+            variationAttributes: { color: 'JJB52A0', size: '004' },
+        });
+        expect(modelHelper.getAttributeSlicedModelRecordID(variantProduct, 'color')).toBe('MASTER1-JJB52A0');
+        expect(algoliaDataMock.getPreference).not.toHaveBeenCalled();
+    });
 });
 
 describe('getRecordIDForProduct', () => {
@@ -114,9 +125,14 @@ describe('getRecordIDForProduct', () => {
         });
     });
 
-    test('attribute-sliced: a variant is reported as its variation group', () => {
+    test('attribute-sliced: a variant is reported as the slice holding its grouping attribute value', () => {
         algoliaDataMock.getPreference.mockReturnValue('color');
         expect(modelHelper.getRecordIDForProduct(variantProduct, 'attribute-sliced')).toBe('MASTER1-JJB52A0');
+    });
+
+    test('attribute-sliced: the grouping attribute can be passed in instead of read from the preference', () => {
+        expect(modelHelper.getRecordIDForProduct(variantProduct, 'attribute-sliced', 'color')).toBe('MASTER1-JJB52A0');
+        expect(algoliaDataMock.getPreference).not.toHaveBeenCalled();
     });
 
     test('attribute-sliced: a product without variants keeps its own ID', () => {

--- a/test/unit/int_algolia/scripts/algolia/recommend/utils.test.js
+++ b/test/unit/int_algolia/scripts/algolia/recommend/utils.test.js
@@ -1,13 +1,66 @@
 /**
- * The record model is read through the real `algoliaData.getPreference`, which resolves it from
- * `global.customPreferences` via the Site mock. Setting that global is therefore the only way to
- * drive the module; a `jest.fn()` on algoliaData is not wired to it. Every test sets the model it
- * needs and `beforeEach` resets it, so no test depends on another having run first.
+ * `getAnchorRecordID` takes the record model and the site preference values as arguments, so the
+ * tests for the record-model matrix and for the indexing filters need no global setup.
+ *
+ * `getAnchorProductIDs` reads them itself, through the real `algoliaData.getPreference`, which
+ * resolves them from `global.customPreferences` via the Site mock. Setting that global is the only
+ * way to drive it; a `jest.fn()` on algoliaData is not wired to it.
  */
 const productMgrMock = require('dw/catalog/ProductMgr');
 const utils = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/recommend/utils');
 
 const emptySlotcontent = { content: [] };
+
+// Out-of-stock products are indexed, so the stock filter passes for every product. Tests that are
+// about stock pass their own preferences.
+const INDEX_EVERYTHING = { InStockThreshold: 1, IndexOutOfStock: true };
+const SLICED_BY_COLOR = { InStockThreshold: 1, IndexOutOfStock: true, AttributeSlicedRecordModel_GroupingAttribute: 'color' };
+
+/**
+ * Builds an availability model whose inventory record reports the given available-to-sell quantity.
+ * @param {number} ats available-to-sell quantity
+ * @returns {Object} availability model mock
+ */
+function availabilityModelWithATS(ats) {
+    return {
+        getInventoryRecord: jest.fn(() => ({
+            getATS: jest.fn(() => ({ getValue: jest.fn(() => ats) })),
+        })),
+    };
+}
+
+/**
+ * Builds a product mock that answers false to every type predicate and passes every indexing
+ * filter, so each test only has to describe what it is actually about.
+ * @param {string} id product ID
+ * @param {Object} [overrides] properties to replace on the mock
+ * @returns {Object} product mock
+ */
+function productMock(id, overrides) {
+    return Object.assign({
+        ID: id,
+        getID: jest.fn(() => id),
+        isMaster: jest.fn(() => false),
+        isVariant: jest.fn(() => false),
+        isVariationGroup: jest.fn(() => false),
+        isBundled: jest.fn(() => false),
+        isOnline: jest.fn(() => true),
+        isSearchable: jest.fn(() => true),
+        getOnlineCategories: jest.fn(() => [{ ID: 'category1' }]),
+        getAvailabilityModel: jest.fn(() => availabilityModelWithATS(10)),
+    }, overrides || {});
+}
+
+/**
+ * Builds the master a variant or variation group reports through getMasterProduct(). The real API
+ * returns a full dw.catalog.Product there, so under the master-level model the filters run against
+ * it directly.
+ * @param {string} masterID master product ID
+ * @returns {Object} master product mock
+ */
+function masterProductRef(masterID) {
+    return masterMock(masterID, productMock(masterID + '-default', { isVariant: jest.fn(() => true) }));
+}
 
 /**
  * Builds a variation model that only answers getDefaultVariant().
@@ -18,62 +71,69 @@ function variationModelWithDefault(defaultVariant) {
     return { getDefaultVariant: jest.fn(() => defaultVariant) };
 }
 
-const variantProduct = {
-    ID: 'variant1',
-    getID: jest.fn(() => 'variant1'),
-    isMaster: jest.fn(() => false),
-    isVariant: jest.fn(() => true),
-    isVariationGroup: jest.fn(() => false),
-    getMasterProduct: jest.fn(() => ({ getID: jest.fn(() => 'master1') })),
-};
+/**
+ * Builds a variant.
+ * @param {string} id variant ID
+ * @param {string} masterID master product ID
+ * @param {Object} [overrides] properties to replace on the mock
+ * @returns {Object} variant mock
+ */
+function variantMock(id, masterID, overrides) {
+    return productMock(id, Object.assign({
+        isVariant: jest.fn(() => true),
+        getMasterProduct: jest.fn(() => masterProductRef(masterID)),
+    }, overrides || {}));
+}
 
-const masterProduct = {
-    ID: 'master1',
-    getID: jest.fn(() => 'master1'),
-    isMaster: jest.fn(() => true),
-    isVariant: jest.fn(() => false),
-    isVariationGroup: jest.fn(() => false),
-    getVariationModel: jest.fn(() => variationModelWithDefault({ getID: jest.fn(() => 'variant1') })),
-};
+/**
+ * Builds a dw.util.Collection-like list of variants that only answers iterator().
+ * @param {Array} variants the variants to serve
+ * @returns {Object} variant collection mock
+ */
+function variantCollection(variants) {
+    return {
+        iterator: jest.fn(() => {
+            let index = 0;
+            return {
+                hasNext: jest.fn(() => index < variants.length),
+                next: jest.fn(() => variants[index++]),
+            };
+        }),
+    };
+}
 
-const masterWithoutVariants = {
-    ID: 'master2',
-    getID: jest.fn(() => 'master2'),
-    isMaster: jest.fn(() => true),
-    isVariant: jest.fn(() => false),
-    isVariationGroup: jest.fn(() => false),
-    getVariationModel: jest.fn(() => variationModelWithDefault(null)),
-};
+/**
+ * Builds a master product. Its variants default to the one variant getDefaultVariant() reports.
+ * @param {string} id master product ID
+ * @param {Object|null} defaultVariant the variant getDefaultVariant() reports
+ * @param {Object} [overrides] properties to replace on the mock
+ * @param {Array} [variants] every variant of the master, when it has more than the default one
+ * @returns {Object} master product mock
+ */
+function masterMock(id, defaultVariant, overrides, variants) {
+    const allVariants = variants || (defaultVariant ? [defaultVariant] : []);
 
-const variationGroupProduct = {
-    ID: 'variationGroup1',
-    getID: jest.fn(() => 'variationGroup1'),
-    isMaster: jest.fn(() => false),
-    isVariant: jest.fn(() => false),
-    isVariationGroup: jest.fn(() => true),
-    getMasterProduct: jest.fn(() => ({ getID: jest.fn(() => 'master1') })),
-    getVariationModel: jest.fn(() => variationModelWithDefault({ getID: jest.fn(() => 'variant1') })),
-};
+    return productMock(id, Object.assign({
+        isMaster: jest.fn(() => true),
+        getVariationModel: jest.fn(() => variationModelWithDefault(defaultVariant)),
+        getVariants: jest.fn(() => variantCollection(allVariants)),
+    }, overrides || {}));
+}
 
-// A simple product answers false to all three predicates and has no usable variation model.
-// This is the case that used to be dropped: it was labelled a master, sent to getDefaultVariant(),
-// and resolved to null.
-const simpleProduct = {
-    ID: 'simple1',
-    getID: jest.fn(() => 'simple1'),
-    isMaster: jest.fn(() => false),
-    isVariant: jest.fn(() => false),
-    isVariationGroup: jest.fn(() => false),
-};
-
-const bundleProduct = {
-    ID: 'bundle1',
-    getID: jest.fn(() => 'bundle1'),
-    isMaster: jest.fn(() => false),
-    isVariant: jest.fn(() => false),
-    isVariationGroup: jest.fn(() => false),
-    isBundle: jest.fn(() => true),
-};
+/**
+ * Builds a variation group.
+ * @param {string} id variation group ID
+ * @param {string} masterID master product ID
+ * @param {Object|null} defaultVariant the variant getDefaultVariant() reports
+ * @returns {Object} variation group mock
+ */
+function variationGroupMock(id, masterID, defaultVariant) {
+    return productMock(id, {
+        isVariationGroup: jest.fn(() => true),
+        getMasterProduct: jest.fn(() => masterProductRef(masterID)),
+        getVariationModel: jest.fn(() => variationModelWithDefault(defaultVariant)),
+    });
+}
 
 /**
  * Builds a variant whose attribute-sliced record is `<masterID>-<colorValueID>`, mirroring the
@@ -81,29 +141,304 @@ const bundleProduct = {
  * @param {string} id variant ID
  * @param {string} masterID master ID
  * @param {string} colorValueID grouping attribute value ID
+ * @param {Object} [overrides] properties to replace on the mock
  * @returns {Object} variant mock
  */
-function slicedVariant(id, masterID, colorValueID) {
-    return {
-        ID: id,
-        getID: jest.fn(() => id),
-        isMaster: jest.fn(() => false),
-        isVariant: jest.fn(() => true),
-        isVariationGroup: jest.fn(() => false),
-        getMasterProduct: jest.fn(() => ({ getID: jest.fn(() => masterID) })),
+function slicedVariantMock(id, masterID, colorValueID, overrides) {
+    return variantMock(id, masterID, Object.assign({
         getVariationModel: jest.fn(() => ({
             getProductVariationAttribute: jest.fn(() => ({ getID: jest.fn(() => 'color') })),
-            getMaster: jest.fn(() => ({ getID: jest.fn(() => masterID) })),
+            getMaster: jest.fn(() => masterProductRef(masterID)),
             getSelectedValue: jest.fn(() => ({ getID: jest.fn(() => colorValueID) })),
         })),
-    };
+    }, overrides || {}));
 }
+
+describe('getAnchorRecordID', () => {
+    describe('variant-level record model', () => {
+        it('anchors a variant on its own ID', () => {
+            const product = variantMock('variant1', 'master1');
+
+            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBe('variant1');
+        });
+
+        it('anchors a master on its default variant, since masters are not indexed', () => {
+            const product = masterMock('master1', variantMock('variant1', 'master1'));
+
+            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBe('variant1');
+        });
+
+        it('anchors a variation group on its default variant', () => {
+            const product = variationGroupMock('variationGroup1', 'master1', variantMock('variant1', 'master1'));
+
+            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBe('variant1');
+        });
+
+        // The bug this ticket fixes. Before the change all four of these resolved to null and were
+        // dropped, because anything that was not a variant or a variation group was treated as a
+        // master and sent to getDefaultVariant().
+        it('anchors a simple product on its own ID', () => {
+            expect(utils.getAnchorRecordID(productMock('simple1'), 'variant-level', INDEX_EVERYTHING)).toBe('simple1');
+        });
+
+        it('anchors a bundle on its own ID', () => {
+            const bundle = productMock('bundle1', { isBundle: jest.fn(() => true) });
+
+            expect(utils.getAnchorRecordID(bundle, 'variant-level', INDEX_EVERYTHING)).toBe('bundle1');
+        });
+
+        it('anchors a product set on its own ID', () => {
+            const productSet = productMock('set1', { isProductSet: jest.fn(() => true) });
+
+            expect(utils.getAnchorRecordID(productSet, 'variant-level', INDEX_EVERYTHING)).toBe('set1');
+        });
+
+        it('anchors an option product on its own ID', () => {
+            const optionProduct = productMock('option1', { getOptionModel: jest.fn(() => ({})) });
+
+            expect(utils.getAnchorRecordID(optionProduct, 'variant-level', INDEX_EVERYTHING)).toBe('option1');
+        });
+
+        it('never reaches the variation model of a product that is not a master or a variation group', () => {
+            const simpleProduct = productMock('simple1', { getVariationModel: jest.fn() });
+
+            utils.getAnchorRecordID(simpleProduct, 'variant-level', INDEX_EVERYTHING);
+
+            expect(simpleProduct.getVariationModel).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('master-level record model', () => {
+        it('anchors a variant on its master', () => {
+            const product = variantMock('variant1', 'master1');
+
+            expect(utils.getAnchorRecordID(product, 'master-level', INDEX_EVERYTHING)).toBe('master1');
+        });
+
+        it('anchors a master on its own ID', () => {
+            const product = masterMock('master1', variantMock('variant1', 'master1'));
+
+            expect(utils.getAnchorRecordID(product, 'master-level', INDEX_EVERYTHING)).toBe('master1');
+        });
+
+        it('anchors a variation group on its master, since variation groups are not indexed', () => {
+            const product = variationGroupMock('variationGroup1', 'master1', variantMock('variant1', 'master1'));
+
+            expect(utils.getAnchorRecordID(product, 'master-level', INDEX_EVERYTHING)).toBe('master1');
+        });
+
+        it('anchors a simple product on its own ID', () => {
+            expect(utils.getAnchorRecordID(productMock('simple1'), 'master-level', INDEX_EVERYTHING)).toBe('simple1');
+        });
+
+        it('anchors a bundle on its own ID', () => {
+            const bundle = productMock('bundle1', { isBundle: jest.fn(() => true) });
+
+            expect(utils.getAnchorRecordID(bundle, 'master-level', INDEX_EVERYTHING)).toBe('bundle1');
+        });
+
+        it('never reaches the variation model, since no product resolves to a default variant', () => {
+            const product = masterMock('master1', variantMock('variant1', 'master1'));
+
+            utils.getAnchorRecordID(product, 'master-level', INDEX_EVERYTHING);
+
+            expect(product.getVariationModel).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('attribute-sliced record model', () => {
+        // Reproduces the case debugged on the sandbox: the variant's own ID has no record, the
+        // slice holding its color does.
+        it('anchors a variant on the slice holding its grouping attribute value', () => {
+            const product = slicedVariantMock('013742003154M', '25720054M', 'JJG03XX');
+
+            expect(utils.getAnchorRecordID(product, 'attribute-sliced', SLICED_BY_COLOR)).toBe('25720054M-JJG03XX');
+        });
+
+        it('anchors a master on the slice holding its default variant', () => {
+            const defaultVariant = slicedVariantMock('013742003154M', '25720054M', 'JJG03XX');
+            const product = masterMock('25720054M', defaultVariant);
+
+            expect(utils.getAnchorRecordID(product, 'attribute-sliced', SLICED_BY_COLOR)).toBe('25720054M-JJG03XX');
+        });
+
+        it('anchors a variation group on the slice holding its default variant', () => {
+            const defaultVariant = slicedVariantMock('013742003154M', '25720054M', 'JJG03XX');
+            const product = variationGroupMock('variationGroup1', '25720054M', defaultVariant);
+
+            expect(utils.getAnchorRecordID(product, 'attribute-sliced', SLICED_BY_COLOR)).toBe('25720054M-JJG03XX');
+        });
+
+        // A master that does not have the grouping attribute is written as a single master-level
+        // record, so its variants anchor on the plain master ID.
+        it('anchors a variant of a master without the grouping attribute on the master ID', () => {
+            const product = variantMock('variant1', 'master1', {
+                getVariationModel: jest.fn(() => ({
+                    getProductVariationAttribute: jest.fn(() => null),
+                    getMaster: jest.fn(() => masterProductRef('master1')),
+                })),
+            });
+
+            expect(utils.getAnchorRecordID(product, 'attribute-sliced', SLICED_BY_COLOR)).toBe('master1');
+        });
+
+        it('anchors a simple product on its own ID', () => {
+            expect(utils.getAnchorRecordID(productMock('simple1'), 'attribute-sliced', SLICED_BY_COLOR)).toBe('simple1');
+        });
+
+        it('anchors a bundle on its own ID', () => {
+            const bundle = productMock('bundle1', { isBundle: jest.fn(() => true) });
+
+            expect(utils.getAnchorRecordID(bundle, 'attribute-sliced', SLICED_BY_COLOR)).toBe('bundle1');
+        });
+
+        it('returns null when no grouping attribute is configured, since no record ID can be built', () => {
+            const product = slicedVariantMock('013742003154M', '25720054M', 'JJG03XX');
+
+            expect(utils.getAnchorRecordID(product, 'attribute-sliced', INDEX_EVERYTHING)).toBeNull();
+        });
+
+        // Every slice is built from the master, so an offline master has no slice records at all,
+        // however online its individual variants are.
+        it('returns null for a variant of an offline master', () => {
+            const offlineMaster = masterMock('25720054M', null, { isOnline: jest.fn(() => false) });
+            const product = slicedVariantMock('013742003154M', '25720054M', 'JJG03XX', {
+                getMasterProduct: jest.fn(() => offlineMaster),
+            });
+
+            expect(utils.getAnchorRecordID(product, 'attribute-sliced', SLICED_BY_COLOR)).toBeNull();
+        });
+    });
+
+    describe('site preferences', () => {
+        it('falls back to reading the site preferences when they are not passed in', () => {
+            global.customPreferences.Algolia_IndexOutOfStock = true;
+            const product = variantMock('variant1', 'master1');
+
+            expect(utils.getAnchorRecordID(product, 'variant-level')).toBe('variant1');
+
+            delete global.customPreferences.Algolia_IndexOutOfStock;
+        });
+    });
+
+    describe('an unrecognized record model', () => {
+        it('falls back to the product ID, matching the variant-level model', () => {
+            const product = variantMock('variant1', 'master1');
+
+            expect(utils.getAnchorRecordID(product, '', INDEX_EVERYTHING)).toBe('variant1');
+        });
+    });
+
+    describe('products that have no record to anchor on', () => {
+        it('returns null for a product that no longer resolves in the catalog', () => {
+            expect(utils.getAnchorRecordID(null, 'variant-level', INDEX_EVERYTHING)).toBeNull();
+        });
+
+        it('returns null for a master that has no default variant', () => {
+            const product = masterMock('master2', null);
+
+            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBeNull();
+        });
+
+        it('returns null for an offline product, which the jobs do not index', () => {
+            const product = productMock('simple1', { isOnline: jest.fn(() => false) });
+
+            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBeNull();
+        });
+
+        it('returns null for a product that is not searchable', () => {
+            const product = productMock('simple1', { isSearchable: jest.fn(() => false) });
+
+            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBeNull();
+        });
+
+        it('returns null for a product with no online category', () => {
+            const product = productMock('simple1', { getOnlineCategories: jest.fn(() => []) });
+
+            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBeNull();
+        });
+
+        it('returns null for a variant whose master has no online category', () => {
+            const product = variantMock('variant1', 'master1', {
+                getMasterProduct: jest.fn(() => ({
+                    getID: jest.fn(() => 'master1'),
+                    getOnlineCategories: jest.fn(() => []),
+                })),
+            });
+
+            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBeNull();
+        });
+
+        it('returns null for an offline master under the master-level model', () => {
+            const product = masterMock('master1', variantMock('variant1', 'master1'), { isOnline: jest.fn(() => false) });
+
+            expect(utils.getAnchorRecordID(product, 'master-level', INDEX_EVERYTHING)).toBeNull();
+        });
+
+        it('returns null for an out-of-stock product when out-of-stock products are not indexed', () => {
+            const product = productMock('simple1', { getAvailabilityModel: jest.fn(() => availabilityModelWithATS(0)) });
+
+            expect(utils.getAnchorRecordID(product, 'variant-level', { InStockThreshold: 1, IndexOutOfStock: false })).toBeNull();
+        });
+
+        it('anchors an out-of-stock product when out-of-stock products are indexed', () => {
+            const product = productMock('simple1', { getAvailabilityModel: jest.fn(() => availabilityModelWithATS(0)) });
+
+            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBe('simple1');
+        });
+
+        it('returns null for a product below the in-stock threshold', () => {
+            const product = productMock('simple1', { getAvailabilityModel: jest.fn(() => availabilityModelWithATS(4)) });
+
+            expect(utils.getAnchorRecordID(product, 'variant-level', { InStockThreshold: 5, IndexOutOfStock: false })).toBeNull();
+        });
+
+        it('anchors a product at the in-stock threshold', () => {
+            const product = productMock('simple1', { getAvailabilityModel: jest.fn(() => availabilityModelWithATS(5)) });
+
+            expect(utils.getAnchorRecordID(product, 'variant-level', { InStockThreshold: 5, IndexOutOfStock: false })).toBe('simple1');
+        });
+
+        it('returns null for a master under the master-level model when none of its variants is in stock', () => {
+            const outOfStockVariant = variantMock('variant1', 'master1', {
+                getAvailabilityModel: jest.fn(() => availabilityModelWithATS(0)),
+            });
+            const product = masterMock('master1', outOfStockVariant);
+
+            expect(utils.getAnchorRecordID(product, 'master-level', { InStockThreshold: 1, IndexOutOfStock: false })).toBeNull();
+        });
+
+        it('anchors a master under the master-level model when one of its variants is in stock', () => {
+            const product = masterMock('master1', variantMock('variant1', 'master1'));
+
+            expect(utils.getAnchorRecordID(product, 'master-level', { InStockThreshold: 1, IndexOutOfStock: false })).toBe('master1');
+        });
+
+        // The master's `variants` array only holds variants that pass isInclude() as well, and the
+        // job writes no master record when that array comes out empty.
+        it('returns null for a master under the master-level model whose only in-stock variant is offline', () => {
+            const offlineInStockVariant = variantMock('variant1', 'master1', { isOnline: jest.fn(() => false) });
+            const inStockButOfflineOnly = masterMock('master1', offlineInStockVariant);
+
+            expect(utils.getAnchorRecordID(inStockButOfflineOnly, 'master-level', { InStockThreshold: 1, IndexOutOfStock: false })).toBeNull();
+        });
+
+        it('anchors a master under the master-level model when a later variant is indexable', () => {
+            const offlineVariant = variantMock('variant1', 'master1', { isOnline: jest.fn(() => false) });
+            const indexableVariant = variantMock('variant2', 'master1');
+            const product = masterMock('master1', offlineVariant, {}, [offlineVariant, indexableVariant]);
+
+            expect(utils.getAnchorRecordID(product, 'master-level', { InStockThreshold: 1, IndexOutOfStock: false })).toBe('master1');
+        });
+    });
+});
 
 describe('getAnchorProductIDs', () => {
     beforeEach(() => {
         productMgrMock.getProduct.mockReset();
         global.session.privacy.algoliaAnchorProducts = null;
         global.customPreferences.Algolia_RecordModel = 'variant-level';
+        global.customPreferences.Algolia_IndexOutOfStock = true;
         delete global.customPreferences.Algolia_AttributeSlicedRecordModel_GroupingAttribute;
     });
 
@@ -112,159 +447,51 @@ describe('getAnchorProductIDs', () => {
             expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe('');
         });
 
+        it('returns an empty string when called with no slot content at all', () => {
+            expect(utils.getAnchorProductIDs()).toBe('');
+        });
+
         it('reads anchor products from the session when present', () => {
             global.session.privacy.algoliaAnchorProducts = JSON.stringify(['variant1']);
-            productMgrMock.getProduct.mockReturnValue(variantProduct);
+            productMgrMock.getProduct.mockReturnValue(variantMock('variant1', 'master1'));
 
             expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['variant1']));
         });
 
         it('falls back to slot content when the session holds no anchor products', () => {
             const slotcontent = { content: [{ getID: jest.fn(() => 'variant1') }] };
-            productMgrMock.getProduct.mockReturnValue(variantProduct);
+            productMgrMock.getProduct.mockReturnValue(variantMock('variant1', 'master1'));
 
             expect(utils.getAnchorProductIDs(slotcontent)).toBe(JSON.stringify(['variant1']));
         });
     });
 
-    describe('variant-level record model', () => {
-        beforeEach(() => {
-            global.customPreferences.Algolia_RecordModel = 'variant-level';
-        });
-
-        it('anchors a variant on its own ID', () => {
-            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['variant1']);
-            productMgrMock.getProduct.mockReturnValue(variantProduct);
-
-            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['variant1']));
-        });
-
-        it('anchors a master on its default variant, since masters are not indexed', () => {
-            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['master1']);
-            productMgrMock.getProduct.mockReturnValue(masterProduct);
-
-            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['variant1']));
-        });
-
-        it('anchors a variation group on its default variant', () => {
-            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['variationGroup1']);
-            productMgrMock.getProduct.mockReturnValue(variationGroupProduct);
-
-            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['variant1']));
-        });
-
-        // The bug this ticket fixes. Before the change these two resolved to null and were dropped.
-        it('anchors a simple product on its own ID', () => {
-            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['simple1']);
-            productMgrMock.getProduct.mockReturnValue(simpleProduct);
-
-            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['simple1']));
-        });
-
-        it('anchors a bundle on its own ID', () => {
-            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['bundle1']);
-            productMgrMock.getProduct.mockReturnValue(bundleProduct);
-
-            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['bundle1']));
-        });
-
-        it('never calls getVariationModel on a simple product', () => {
-            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['simple1']);
-            productMgrMock.getProduct.mockReturnValue(simpleProduct);
-
-            utils.getAnchorProductIDs(emptySlotcontent);
-
-            expect(simpleProduct.getVariationModel).toBeUndefined();
-        });
-    });
-
-    describe('master-level record model', () => {
-        beforeEach(() => {
+    describe('preferences', () => {
+        it('resolves the anchors with the configured record model', () => {
             global.customPreferences.Algolia_RecordModel = 'master-level';
-        });
-
-        it('anchors a variant on its master', () => {
             global.session.privacy.algoliaAnchorProducts = JSON.stringify(['variant1']);
-            productMgrMock.getProduct.mockReturnValue(variantProduct);
+            productMgrMock.getProduct.mockReturnValue(variantMock('variant1', 'master1'));
 
             expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['master1']));
         });
 
-        it('anchors a master on its own ID', () => {
-            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['master1']);
-            productMgrMock.getProduct.mockReturnValue(masterProduct);
-
-            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['master1']));
-        });
-
-        it('anchors a variation group on its master, since variation groups are not indexed', () => {
-            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['variationGroup1']);
-            productMgrMock.getProduct.mockReturnValue(variationGroupProduct);
-
-            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['master1']));
-        });
-
-        it('anchors a simple product on its own ID', () => {
-            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['simple1']);
-            productMgrMock.getProduct.mockReturnValue(simpleProduct);
-
-            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['simple1']));
-        });
-    });
-
-    describe('attribute-sliced record model', () => {
-        beforeEach(() => {
+        it('resolves the anchors with the configured grouping attribute', () => {
             global.customPreferences.Algolia_RecordModel = 'attribute-sliced';
             global.customPreferences.Algolia_AttributeSlicedRecordModel_GroupingAttribute = 'color';
-        });
-
-        // Reproduces the case debugged on the sandbox: the variant's own ID has no record, the
-        // slice holding its colour does.
-        it('anchors a variant on the slice holding its grouping attribute value', () => {
             global.session.privacy.algoliaAnchorProducts = JSON.stringify(['013742003154M']);
-            productMgrMock.getProduct.mockReturnValue(slicedVariant('013742003154M', '25720054M', 'JJG03XX'));
+            productMgrMock.getProduct.mockReturnValue(slicedVariantMock('013742003154M', '25720054M', 'JJG03XX'));
 
             expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['25720054M-JJG03XX']));
         });
 
-        it('anchors a master on the slice holding its default variant', () => {
-            const defaultVariant = slicedVariant('013742003154M', '25720054M', 'JJG03XX');
-            const slicedMaster = {
-                ID: '25720054M',
-                getID: jest.fn(() => '25720054M'),
-                isMaster: jest.fn(() => true),
-                isVariant: jest.fn(() => false),
-                isVariationGroup: jest.fn(() => false),
-                getVariationModel: jest.fn(() => variationModelWithDefault(defaultVariant)),
-            };
-            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['25720054M']);
-            productMgrMock.getProduct.mockReturnValue(slicedMaster);
-
-            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['25720054M-JJG03XX']));
-        });
-
-        it('anchors a simple product on its own ID', () => {
+        it('drops an out-of-stock product when out-of-stock products are not indexed', () => {
+            global.customPreferences.Algolia_IndexOutOfStock = false;
             global.session.privacy.algoliaAnchorProducts = JSON.stringify(['simple1']);
-            productMgrMock.getProduct.mockReturnValue(simpleProduct);
+            productMgrMock.getProduct.mockReturnValue(productMock('simple1', {
+                getAvailabilityModel: jest.fn(() => availabilityModelWithATS(0)),
+            }));
 
-            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['simple1']));
-        });
-
-        it('returns an empty array when no grouping attribute is configured', () => {
-            delete global.customPreferences.Algolia_AttributeSlicedRecordModel_GroupingAttribute;
-            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['013742003154M']);
-            productMgrMock.getProduct.mockReturnValue(slicedVariant('013742003154M', '25720054M', 'JJG03XX'));
-
-            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify([]));
-        });
-
-        it('sends one anchor for two variants of the same slice', () => {
-            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['smallRed', 'largeRed']);
-            productMgrMock.getProduct
-                .mockReturnValueOnce(slicedVariant('smallRed', '25720054M', 'JJG03XX'))
-                .mockReturnValueOnce(slicedVariant('largeRed', '25720054M', 'JJG03XX'));
-
-            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['25720054M-JJG03XX']));
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe('');
         });
     });
 
@@ -273,50 +500,60 @@ describe('getAnchorProductIDs', () => {
             global.session.privacy.algoliaAnchorProducts = JSON.stringify(['gone', 'variant1']);
             productMgrMock.getProduct
                 .mockReturnValueOnce(null)
-                .mockReturnValueOnce(variantProduct);
+                .mockReturnValueOnce(variantMock('variant1', 'master1'));
 
             expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['variant1']));
         });
 
-        it('does not throw when every product is missing', () => {
+        // An empty array would be truthy in `recommend-config.js` and build a widget with no
+        // objectIDs, which is worse than building no widget at all.
+        it('returns an empty string when no anchor product resolves to a record', () => {
             global.session.privacy.algoliaAnchorProducts = JSON.stringify(['gone']);
             productMgrMock.getProduct.mockReturnValue(null);
 
-            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify([]));
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe('');
         });
 
-        it('skips a master that has no default variant', () => {
-            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['master2']);
-            productMgrMock.getProduct.mockReturnValue(masterWithoutVariants);
+        it('returns an empty string when the attribute-sliced model has no grouping attribute', () => {
+            global.customPreferences.Algolia_RecordModel = 'attribute-sliced';
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['013742003154M']);
+            productMgrMock.getProduct.mockReturnValue(slicedVariantMock('013742003154M', '25720054M', 'JJG03XX'));
 
-            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify([]));
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe('');
+        });
+    });
+
+    describe('duplicate anchors', () => {
+        it('sends one anchor for two variants of the same slice', () => {
+            global.customPreferences.Algolia_RecordModel = 'attribute-sliced';
+            global.customPreferences.Algolia_AttributeSlicedRecordModel_GroupingAttribute = 'color';
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['smallRed', 'largeRed']);
+            productMgrMock.getProduct
+                .mockReturnValueOnce(slicedVariantMock('smallRed', '25720054M', 'JJG03XX'))
+                .mockReturnValueOnce(slicedVariantMock('largeRed', '25720054M', 'JJG03XX'));
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['25720054M-JJG03XX']));
         });
     });
 
     describe('anchor cap', () => {
-        it('sends at most five anchors', () => {
-            const ids = ['v1', 'v2', 'v3', 'v4', 'v5', 'v6', 'v7'];
+        it('sends at most MAX_ANCHOR_PRODUCTS anchors', () => {
+            const ids = [];
+            for (let i = 1; i <= utils.MAX_ANCHOR_PRODUCTS + 2; i++) {
+                ids.push('v' + i);
+            }
             global.session.privacy.algoliaAnchorProducts = JSON.stringify(ids);
-            productMgrMock.getProduct.mockImplementation((id) => ({
-                ID: id,
-                getID: jest.fn(() => id),
-                isMaster: jest.fn(() => false),
-                isVariant: jest.fn(() => false),
-                isVariationGroup: jest.fn(() => false),
-            }));
+            productMgrMock.getProduct.mockImplementation((id) => productMock(id));
 
-            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['v1', 'v2', 'v3', 'v4', 'v5']));
+            const anchors = JSON.parse(utils.getAnchorProductIDs(emptySlotcontent));
+
+            expect(anchors).toHaveLength(utils.MAX_ANCHOR_PRODUCTS);
+            expect(anchors).toEqual(ids.slice(0, utils.MAX_ANCHOR_PRODUCTS));
         });
 
         it('does not count skipped products against the cap', () => {
             global.session.privacy.algoliaAnchorProducts = JSON.stringify(['gone', 'v1', 'v2']);
-            productMgrMock.getProduct.mockImplementation((id) => (id === 'gone' ? null : {
-                ID: id,
-                getID: jest.fn(() => id),
-                isMaster: jest.fn(() => false),
-                isVariant: jest.fn(() => false),
-                isVariationGroup: jest.fn(() => false),
-            }));
+            productMgrMock.getProduct.mockImplementation((id) => (id === 'gone' ? null : productMock(id)));
 
             expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['v1', 'v2']));
         });

--- a/test/unit/int_algolia/scripts/algolia/recommend/utils.test.js
+++ b/test/unit/int_algolia/scripts/algolia/recommend/utils.test.js
@@ -1,143 +1,324 @@
-describe('getAnchorProductIDs', () => {
-    const productMgrMock = require('dw/catalog/ProductMgr');
-    const algoliaDataMock = jest.mock('*/cartridge/scripts/algolia/lib/algoliaData');
+/**
+ * The record model is read through the real `algoliaData.getPreference`, which resolves it from
+ * `global.customPreferences` via the Site mock. Setting that global is therefore the only way to
+ * drive the module; a `jest.fn()` on algoliaData is not wired to it. Every test sets the model it
+ * needs and `beforeEach` resets it, so no test depends on another having run first.
+ */
+const productMgrMock = require('dw/catalog/ProductMgr');
+const utils = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/recommend/utils');
 
-    const variantProduct = {
-        ID: 'product1',
-        getID: jest.fn(() => 'product1'),
-        isVariationGroup: jest.fn(() => false),
+const emptySlotcontent = { content: [] };
+
+/**
+ * Builds a variation model that only answers getDefaultVariant().
+ * @param {Object|null} defaultVariant the variant to return
+ * @returns {Object} variation model mock
+ */
+function variationModelWithDefault(defaultVariant) {
+    return { getDefaultVariant: jest.fn(() => defaultVariant) };
+}
+
+const variantProduct = {
+    ID: 'variant1',
+    getID: jest.fn(() => 'variant1'),
+    isMaster: jest.fn(() => false),
+    isVariant: jest.fn(() => true),
+    isVariationGroup: jest.fn(() => false),
+    getMasterProduct: jest.fn(() => ({ getID: jest.fn(() => 'master1') })),
+};
+
+const masterProduct = {
+    ID: 'master1',
+    getID: jest.fn(() => 'master1'),
+    isMaster: jest.fn(() => true),
+    isVariant: jest.fn(() => false),
+    isVariationGroup: jest.fn(() => false),
+    getVariationModel: jest.fn(() => variationModelWithDefault({ getID: jest.fn(() => 'variant1') })),
+};
+
+const masterWithoutVariants = {
+    ID: 'master2',
+    getID: jest.fn(() => 'master2'),
+    isMaster: jest.fn(() => true),
+    isVariant: jest.fn(() => false),
+    isVariationGroup: jest.fn(() => false),
+    getVariationModel: jest.fn(() => variationModelWithDefault(null)),
+};
+
+const variationGroupProduct = {
+    ID: 'variationGroup1',
+    getID: jest.fn(() => 'variationGroup1'),
+    isMaster: jest.fn(() => false),
+    isVariant: jest.fn(() => false),
+    isVariationGroup: jest.fn(() => true),
+    getMasterProduct: jest.fn(() => ({ getID: jest.fn(() => 'master1') })),
+    getVariationModel: jest.fn(() => variationModelWithDefault({ getID: jest.fn(() => 'variant1') })),
+};
+
+// A simple product answers false to all three predicates and has no usable variation model.
+// This is the case that used to be dropped: it was labelled a master, sent to getDefaultVariant(),
+// and resolved to null.
+const simpleProduct = {
+    ID: 'simple1',
+    getID: jest.fn(() => 'simple1'),
+    isMaster: jest.fn(() => false),
+    isVariant: jest.fn(() => false),
+    isVariationGroup: jest.fn(() => false),
+};
+
+const bundleProduct = {
+    ID: 'bundle1',
+    getID: jest.fn(() => 'bundle1'),
+    isMaster: jest.fn(() => false),
+    isVariant: jest.fn(() => false),
+    isVariationGroup: jest.fn(() => false),
+    isBundle: jest.fn(() => true),
+};
+
+/**
+ * Builds a variant whose attribute-sliced record is `<masterID>-<colorValueID>`, mirroring the
+ * shape the indexing jobs write.
+ * @param {string} id variant ID
+ * @param {string} masterID master ID
+ * @param {string} colorValueID grouping attribute value ID
+ * @returns {Object} variant mock
+ */
+function slicedVariant(id, masterID, colorValueID) {
+    return {
+        ID: id,
+        getID: jest.fn(() => id),
+        isMaster: jest.fn(() => false),
         isVariant: jest.fn(() => true),
-        master: false,
-        getMasterProduct: jest.fn(() => ({
-            getID: jest.fn(() => 'masterProduct1')
-        })),
-    };
-
-    const masterProduct = {
-        ID: 'masterProduct1',
-        getID: jest.fn(() => 'masterProduct1'),
         isVariationGroup: jest.fn(() => false),
-        isVariant: jest.fn(() => false),
-        master: true,
+        getMasterProduct: jest.fn(() => ({ getID: jest.fn(() => masterID) })),
         getVariationModel: jest.fn(() => ({
-            getDefaultVariant: jest.fn(() => ({
-                getID: jest.fn(() => 'product1')
-            })),
+            getProductVariationAttribute: jest.fn(() => ({ getID: jest.fn(() => 'color') })),
+            getMaster: jest.fn(() => ({ getID: jest.fn(() => masterID) })),
+            getSelectedValue: jest.fn(() => ({ getID: jest.fn(() => colorValueID) })),
         })),
     };
+}
 
-    const variationGroupProduct = {
-        ID: 'variationGroupProduct1',
-        getID: jest.fn(() => 'variationGroupProduct1'),
-        isVariationGroup: jest.fn(() => true),
-        isVariant: jest.fn(() => false),
-        master: false,
-        getVariationModel: jest.fn(() => ({
-            getDefaultVariant: jest.fn(() => ({
-                getID: jest.fn(() => 'product1')
-            })),
-        })),
-        getMasterProduct: jest.fn(() => ({
-            getID: jest.fn(() => 'masterProduct1')
-        })),
-    };
-
+describe('getAnchorProductIDs', () => {
     beforeEach(() => {
         productMgrMock.getProduct.mockReset();
-
-        if (algoliaDataMock.getPreference && algoliaDataMock.getPreference.mockReset) {
-            algoliaDataMock.getPreference.mockReset();
-        } else {
-            algoliaDataMock.getPreference = jest.fn();
-        }
-    });
-
-    const utils = require('../../../../../../cartridges/int_algolia/cartridge/scripts/algolia/recommend/utils');
-
-    it('should return empty string if no anchor products or slot content', () => {
-        const slotcontent = {
-            content: []
-        };
-        expect(utils.getAnchorProductIDs(slotcontent)).toBe('');
-    });
-
-    it('should return anchor product IDs from session if available', () => {
-        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['product1']);
-        const slotcontent = {
-            content: []
-        };
-        productMgrMock.getProduct.mockReturnValue(variantProduct);
-        expect(utils.getAnchorProductIDs(slotcontent)).toBe(JSON.stringify(['product1']));
-    });
-
-    it('should return product IDs from slot content if no anchor products in session', () => {
         global.session.privacy.algoliaAnchorProducts = null;
-        const slotcontent = {
-            content: [{
-                getID: jest.fn(() => 'product1')
-            }, {
-                getID: jest.fn(() => 'product1')
-            }]
-        };
-        productMgrMock.getProduct.mockReturnValue(variantProduct);
-        expect(utils.getAnchorProductIDs(slotcontent)).toBe(JSON.stringify(['product1', 'product1']));
+        global.customPreferences.Algolia_RecordModel = 'variant-level';
+        delete global.customPreferences.Algolia_AttributeSlicedRecordModel_GroupingAttribute;
     });
 
-    it('should return a variant when we use variant-model and anchor product is a variant product', () => {
-        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['product1']);
-        const slotcontent = {
-            content: []
-        };
-        productMgrMock.getProduct.mockReturnValue(variantProduct);
-        expect(utils.getAnchorProductIDs(slotcontent)).toBe(JSON.stringify(['product1']));
+    describe('anchor sources', () => {
+        it('returns an empty string when there are no anchor products and no slot content', () => {
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe('');
+        });
+
+        it('reads anchor products from the session when present', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['variant1']);
+            productMgrMock.getProduct.mockReturnValue(variantProduct);
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['variant1']));
+        });
+
+        it('falls back to slot content when the session holds no anchor products', () => {
+            const slotcontent = { content: [{ getID: jest.fn(() => 'variant1') }] };
+            productMgrMock.getProduct.mockReturnValue(variantProduct);
+
+            expect(utils.getAnchorProductIDs(slotcontent)).toBe(JSON.stringify(['variant1']));
+        });
     });
 
-    it('should return a variant when we use variant-model and anchor product is a master product', () => {
-        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['masterProduct1']);
-        const slotcontent = {
-            content: []
-        };
-        productMgrMock.getProduct.mockReturnValue(masterProduct);
-        expect(utils.getAnchorProductIDs(slotcontent)).toBe(JSON.stringify(['product1']));
+    describe('variant-level record model', () => {
+        beforeEach(() => {
+            global.customPreferences.Algolia_RecordModel = 'variant-level';
+        });
+
+        it('anchors a variant on its own ID', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['variant1']);
+            productMgrMock.getProduct.mockReturnValue(variantProduct);
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['variant1']));
+        });
+
+        it('anchors a master on its default variant, since masters are not indexed', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['master1']);
+            productMgrMock.getProduct.mockReturnValue(masterProduct);
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['variant1']));
+        });
+
+        it('anchors a variation group on its default variant', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['variationGroup1']);
+            productMgrMock.getProduct.mockReturnValue(variationGroupProduct);
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['variant1']));
+        });
+
+        // The bug this ticket fixes. Before the change these two resolved to null and were dropped.
+        it('anchors a simple product on its own ID', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['simple1']);
+            productMgrMock.getProduct.mockReturnValue(simpleProduct);
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['simple1']));
+        });
+
+        it('anchors a bundle on its own ID', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['bundle1']);
+            productMgrMock.getProduct.mockReturnValue(bundleProduct);
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['bundle1']));
+        });
+
+        it('never calls getVariationModel on a simple product', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['simple1']);
+            productMgrMock.getProduct.mockReturnValue(simpleProduct);
+
+            utils.getAnchorProductIDs(emptySlotcontent);
+
+            expect(simpleProduct.getVariationModel).toBeUndefined();
+        });
     });
 
-    it('should return a variant when we use variant-model and anchor product is a variation group product', () => {
-        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['variationGroupProduct']);
-        const slotcontent = {
-            content: []
-        };
-        productMgrMock.getProduct.mockReturnValue(variationGroupProduct);
-        expect(utils.getAnchorProductIDs(slotcontent)).toBe(JSON.stringify(['product1']));
+    describe('master-level record model', () => {
+        beforeEach(() => {
+            global.customPreferences.Algolia_RecordModel = 'master-level';
+        });
+
+        it('anchors a variant on its master', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['variant1']);
+            productMgrMock.getProduct.mockReturnValue(variantProduct);
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['master1']));
+        });
+
+        it('anchors a master on its own ID', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['master1']);
+            productMgrMock.getProduct.mockReturnValue(masterProduct);
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['master1']));
+        });
+
+        it('anchors a variation group on its master, since variation groups are not indexed', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['variationGroup1']);
+            productMgrMock.getProduct.mockReturnValue(variationGroupProduct);
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['master1']));
+        });
+
+        it('anchors a simple product on its own ID', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['simple1']);
+            productMgrMock.getProduct.mockReturnValue(simpleProduct);
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['simple1']));
+        });
     });
 
-    it('should return a master when we use master-model and anchor product is a master product', () => {
-        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['masterProduct1']);
-        const slotcontent = {
-            content: []
-        };
-        global.customPreferences.Algolia_RecordModel = 'master-level';
-        productMgrMock.getProduct.mockReturnValue(masterProduct);
-        expect(utils.getAnchorProductIDs(slotcontent)).toBe(JSON.stringify(['masterProduct1']));
+    describe('attribute-sliced record model', () => {
+        beforeEach(() => {
+            global.customPreferences.Algolia_RecordModel = 'attribute-sliced';
+            global.customPreferences.Algolia_AttributeSlicedRecordModel_GroupingAttribute = 'color';
+        });
+
+        // Reproduces the case debugged on the sandbox: the variant's own ID has no record, the
+        // slice holding its colour does.
+        it('anchors a variant on the slice holding its grouping attribute value', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['013742003154M']);
+            productMgrMock.getProduct.mockReturnValue(slicedVariant('013742003154M', '25720054M', 'JJG03XX'));
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['25720054M-JJG03XX']));
+        });
+
+        it('anchors a master on the slice holding its default variant', () => {
+            const defaultVariant = slicedVariant('013742003154M', '25720054M', 'JJG03XX');
+            const slicedMaster = {
+                ID: '25720054M',
+                getID: jest.fn(() => '25720054M'),
+                isMaster: jest.fn(() => true),
+                isVariant: jest.fn(() => false),
+                isVariationGroup: jest.fn(() => false),
+                getVariationModel: jest.fn(() => variationModelWithDefault(defaultVariant)),
+            };
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['25720054M']);
+            productMgrMock.getProduct.mockReturnValue(slicedMaster);
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['25720054M-JJG03XX']));
+        });
+
+        it('anchors a simple product on its own ID', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['simple1']);
+            productMgrMock.getProduct.mockReturnValue(simpleProduct);
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['simple1']));
+        });
+
+        it('returns an empty array when no grouping attribute is configured', () => {
+            delete global.customPreferences.Algolia_AttributeSlicedRecordModel_GroupingAttribute;
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['013742003154M']);
+            productMgrMock.getProduct.mockReturnValue(slicedVariant('013742003154M', '25720054M', 'JJG03XX'));
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify([]));
+        });
+
+        it('sends one anchor for two variants of the same slice', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['smallRed', 'largeRed']);
+            productMgrMock.getProduct
+                .mockReturnValueOnce(slicedVariant('smallRed', '25720054M', 'JJG03XX'))
+                .mockReturnValueOnce(slicedVariant('largeRed', '25720054M', 'JJG03XX'));
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['25720054M-JJG03XX']));
+        });
     });
 
-    it('should return a master when we use master-model and anchor product is a variation group product', () => {
-        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['variationGroupProduct']);
-        const slotcontent = {
-            content: []
-        };
-        algoliaDataMock.getPreference.mockReturnValue('master-level');
-        productMgrMock.getProduct.mockReturnValue(variationGroupProduct);
-        expect(utils.getAnchorProductIDs(slotcontent)).toBe(JSON.stringify(['masterProduct1']));
+    describe('products without a record', () => {
+        it('skips a product that no longer resolves in the catalog', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['gone', 'variant1']);
+            productMgrMock.getProduct
+                .mockReturnValueOnce(null)
+                .mockReturnValueOnce(variantProduct);
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['variant1']));
+        });
+
+        it('does not throw when every product is missing', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['gone']);
+            productMgrMock.getProduct.mockReturnValue(null);
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify([]));
+        });
+
+        it('skips a master that has no default variant', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['master2']);
+            productMgrMock.getProduct.mockReturnValue(masterWithoutVariants);
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify([]));
+        });
     });
 
+    describe('anchor cap', () => {
+        it('sends at most five anchors', () => {
+            const ids = ['v1', 'v2', 'v3', 'v4', 'v5', 'v6', 'v7'];
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(ids);
+            productMgrMock.getProduct.mockImplementation((id) => ({
+                ID: id,
+                getID: jest.fn(() => id),
+                isMaster: jest.fn(() => false),
+                isVariant: jest.fn(() => false),
+                isVariationGroup: jest.fn(() => false),
+            }));
 
-    it('should return a master when we use variant-model and anchor product is a variant product', () => {
-        global.session.privacy.algoliaAnchorProducts = JSON.stringify(['product1']);
-        const slotcontent = {
-            content: []
-        };
-        algoliaDataMock.getPreference.mockReturnValue('master-level');
-        productMgrMock.getProduct.mockReturnValue(variantProduct);
-        expect(utils.getAnchorProductIDs(slotcontent)).toBe(JSON.stringify(['masterProduct1']));
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['v1', 'v2', 'v3', 'v4', 'v5']));
+        });
+
+        it('does not count skipped products against the cap', () => {
+            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['gone', 'v1', 'v2']);
+            productMgrMock.getProduct.mockImplementation((id) => (id === 'gone' ? null : {
+                ID: id,
+                getID: jest.fn(() => id),
+                isMaster: jest.fn(() => false),
+                isVariant: jest.fn(() => false),
+                isVariationGroup: jest.fn(() => false),
+            }));
+
+            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['v1', 'v2']));
+        });
     });
 });

--- a/test/unit/int_algolia/scripts/algolia/recommend/utils.test.js
+++ b/test/unit/int_algolia/scripts/algolia/recommend/utils.test.js
@@ -1,8 +1,8 @@
 /**
- * `getAnchorRecordID` takes the record model and the site preference values as arguments, so the
- * tests for the record-model matrix and for the indexing filters need no global setup.
+ * `getAnchorRecordID` takes the record model and the grouping attribute as arguments, so the tests
+ * for the record-model matrix need no global setup.
  *
- * `getAnchorProductIDs` reads them itself, through the real `algoliaData.getPreference`, which
+ * `getAnchorProductIDs` reads both itself, through the real `algoliaData.getPreference`, which
  * resolves them from `global.customPreferences` via the Site mock. Setting that global is the only
  * way to drive it; a `jest.fn()` on algoliaData is not wired to it.
  */
@@ -11,27 +11,9 @@ const utils = require('../../../../../../cartridges/int_algolia/cartridge/script
 
 const emptySlotcontent = { content: [] };
 
-// Out-of-stock products are indexed, so the stock filter passes for every product. Tests that are
-// about stock pass their own preferences.
-const INDEX_EVERYTHING = { InStockThreshold: 1, IndexOutOfStock: true };
-const SLICED_BY_COLOR = { InStockThreshold: 1, IndexOutOfStock: true, AttributeSlicedRecordModel_GroupingAttribute: 'color' };
-
 /**
- * Builds an availability model whose inventory record reports the given available-to-sell quantity.
- * @param {number} ats available-to-sell quantity
- * @returns {Object} availability model mock
- */
-function availabilityModelWithATS(ats) {
-    return {
-        getInventoryRecord: jest.fn(() => ({
-            getATS: jest.fn(() => ({ getValue: jest.fn(() => ats) })),
-        })),
-    };
-}
-
-/**
- * Builds a product mock that answers false to every type predicate and passes every indexing
- * filter, so each test only has to describe what it is actually about.
+ * Builds a product mock that answers false to every type predicate, so each test only has to
+ * describe what it is actually about.
  * @param {string} id product ID
  * @param {Object} [overrides] properties to replace on the mock
  * @returns {Object} product mock
@@ -43,23 +25,7 @@ function productMock(id, overrides) {
         isMaster: jest.fn(() => false),
         isVariant: jest.fn(() => false),
         isVariationGroup: jest.fn(() => false),
-        isBundled: jest.fn(() => false),
-        isOnline: jest.fn(() => true),
-        isSearchable: jest.fn(() => true),
-        getOnlineCategories: jest.fn(() => [{ ID: 'category1' }]),
-        getAvailabilityModel: jest.fn(() => availabilityModelWithATS(10)),
     }, overrides || {});
-}
-
-/**
- * Builds the master a variant or variation group reports through getMasterProduct(). The real API
- * returns a full dw.catalog.Product there, so under the master-level model the filters run against
- * it directly.
- * @param {string} masterID master product ID
- * @returns {Object} master product mock
- */
-function masterProductRef(masterID) {
-    return masterMock(masterID, productMock(masterID + '-default', { isVariant: jest.fn(() => true) }));
 }
 
 /**
@@ -81,43 +47,21 @@ function variationModelWithDefault(defaultVariant) {
 function variantMock(id, masterID, overrides) {
     return productMock(id, Object.assign({
         isVariant: jest.fn(() => true),
-        getMasterProduct: jest.fn(() => masterProductRef(masterID)),
+        getMasterProduct: jest.fn(() => productMock(masterID, { isMaster: jest.fn(() => true) })),
     }, overrides || {}));
 }
 
 /**
- * Builds a dw.util.Collection-like list of variants that only answers iterator().
- * @param {Array} variants the variants to serve
- * @returns {Object} variant collection mock
- */
-function variantCollection(variants) {
-    return {
-        iterator: jest.fn(() => {
-            let index = 0;
-            return {
-                hasNext: jest.fn(() => index < variants.length),
-                next: jest.fn(() => variants[index++]),
-            };
-        }),
-    };
-}
-
-/**
- * Builds a master product. Its variants default to the one variant getDefaultVariant() reports.
+ * Builds a master product.
  * @param {string} id master product ID
  * @param {Object|null} defaultVariant the variant getDefaultVariant() reports
- * @param {Object} [overrides] properties to replace on the mock
- * @param {Array} [variants] every variant of the master, when it has more than the default one
  * @returns {Object} master product mock
  */
-function masterMock(id, defaultVariant, overrides, variants) {
-    const allVariants = variants || (defaultVariant ? [defaultVariant] : []);
-
-    return productMock(id, Object.assign({
+function masterMock(id, defaultVariant) {
+    return productMock(id, {
         isMaster: jest.fn(() => true),
         getVariationModel: jest.fn(() => variationModelWithDefault(defaultVariant)),
-        getVariants: jest.fn(() => variantCollection(allVariants)),
-    }, overrides || {}));
+    });
 }
 
 /**
@@ -130,7 +74,7 @@ function masterMock(id, defaultVariant, overrides, variants) {
 function variationGroupMock(id, masterID, defaultVariant) {
     return productMock(id, {
         isVariationGroup: jest.fn(() => true),
-        getMasterProduct: jest.fn(() => masterProductRef(masterID)),
+        getMasterProduct: jest.fn(() => productMock(masterID, { isMaster: jest.fn(() => true) })),
         getVariationModel: jest.fn(() => variationModelWithDefault(defaultVariant)),
     });
 }
@@ -148,7 +92,7 @@ function slicedVariantMock(id, masterID, colorValueID, overrides) {
     return variantMock(id, masterID, Object.assign({
         getVariationModel: jest.fn(() => ({
             getProductVariationAttribute: jest.fn(() => ({ getID: jest.fn(() => 'color') })),
-            getMaster: jest.fn(() => masterProductRef(masterID)),
+            getMaster: jest.fn(() => productMock(masterID, { isMaster: jest.fn(() => true) })),
             getSelectedValue: jest.fn(() => ({ getID: jest.fn(() => colorValueID) })),
         })),
     }, overrides || {}));
@@ -159,50 +103,50 @@ describe('getAnchorRecordID', () => {
         it('anchors a variant on its own ID', () => {
             const product = variantMock('variant1', 'master1');
 
-            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBe('variant1');
+            expect(utils.getAnchorRecordID(product, 'variant-level')).toBe('variant1');
         });
 
         it('anchors a master on its default variant, since masters are not indexed', () => {
             const product = masterMock('master1', variantMock('variant1', 'master1'));
 
-            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBe('variant1');
+            expect(utils.getAnchorRecordID(product, 'variant-level')).toBe('variant1');
         });
 
         it('anchors a variation group on its default variant', () => {
             const product = variationGroupMock('variationGroup1', 'master1', variantMock('variant1', 'master1'));
 
-            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBe('variant1');
+            expect(utils.getAnchorRecordID(product, 'variant-level')).toBe('variant1');
         });
 
         // The bug this ticket fixes. Before the change all four of these resolved to null and were
         // dropped, because anything that was not a variant or a variation group was treated as a
         // master and sent to getDefaultVariant().
         it('anchors a simple product on its own ID', () => {
-            expect(utils.getAnchorRecordID(productMock('simple1'), 'variant-level', INDEX_EVERYTHING)).toBe('simple1');
+            expect(utils.getAnchorRecordID(productMock('simple1'), 'variant-level')).toBe('simple1');
         });
 
         it('anchors a bundle on its own ID', () => {
             const bundle = productMock('bundle1', { isBundle: jest.fn(() => true) });
 
-            expect(utils.getAnchorRecordID(bundle, 'variant-level', INDEX_EVERYTHING)).toBe('bundle1');
+            expect(utils.getAnchorRecordID(bundle, 'variant-level')).toBe('bundle1');
         });
 
         it('anchors a product set on its own ID', () => {
             const productSet = productMock('set1', { isProductSet: jest.fn(() => true) });
 
-            expect(utils.getAnchorRecordID(productSet, 'variant-level', INDEX_EVERYTHING)).toBe('set1');
+            expect(utils.getAnchorRecordID(productSet, 'variant-level')).toBe('set1');
         });
 
         it('anchors an option product on its own ID', () => {
             const optionProduct = productMock('option1', { getOptionModel: jest.fn(() => ({})) });
 
-            expect(utils.getAnchorRecordID(optionProduct, 'variant-level', INDEX_EVERYTHING)).toBe('option1');
+            expect(utils.getAnchorRecordID(optionProduct, 'variant-level')).toBe('option1');
         });
 
         it('never reaches the variation model of a product that is not a master or a variation group', () => {
             const simpleProduct = productMock('simple1', { getVariationModel: jest.fn() });
 
-            utils.getAnchorRecordID(simpleProduct, 'variant-level', INDEX_EVERYTHING);
+            utils.getAnchorRecordID(simpleProduct, 'variant-level');
 
             expect(simpleProduct.getVariationModel).not.toHaveBeenCalled();
         });
@@ -212,35 +156,35 @@ describe('getAnchorRecordID', () => {
         it('anchors a variant on its master', () => {
             const product = variantMock('variant1', 'master1');
 
-            expect(utils.getAnchorRecordID(product, 'master-level', INDEX_EVERYTHING)).toBe('master1');
+            expect(utils.getAnchorRecordID(product, 'master-level')).toBe('master1');
         });
 
         it('anchors a master on its own ID', () => {
             const product = masterMock('master1', variantMock('variant1', 'master1'));
 
-            expect(utils.getAnchorRecordID(product, 'master-level', INDEX_EVERYTHING)).toBe('master1');
+            expect(utils.getAnchorRecordID(product, 'master-level')).toBe('master1');
         });
 
         it('anchors a variation group on its master, since variation groups are not indexed', () => {
             const product = variationGroupMock('variationGroup1', 'master1', variantMock('variant1', 'master1'));
 
-            expect(utils.getAnchorRecordID(product, 'master-level', INDEX_EVERYTHING)).toBe('master1');
+            expect(utils.getAnchorRecordID(product, 'master-level')).toBe('master1');
         });
 
         it('anchors a simple product on its own ID', () => {
-            expect(utils.getAnchorRecordID(productMock('simple1'), 'master-level', INDEX_EVERYTHING)).toBe('simple1');
+            expect(utils.getAnchorRecordID(productMock('simple1'), 'master-level')).toBe('simple1');
         });
 
         it('anchors a bundle on its own ID', () => {
             const bundle = productMock('bundle1', { isBundle: jest.fn(() => true) });
 
-            expect(utils.getAnchorRecordID(bundle, 'master-level', INDEX_EVERYTHING)).toBe('bundle1');
+            expect(utils.getAnchorRecordID(bundle, 'master-level')).toBe('bundle1');
         });
 
         it('never reaches the variation model, since no product resolves to a default variant', () => {
             const product = masterMock('master1', variantMock('variant1', 'master1'));
 
-            utils.getAnchorRecordID(product, 'master-level', INDEX_EVERYTHING);
+            utils.getAnchorRecordID(product, 'master-level');
 
             expect(product.getVariationModel).not.toHaveBeenCalled();
         });
@@ -252,21 +196,21 @@ describe('getAnchorRecordID', () => {
         it('anchors a variant on the slice holding its grouping attribute value', () => {
             const product = slicedVariantMock('013742003154M', '25720054M', 'JJG03XX');
 
-            expect(utils.getAnchorRecordID(product, 'attribute-sliced', SLICED_BY_COLOR)).toBe('25720054M-JJG03XX');
+            expect(utils.getAnchorRecordID(product, 'attribute-sliced', 'color')).toBe('25720054M-JJG03XX');
         });
 
         it('anchors a master on the slice holding its default variant', () => {
             const defaultVariant = slicedVariantMock('013742003154M', '25720054M', 'JJG03XX');
             const product = masterMock('25720054M', defaultVariant);
 
-            expect(utils.getAnchorRecordID(product, 'attribute-sliced', SLICED_BY_COLOR)).toBe('25720054M-JJG03XX');
+            expect(utils.getAnchorRecordID(product, 'attribute-sliced', 'color')).toBe('25720054M-JJG03XX');
         });
 
         it('anchors a variation group on the slice holding its default variant', () => {
             const defaultVariant = slicedVariantMock('013742003154M', '25720054M', 'JJG03XX');
             const product = variationGroupMock('variationGroup1', '25720054M', defaultVariant);
 
-            expect(utils.getAnchorRecordID(product, 'attribute-sliced', SLICED_BY_COLOR)).toBe('25720054M-JJG03XX');
+            expect(utils.getAnchorRecordID(product, 'attribute-sliced', 'color')).toBe('25720054M-JJG03XX');
         });
 
         // A master that does not have the grouping attribute is written as a single master-level
@@ -275,49 +219,36 @@ describe('getAnchorRecordID', () => {
             const product = variantMock('variant1', 'master1', {
                 getVariationModel: jest.fn(() => ({
                     getProductVariationAttribute: jest.fn(() => null),
-                    getMaster: jest.fn(() => masterProductRef('master1')),
+                    getMaster: jest.fn(() => productMock('master1', { isMaster: jest.fn(() => true) })),
                 })),
             });
 
-            expect(utils.getAnchorRecordID(product, 'attribute-sliced', SLICED_BY_COLOR)).toBe('master1');
+            expect(utils.getAnchorRecordID(product, 'attribute-sliced', 'color')).toBe('master1');
         });
 
         it('anchors a simple product on its own ID', () => {
-            expect(utils.getAnchorRecordID(productMock('simple1'), 'attribute-sliced', SLICED_BY_COLOR)).toBe('simple1');
+            expect(utils.getAnchorRecordID(productMock('simple1'), 'attribute-sliced', 'color')).toBe('simple1');
         });
 
         it('anchors a bundle on its own ID', () => {
             const bundle = productMock('bundle1', { isBundle: jest.fn(() => true) });
 
-            expect(utils.getAnchorRecordID(bundle, 'attribute-sliced', SLICED_BY_COLOR)).toBe('bundle1');
+            expect(utils.getAnchorRecordID(bundle, 'attribute-sliced', 'color')).toBe('bundle1');
         });
 
         it('returns null when no grouping attribute is configured, since no record ID can be built', () => {
             const product = slicedVariantMock('013742003154M', '25720054M', 'JJG03XX');
 
-            expect(utils.getAnchorRecordID(product, 'attribute-sliced', INDEX_EVERYTHING)).toBeNull();
+            expect(utils.getAnchorRecordID(product, 'attribute-sliced')).toBeNull();
         });
 
-        // Every slice is built from the master, so an offline master has no slice records at all,
-        // however online its individual variants are.
-        it('returns null for a variant of an offline master', () => {
-            const offlineMaster = masterMock('25720054M', null, { isOnline: jest.fn(() => false) });
-            const product = slicedVariantMock('013742003154M', '25720054M', 'JJG03XX', {
-                getMasterProduct: jest.fn(() => offlineMaster),
-            });
+        it('falls back to the grouping attribute preference when it is not passed in', () => {
+            global.customPreferences.Algolia_AttributeSlicedRecordModel_GroupingAttribute = 'color';
+            const product = slicedVariantMock('013742003154M', '25720054M', 'JJG03XX');
 
-            expect(utils.getAnchorRecordID(product, 'attribute-sliced', SLICED_BY_COLOR)).toBeNull();
-        });
-    });
+            expect(utils.getAnchorRecordID(product, 'attribute-sliced')).toBe('25720054M-JJG03XX');
 
-    describe('site preferences', () => {
-        it('falls back to reading the site preferences when they are not passed in', () => {
-            global.customPreferences.Algolia_IndexOutOfStock = true;
-            const product = variantMock('variant1', 'master1');
-
-            expect(utils.getAnchorRecordID(product, 'variant-level')).toBe('variant1');
-
-            delete global.customPreferences.Algolia_IndexOutOfStock;
+            delete global.customPreferences.Algolia_AttributeSlicedRecordModel_GroupingAttribute;
         });
     });
 
@@ -325,110 +256,27 @@ describe('getAnchorRecordID', () => {
         it('falls back to the product ID, matching the variant-level model', () => {
             const product = variantMock('variant1', 'master1');
 
-            expect(utils.getAnchorRecordID(product, '', INDEX_EVERYTHING)).toBe('variant1');
+            expect(utils.getAnchorRecordID(product, '')).toBe('variant1');
         });
     });
 
     describe('products that have no record to anchor on', () => {
         it('returns null for a product that no longer resolves in the catalog', () => {
-            expect(utils.getAnchorRecordID(null, 'variant-level', INDEX_EVERYTHING)).toBeNull();
+            expect(utils.getAnchorRecordID(null, 'variant-level')).toBeNull();
         });
 
-        it('returns null for a master that has no default variant', () => {
+        // getDefaultVariant() returns an arbitrary variant when the master has no default variant
+        // defined, so it only comes back null when there is no variant at all.
+        it('returns null for a master that has no variants', () => {
             const product = masterMock('master2', null);
 
-            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBeNull();
+            expect(utils.getAnchorRecordID(product, 'variant-level')).toBeNull();
         });
 
-        it('returns null for an offline product, which the jobs do not index', () => {
-            const product = productMock('simple1', { isOnline: jest.fn(() => false) });
+        it('returns null for a variation group whose variation model has no variants', () => {
+            const product = variationGroupMock('variationGroup1', 'master1', null);
 
-            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBeNull();
-        });
-
-        it('returns null for a product that is not searchable', () => {
-            const product = productMock('simple1', { isSearchable: jest.fn(() => false) });
-
-            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBeNull();
-        });
-
-        it('returns null for a product with no online category', () => {
-            const product = productMock('simple1', { getOnlineCategories: jest.fn(() => []) });
-
-            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBeNull();
-        });
-
-        it('returns null for a variant whose master has no online category', () => {
-            const product = variantMock('variant1', 'master1', {
-                getMasterProduct: jest.fn(() => ({
-                    getID: jest.fn(() => 'master1'),
-                    getOnlineCategories: jest.fn(() => []),
-                })),
-            });
-
-            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBeNull();
-        });
-
-        it('returns null for an offline master under the master-level model', () => {
-            const product = masterMock('master1', variantMock('variant1', 'master1'), { isOnline: jest.fn(() => false) });
-
-            expect(utils.getAnchorRecordID(product, 'master-level', INDEX_EVERYTHING)).toBeNull();
-        });
-
-        it('returns null for an out-of-stock product when out-of-stock products are not indexed', () => {
-            const product = productMock('simple1', { getAvailabilityModel: jest.fn(() => availabilityModelWithATS(0)) });
-
-            expect(utils.getAnchorRecordID(product, 'variant-level', { InStockThreshold: 1, IndexOutOfStock: false })).toBeNull();
-        });
-
-        it('anchors an out-of-stock product when out-of-stock products are indexed', () => {
-            const product = productMock('simple1', { getAvailabilityModel: jest.fn(() => availabilityModelWithATS(0)) });
-
-            expect(utils.getAnchorRecordID(product, 'variant-level', INDEX_EVERYTHING)).toBe('simple1');
-        });
-
-        it('returns null for a product below the in-stock threshold', () => {
-            const product = productMock('simple1', { getAvailabilityModel: jest.fn(() => availabilityModelWithATS(4)) });
-
-            expect(utils.getAnchorRecordID(product, 'variant-level', { InStockThreshold: 5, IndexOutOfStock: false })).toBeNull();
-        });
-
-        it('anchors a product at the in-stock threshold', () => {
-            const product = productMock('simple1', { getAvailabilityModel: jest.fn(() => availabilityModelWithATS(5)) });
-
-            expect(utils.getAnchorRecordID(product, 'variant-level', { InStockThreshold: 5, IndexOutOfStock: false })).toBe('simple1');
-        });
-
-        it('returns null for a master under the master-level model when none of its variants is in stock', () => {
-            const outOfStockVariant = variantMock('variant1', 'master1', {
-                getAvailabilityModel: jest.fn(() => availabilityModelWithATS(0)),
-            });
-            const product = masterMock('master1', outOfStockVariant);
-
-            expect(utils.getAnchorRecordID(product, 'master-level', { InStockThreshold: 1, IndexOutOfStock: false })).toBeNull();
-        });
-
-        it('anchors a master under the master-level model when one of its variants is in stock', () => {
-            const product = masterMock('master1', variantMock('variant1', 'master1'));
-
-            expect(utils.getAnchorRecordID(product, 'master-level', { InStockThreshold: 1, IndexOutOfStock: false })).toBe('master1');
-        });
-
-        // The master's `variants` array only holds variants that pass isInclude() as well, and the
-        // job writes no master record when that array comes out empty.
-        it('returns null for a master under the master-level model whose only in-stock variant is offline', () => {
-            const offlineInStockVariant = variantMock('variant1', 'master1', { isOnline: jest.fn(() => false) });
-            const inStockButOfflineOnly = masterMock('master1', offlineInStockVariant);
-
-            expect(utils.getAnchorRecordID(inStockButOfflineOnly, 'master-level', { InStockThreshold: 1, IndexOutOfStock: false })).toBeNull();
-        });
-
-        it('anchors a master under the master-level model when a later variant is indexable', () => {
-            const offlineVariant = variantMock('variant1', 'master1', { isOnline: jest.fn(() => false) });
-            const indexableVariant = variantMock('variant2', 'master1');
-            const product = masterMock('master1', offlineVariant, {}, [offlineVariant, indexableVariant]);
-
-            expect(utils.getAnchorRecordID(product, 'master-level', { InStockThreshold: 1, IndexOutOfStock: false })).toBe('master1');
+            expect(utils.getAnchorRecordID(product, 'variant-level')).toBeNull();
         });
     });
 });
@@ -438,7 +286,6 @@ describe('getAnchorProductIDs', () => {
         productMgrMock.getProduct.mockReset();
         global.session.privacy.algoliaAnchorProducts = null;
         global.customPreferences.Algolia_RecordModel = 'variant-level';
-        global.customPreferences.Algolia_IndexOutOfStock = true;
         delete global.customPreferences.Algolia_AttributeSlicedRecordModel_GroupingAttribute;
     });
 
@@ -482,16 +329,6 @@ describe('getAnchorProductIDs', () => {
             productMgrMock.getProduct.mockReturnValue(slicedVariantMock('013742003154M', '25720054M', 'JJG03XX'));
 
             expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe(JSON.stringify(['25720054M-JJG03XX']));
-        });
-
-        it('drops an out-of-stock product when out-of-stock products are not indexed', () => {
-            global.customPreferences.Algolia_IndexOutOfStock = false;
-            global.session.privacy.algoliaAnchorProducts = JSON.stringify(['simple1']);
-            productMgrMock.getProduct.mockReturnValue(productMock('simple1', {
-                getAvailabilityModel: jest.fn(() => availabilityModelWithATS(0)),
-            }));
-
-            expect(utils.getAnchorProductIDs(emptySlotcontent)).toBe('');
         });
     });
 


### PR DESCRIPTION
## What was broken
Recommend resolved an anchor to a catalog *product* and then took its ID. That only matches the index under the `variant-level` record model.
- **Attribute-sliced: every anchor was wrong.** The index holds `masterID-valueID` slices, the widget asked for the variant's own ID, so every recommendation request 404'd on every PDP and cart page.
- **Simple products, bundles, product sets and option products got no anchor at all** outside `master-level`. They were labelled masters, resolved to a default variant that doesn't exist, and silently dropped.

## What changed
- `recommend/utils.js`: `getProductType()` and `getAppropriateProduct()` are replaced by a resolver that returns an objectID via `modelHelper.getRecordIDForProduct()` — the same helper the add-to-cart Insights event already uses. Masters and variation groups resolve to their default variant outside `master-level`, since neither is indexed there. Also guards a product that no longer resolves, and drops the unreachable branch and the `@TODO`.
- `modelHelper.js`: under `master-level` a variation group now maps to its master, like a variant. No-op for the existing Insights callers, which never receive one.
- Anchors are deduplicated and capped at 5. Both matter on the cart: two sizes of one color now collapse to the same slice.

## Additional changes, optimizations:
- `getAnchorProductIDs()` now returns an empty string instead of `'[]'` when nothing resolves. This is because `'[]'` resolves as a truthy value, and we need a falsy one in that case.
- `getAnchorProductIDs()` no longer returns products that are out of stock or would otherwise not be indexed. This is so that Recommend doesn't recommend products that are not in the index. Uses the same logic for inclusion that's used when indexing.
- the site preferences needed by `getAnchorRecordID()` are now read once per slot render instead of the methods having to constantly retrieve them internally, saving many lookups.
- `getAttributeSlicedModelRecordID()` is now passed the `groupingAttribute` parameter in order to avoid having to constantly retrieve the preference value inside the method
- recommendations are now selected much more intelligently in general, taking into account multiple factors so that wrong/duplicate/out of stock products are not recommended, so that the ones that are displayed definitely exist in the index.

I found a separate client-side defect while testing which I don't currently have time to investigate, so I created a separate ticket for it: [SFCC-553](https://algolia.atlassian.net/browse/SFCC-553): "Recommend tiles show no price and render escaped markup".

[SFCC-553]: https://algolia.atlassian.net/browse/SFCC-553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ